### PR TITLE
fix(#9): correct Phase 4 packet contract to v2

### DIFF
--- a/docs/phase4-schema.md
+++ b/docs/phase4-schema.md
@@ -1,4 +1,4 @@
-# Phase 4 packet schema
+# Phase 4 packet schema version 2
 
 ## Purpose
 
@@ -10,27 +10,52 @@ The packet is a read model, not a stored career narrative and not a claim that t
 
 ```json
 {
-  "schema_version": 1,
+  "schema_version": 2,
   "contribution": {
     "id": "CONTRIB-001",
+    "candidate_id": "candidate:fixture-001",
     "title": "Checkout validation correction",
     "app_id": "sample_store",
-    "app_name": "Sample Store",
-    "period": {"from": "2026-01-05", "to": "2026-01-14"}
+    "type": "bug_fix",
+    "date_from": "2026-01-05",
+    "date_to": "2026-01-14"
   },
   "as_of": "2026-01-15T12:00:00Z",
   "source_status": {},
+  "evidence_summary": {},
+  "sections": {},
   "participation": {},
   "release_ladder": {},
-  "sections": {},
   "contradictions": [],
-  "gaps": [],
   "defensibility": {},
   "limitations": []
 }
 ```
 
-`as_of` is the packet-build time. `source_status` is included even when all configured sources are complete.
+`as_of` is the newest evidence timestamp represented by the contribution. Contribution dates remain
+the `date_from` and `date_to` fields. `source_status` is included even when all configured sources
+are complete. Evidence gaps are derived as a separate response and are not duplicated in this
+packet envelope.
+
+## Version 2 compatibility correction
+
+Version 2 is a deliberate one-way correction of the generated read model. WorkTrace does not emit
+a dual-version packet or repeat a legacy alias map in every response. No database migration is
+required because packets and question IDs are not persisted ledger state.
+
+| Version 1 ID | Version 2 ID |
+| --- | --- |
+| `problem.requirement_clarity` | `problem.ambiguity` |
+| `action.tools` | `action.technology` |
+| `result.changed` | `result.change` |
+| `result.measured` | `result.measurement` |
+| `result.efficiency` | `result.errors_time` |
+| `result.released` | `result.release` |
+| `result.reused` | `result.reuse` |
+| `result.interview_defensible` | `result.defensibility` |
+
+Version 2 also separates `action.review` from `action.coordination`. Reviewer participation supports
+the review question. Review-only evidence does not support the coordination question.
 
 ## Source status
 
@@ -115,7 +140,7 @@ Allowed statuses are `supported`, `partially_supported`, `human_attested`, `cont
 | `action.architecture` | Which layers or data flow changed? | Changed modules and discussion |
 | `action.coordination` | What coordination occurred? | Cross-role comments and discussions |
 | `action.quality` | What tests, docs, or monitoring changed? | Changed-path metadata and MR description |
-| `action.review` | Did the user review others? | Reviewer participations and discussion records |
+| `action.review` | Did the user review others? | Participations centrally classified as `reviewed` |
 
 ### Result
 

--- a/src/worktrace/mcp_server/limits.py
+++ b/src/worktrace/mcp_server/limits.py
@@ -173,7 +173,11 @@ def _serialized_size(value: JsonValue) -> int:
     return len(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
 
 
-def _longest_string(value: JsonValue) -> tuple[object, object, str] | None:
+def _longest_string(
+    value: JsonValue,
+    *,
+    protected_string_keys: frozenset[str] = frozenset(),
+) -> tuple[object, object, str] | None:
     best: tuple[object, object, str] | None = None
 
     def visit(current: JsonValue, field_name: str | None = None) -> None:
@@ -181,8 +185,10 @@ def _longest_string(value: JsonValue) -> tuple[object, object, str] | None:
         if isinstance(current, dict):
             for key, item in current.items():
                 if isinstance(item, str):
-                    if not _is_structured_identifier(item, key) and (
-                        best is None or len(item) > len(best[2])
+                    if (
+                        key not in protected_string_keys
+                        and not _is_structured_identifier(item, key)
+                        and (best is None or len(item) > len(best[2]))
                     ):
                         best = (current, key, item)
                 else:
@@ -201,16 +207,20 @@ def _longest_string(value: JsonValue) -> tuple[object, object, str] | None:
     return best
 
 
-def _longest_list(value: JsonValue) -> list[JsonValue] | None:
+def _longest_list(
+    value: JsonValue,
+    *,
+    protected_list_keys: frozenset[str] = frozenset(),
+) -> list[JsonValue] | None:
     best: list[JsonValue] | None = None
 
-    def visit(current: JsonValue) -> None:
+    def visit(current: JsonValue, field_name: str | None = None) -> None:
         nonlocal best
         if isinstance(current, dict):
-            for item in current.values():
-                visit(item)
+            for key, item in current.items():
+                visit(item, key)
         elif isinstance(current, list):
-            if best is None or len(current) > len(best):
+            if field_name not in protected_list_keys and (best is None or len(current) > len(best)):
                 best = current
             for item in current:
                 visit(item)
@@ -219,7 +229,12 @@ def _longest_list(value: JsonValue) -> list[JsonValue] | None:
     return best
 
 
-def enforce_total_limit(payload: dict[str, object]) -> dict[str, object]:
+def enforce_total_limit(
+    payload: dict[str, object],
+    *,
+    protected_list_keys: frozenset[str] = frozenset(),
+    protected_string_keys: frozenset[str] = frozenset(),
+) -> dict[str, object]:
     sanitized = redact_output(payload)
     if not isinstance(sanitized, dict):
         raise TypeError("MCP response must be an object")
@@ -235,7 +250,7 @@ def enforce_total_limit(payload: dict[str, object]) -> dict[str, object]:
     limitations.append("Response was truncated to the server-wide text budget.")
 
     while _serialized_size(result) > MAX_RESPONSE_CHARS:
-        longest = _longest_string(result)
+        longest = _longest_string(result, protected_string_keys=protected_string_keys)
         if longest is not None and len(longest[2]) > 64:
             parent, key, text = longest
             shortened = text[: max(32, len(text) // 2)] + "…[truncated]"
@@ -244,7 +259,7 @@ def enforce_total_limit(payload: dict[str, object]) -> dict[str, object]:
             elif isinstance(parent, list) and isinstance(key, int):
                 parent[key] = shortened
             continue
-        longest_list = _longest_list(result)
+        longest_list = _longest_list(result, protected_list_keys=protected_list_keys)
         if longest_list is not None and len(longest_list) > 1:
             del longest_list[max(1, len(longest_list) // 2) :]
             continue

--- a/src/worktrace/mcp_server/tools.py
+++ b/src/worktrace/mcp_server/tools.py
@@ -22,6 +22,10 @@ from worktrace.mcp_server.schemas import (
 )
 from worktrace.mcp_server.schemas import source_types as validate_source_types
 from worktrace.packets.builder import PacketBuilder
+from worktrace.packets.schema import PHASE4_QUESTIONS
+
+_PHASE4_SECTION_NAMES = frozenset(question.section for question in PHASE4_QUESTIONS)
+_PHASE4_QUESTION_IDENTITY_KEYS = frozenset({"question_id", "question"})
 
 
 class WorkTraceTools:
@@ -52,10 +56,22 @@ class WorkTraceTools:
             connection.close()
 
     @staticmethod
-    def _bounded_response(result: dict[str, object]) -> dict[str, object]:
+    def _bounded_response(
+        result: dict[str, object],
+        *,
+        preserve_phase4_questions: bool = False,
+    ) -> dict[str, object]:
         result["source_text_trust"] = "untrusted"
         result["source_text_is_untrusted"] = True
-        return enforce_total_limit(result)
+        return enforce_total_limit(
+            result,
+            protected_list_keys=(
+                _PHASE4_SECTION_NAMES if preserve_phase4_questions else frozenset()
+            ),
+            protected_string_keys=(
+                _PHASE4_QUESTION_IDENTITY_KEYS if preserve_phase4_questions else frozenset()
+            ),
+        )
 
     @classmethod
     def _cursor_response(cls, result: dict[str, object]) -> dict[str, object]:
@@ -93,7 +109,7 @@ class WorkTraceTools:
         identifier = stable_id(contribution_id, "contribution_id")
         with self._builder() as builder:
             result = builder.build_packet(identifier)
-        return self._bounded_response(result)
+        return self._bounded_response(result, preserve_phase4_questions=True)
 
     def list_evidence_gaps(self, *, contribution_id: str) -> dict[str, object]:
         identifier = stable_id(contribution_id, "contribution_id")

--- a/src/worktrace/packets/builder.py
+++ b/src/worktrace/packets/builder.py
@@ -49,46 +49,7 @@ from worktrace.packets.models import (
 )
 from worktrace.packets.ownership import build_participation_summary
 from worktrace.packets.release import build_release_ladder
-
-PHASE4_QUESTIONS: dict[str, tuple[tuple[str, str], ...]] = {
-    "contribution_identity": (
-        ("identity.what", "What was the contribution?"),
-        ("identity.app_flow", "Which application and flow did it affect?"),
-        ("identity.when", "When did the work occur?"),
-        ("identity.origin", "Was it assigned, proposed, or inherited?"),
-        ("identity.ownership", "Was the engineer the sole, main, or a contributing owner?"),
-    ),
-    "problem_context": (
-        ("problem.what", "What problem existed?"),
-        ("problem.before", "What happened before the change?"),
-        ("problem.severity", "How serious was the problem?"),
-        ("problem.affected", "Who or which flow was affected?"),
-        ("problem.blocked", "What did the problem block?"),
-        ("problem.constraints", "What constraints shaped the work?"),
-        ("problem.requirement_clarity", "Was the requirement unclear or changing?"),
-    ),
-    "action": (
-        ("action.implemented", "What did the engineer implement?"),
-        ("action.decisions", "Which technical decisions were made?"),
-        ("action.tools", "Which tools or frameworks were involved?"),
-        ("action.reuse", "Was a reusable component produced?"),
-        ("action.architecture", "How did architecture or data flow change?"),
-        ("action.coordination", "What coordination or review occurred?"),
-        ("action.quality", "Were tests, documentation, or monitoring added?"),
-    ),
-    "result": (
-        ("result.changed", "What changed as a result?"),
-        ("result.measured", "Is there a measurable before-and-after result?"),
-        ("result.scope", "What scope was affected?"),
-        ("result.efficiency", "Were errors or time reduced?"),
-        ("result.business", "Was conversion, stability, or another outcome improved?"),
-        ("result.released", "What release state is supported?"),
-        ("result.current_use", "Is the contribution still used or enabled?"),
-        ("result.reused", "Was the work reused later?"),
-        ("result.feedback", "Is there client or stakeholder feedback?"),
-        ("result.interview_defensible", "Which parts are defensible in an interview?"),
-    ),
-}
+from worktrace.packets.schema import PHASE4_QUESTIONS, PHASE4_SCHEMA_VERSION
 
 _TITLE_DECISION_ACTIONS = CREATION_ACTIONS | {
     "confirm",
@@ -894,9 +855,7 @@ class PacketBuilder:
         summary: dict[str, object],
     ) -> dict[str, list[dict[str, object]]]:
         by_id = {
-            question_id: question
-            for questions in PHASE4_QUESTIONS.values()
-            for question_id, question in questions
+            specification.question_id: specification.text for specification in PHASE4_QUESTIONS
         }
         raw_contradictions = summary.get("contradictions", [])
         contradictions = raw_contradictions if isinstance(raw_contradictions, list) else []
@@ -1015,7 +974,7 @@ class PacketBuilder:
             ("problem.blocked", {"blocked_flow", "blocked"}, "Confirm what was actually blocked."),
             ("problem.constraints", {"constraints"}, "Document verified constraints."),
             (
-                "problem.requirement_clarity",
+                "problem.ambiguity",
                 {"requirement_clarity", "changing_requirements"},
                 "Document requirement changes or ambiguity.",
             ),
@@ -1099,7 +1058,11 @@ class PacketBuilder:
                 {"technical_decision", "decisions"},
                 "Document a specific decision and its evidence.",
             ),
-            ("action.tools", {"tools", "frameworks"}, "Confirm tools or frameworks used."),
+            (
+                "action.technology",
+                {"tools", "frameworks"},
+                "Confirm tools or frameworks used.",
+            ),
             ("action.reuse", {"reusable_component", "reuse"}, "Add reuse evidence."),
             (
                 "action.architecture",
@@ -1128,7 +1091,7 @@ class PacketBuilder:
                     isinstance(item.get("categories"), list)
                     and any(
                         category in item["categories"]
-                        for category in ("reviewed", "assigned", "merged", "context")
+                        for category in ("assigned", "merged", "context")
                     )
                 )
                 or item.get("role") == "jira_reporter"
@@ -1139,8 +1102,8 @@ class PacketBuilder:
                 question_id="action.coordination",
                 question=by_id["action.coordination"],
                 answer_draft=(
-                    "Participation evidence records MR submission, review, assignment, "
-                    "reporting, or merge roles."
+                    "Participation evidence records MR submission, assignment, reporting, "
+                    "or merge roles."
                 ),
                 status=ClaimStatus.SUPPORTED,
                 observation_types=(ObservationType.SOURCE_ASSERTED,),
@@ -1151,15 +1114,43 @@ class PacketBuilder:
             answers["action.coordination"] = unknown_answer(
                 "action.coordination",
                 by_id["action.coordination"],
-                "Add coordination or review evidence.",
+                "Add coordination evidence.",
+            )
+        review_ids = tuple(
+            sorted(
+                str(item["participation_evidence_id"])
+                for item in self_participations
+                if isinstance(item.get("categories"), list) and "reviewed" in item["categories"]
+            )
+        )
+        if review_ids:
+            answers["action.review"] = QuestionAnswer(
+                question_id="action.review",
+                question=by_id["action.review"],
+                answer_draft=(
+                    "Participation evidence records a reviewer role for the configured identity."
+                ),
+                status=ClaimStatus.SUPPORTED,
+                observation_types=(ObservationType.SOURCE_ASSERTED,),
+                supporting_evidence_ids=review_ids,
+                limitations=(
+                    "A reviewer role does not establish review quality or implementation "
+                    "ownership.",
+                ),
+            )
+        else:
+            answers["action.review"] = unknown_answer(
+                "action.review",
+                by_id["action.review"],
+                "Add reviewer participation evidence.",
             )
 
         ladder = summary.get("release_ladder", {})
         merged_rung = ladder.get("merged", {}) if isinstance(ladder, dict) else {}
         if isinstance(merged_rung, dict) and merged_rung.get("status") != "unknown":
-            answers["result.changed"] = QuestionAnswer(
-                question_id="result.changed",
-                question=by_id["result.changed"],
+            answers["result.change"] = QuestionAnswer(
+                question_id="result.change",
+                question=by_id["result.change"],
                 answer_draft=str(merged_rung.get("statement")),
                 status=(ClaimStatus.CONTRADICTED if contradiction_ids else ClaimStatus.SUPPORTED),
                 observation_types=(ObservationType.SOURCE_ASSERTED,),
@@ -1170,17 +1161,17 @@ class PacketBuilder:
                 limitations=tuple(str(value) for value in merged_rung.get("limitations", [])),
             )
         else:
-            answers["result.changed"] = unknown_answer(
-                "result.changed",
-                by_id["result.changed"],
+            answers["result.change"] = unknown_answer(
+                "result.change",
+                by_id["result.change"],
                 "Add merged or otherwise accepted outcome evidence.",
                 contradictions=contradiction_ids,
             )
         measured_rung = ladder.get("measurably_successful", {}) if isinstance(ladder, dict) else {}
         if isinstance(measured_rung, dict) and measured_rung.get("status") != "unknown":
-            answers["result.measured"] = QuestionAnswer(
-                question_id="result.measured",
-                question=by_id["result.measured"],
+            answers["result.measurement"] = QuestionAnswer(
+                question_id="result.measurement",
+                question=by_id["result.measurement"],
                 answer_draft=str(measured_rung.get("statement")),
                 status=ClaimStatus(str(measured_rung.get("status"))),
                 observation_types=(ObservationType.HUMAN_ATTESTED,),
@@ -1190,9 +1181,9 @@ class PacketBuilder:
                 limitations=tuple(str(value) for value in measured_rung.get("limitations", [])),
             )
         else:
-            answers["result.measured"] = unknown_answer(
-                "result.measured",
-                by_id["result.measured"],
+            answers["result.measurement"] = unknown_answer(
+                "result.measurement",
+                by_id["result.measurement"],
                 "Add a sourced before-and-after metric.",
             )
         if modules and module_records:
@@ -1210,7 +1201,7 @@ class PacketBuilder:
             )
         for question_id, claims, missing in (
             (
-                "result.efficiency",
+                "result.errors_time",
                 {"efficiency", "error_reduction", "time_reduction"},
                 "Add a sourced error or time comparison.",
             ),
@@ -1219,7 +1210,7 @@ class PacketBuilder:
                 {"business_outcome", "conversion", "stability"},
                 "Add a sourced business or stability result.",
             ),
-            ("result.reused", {"reused_later", "reuse"}, "Add a later-reference or reuse record."),
+            ("result.reuse", {"reused_later", "reuse"}, "Add a later-reference or reuse record."),
         ):
             answers[question_id] = self._attested_or_unknown(
                 question_id, by_id[question_id], contribution, claims, missing
@@ -1233,9 +1224,9 @@ class PacketBuilder:
             )
         ]
         if release_evidence:
-            answers["result.released"] = QuestionAnswer(
-                question_id="result.released",
-                question=by_id["result.released"],
+            answers["result.release"] = QuestionAnswer(
+                question_id="result.release",
+                question=by_id["result.release"],
                 answer_draft=(
                     "Evidence reaches the deployment-observed rung; later user-release "
                     "states remain separate."
@@ -1246,9 +1237,9 @@ class PacketBuilder:
                 limitations=("Deployment does not prove release to mobile users.",),
             )
         else:
-            answers["result.released"] = unknown_answer(
-                "result.released",
-                by_id["result.released"],
+            answers["result.release"] = unknown_answer(
+                "result.release",
+                by_id["result.release"],
                 "Add explicit deployment or user-release evidence.",
             )
         current_attestation = find_attestation(
@@ -1286,16 +1277,18 @@ class PacketBuilder:
                 by_id["result.feedback"],
                 "Add a named feedback source or attestation.",
             )
-        answers["result.interview_defensible"] = unknown_answer(
-            "result.interview_defensible",
-            by_id["result.interview_defensible"],
+        answers["result.defensibility"] = unknown_answer(
+            "result.defensibility",
+            by_id["result.defensibility"],
             "Use the defensibility breakdown; WorkTrace does not collapse it to a boolean.",
         )
 
-        return {
-            section: [answers[question_id].as_dict() for question_id, _ in questions]
-            for section, questions in PHASE4_QUESTIONS.items()
-        }
+        sections: dict[str, list[dict[str, object]]] = {}
+        for specification in PHASE4_QUESTIONS:
+            sections.setdefault(specification.section, []).append(
+                answers[specification.question_id].as_dict()
+            )
+        return sections
 
     def build_packet(self, identifier: str) -> dict[str, object]:
         contribution = self._resolve_contribution(identifier)
@@ -1308,6 +1301,7 @@ class PacketBuilder:
             for question in questions
         ]
         packet: dict[str, object] = {
+            "schema_version": PHASE4_SCHEMA_VERSION,
             "contribution": summary["contribution"],
             "as_of": summary["as_of"],
             "source_status": summary["source_status"],

--- a/src/worktrace/packets/schema.py
+++ b/src/worktrace/packets/schema.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+PHASE4_SCHEMA_VERSION = 2
+
+
+@dataclass(frozen=True, slots=True)
+class Phase4QuestionSpec:
+    section: str
+    question_id: str
+    text: str
+
+
+PHASE4_QUESTIONS: tuple[Phase4QuestionSpec, ...] = (
+    Phase4QuestionSpec("contribution_identity", "identity.what", "What was the contribution?"),
+    Phase4QuestionSpec(
+        "contribution_identity", "identity.app_flow", "Which app and business flow?"
+    ),
+    Phase4QuestionSpec("contribution_identity", "identity.when", "When did it occur?"),
+    Phase4QuestionSpec(
+        "contribution_identity",
+        "identity.origin",
+        "Assigned, proposed, inherited, or discovered?",
+    ),
+    Phase4QuestionSpec(
+        "contribution_identity",
+        "identity.ownership",
+        "Sole, main, or contributing role?",
+    ),
+    Phase4QuestionSpec("problem_context", "problem.what", "What problem existed?"),
+    Phase4QuestionSpec("problem_context", "problem.before", "What happened before the change?"),
+    Phase4QuestionSpec("problem_context", "problem.severity", "How serious was it?"),
+    Phase4QuestionSpec("problem_context", "problem.affected", "Who or what was affected?"),
+    Phase4QuestionSpec("problem_context", "problem.blocked", "What did it block?"),
+    Phase4QuestionSpec("problem_context", "problem.constraints", "What constraints existed?"),
+    Phase4QuestionSpec("problem_context", "problem.ambiguity", "Was the requirement unclear?"),
+    Phase4QuestionSpec("action", "action.implemented", "What did the user implement?"),
+    Phase4QuestionSpec(
+        "action", "action.decisions", "Which technical decisions did the user make?"
+    ),
+    Phase4QuestionSpec("action", "action.technology", "Which tools or frameworks were involved?"),
+    Phase4QuestionSpec("action", "action.reuse", "Was a reusable component produced?"),
+    Phase4QuestionSpec("action", "action.architecture", "Which layers or data flow changed?"),
+    Phase4QuestionSpec("action", "action.coordination", "What coordination occurred?"),
+    Phase4QuestionSpec("action", "action.quality", "What tests, docs, or monitoring changed?"),
+    Phase4QuestionSpec("action", "action.review", "Did the user review others?"),
+    Phase4QuestionSpec("result", "result.change", "What changed?"),
+    Phase4QuestionSpec("result", "result.measurement", "Is there a measurable before/after?"),
+    Phase4QuestionSpec(
+        "result",
+        "result.scope",
+        "Which modules, screens, app, or market were affected?",
+    ),
+    Phase4QuestionSpec("result", "result.errors_time", "Were errors or time reduced?"),
+    Phase4QuestionSpec(
+        "result",
+        "result.business",
+        "Was conversion, stability, or another outcome improved?",
+    ),
+    Phase4QuestionSpec("result", "result.release", "How far did delivery progress?"),
+    Phase4QuestionSpec("result", "result.current_use", "Is it still used or enabled?"),
+    Phase4QuestionSpec("result", "result.reuse", "Was it reused later?"),
+    Phase4QuestionSpec("result", "result.feedback", "Was feedback recorded?"),
+    Phase4QuestionSpec(
+        "result",
+        "result.defensibility",
+        "Which parts are defensible in an interview?",
+    ),
+)

--- a/tests/test_acceptance_recovery.py
+++ b/tests/test_acceptance_recovery.py
@@ -475,7 +475,10 @@ def test_cli_git_only_journey_reaches_packet_gaps_and_mcp_entrypoint(
     gaps = runner.invoke(app, ["gaps", contribution_id, "--config", str(config)])
     assert packet.exit_code == 0, packet.stdout
     assert gaps.exit_code == 0, gaps.stdout
-    assert json.loads(packet.stdout)["contribution"]["id"] == contribution_id
+    packet_payload = json.loads(packet.stdout)
+    assert packet_payload["schema_version"] == 2
+    assert packet_payload["contribution"]["id"] == contribution_id
+    assert sum(len(questions) for questions in packet_payload["sections"].values()) == 30
     assert isinstance(json.loads(gaps.stdout), dict)
 
     decision_commands = (

--- a/tests/test_golden_end_to_end.py
+++ b/tests/test_golden_end_to_end.py
@@ -510,7 +510,7 @@ def test_documented_golden_case_runs_source_to_packet_and_bounded_mcp(
             if question["answer_draft"] is not None
         )
         assert _question(packet, "identity.ownership")["answer_draft"] is None
-        assert _question(packet, "result.measured")["answer_draft"] is None
+        assert _question(packet, "result.measurement")["answer_draft"] is None
         assert _question(packet, "result.business")["answer_draft"] is None
         drafts = "\n".join(
             str(question["answer_draft"]).casefold()
@@ -1432,9 +1432,16 @@ def test_production_adapters_feed_import_packet_and_mcp_authority(
         coordination_ids = {
             str(item["participation_evidence_id"])
             for item in self_participations
-            if item["role"] in {"jira_assignee", "mr_author", "mr_reviewer", "mr_merger"}
+            if item["role"] in {"jira_assignee", "mr_author", "mr_merger"}
         }
         assert set(coordination["supporting_evidence_ids"]) == coordination_ids
+        review = _question(packet, "action.review")
+        assert review["status"] == "supported"
+        assert set(review["supporting_evidence_ids"]) == {
+            str(item["participation_evidence_id"])
+            for item in self_participations
+            if item["role"] == "mr_reviewer"
+        }
 
         release_rung = packet["release_ladder"]["release_associated"]
         assert release_rung["status"] == "unknown"
@@ -1457,8 +1464,12 @@ def test_production_adapters_feed_import_packet_and_mcp_authority(
 
     tools = WorkTraceTools(config=config, database_path=database_path)
     mcp_packet = tools.build_phase4_packet(contribution_id=candidate_id)
+    assert mcp_packet["schema_version"] == 2
+    assert mcp_packet["response_truncated"] is True
+    assert len(_material_questions(mcp_packet)) == 30
     assert _question(mcp_packet, "action.implemented")["status"] == "supported"
     assert _question(mcp_packet, "action.coordination")["status"] == "supported"
+    assert _question(mcp_packet, "action.review")["status"] == "supported"
     assert mcp_packet["release_ladder"]["release_associated"]["status"] == "unknown"
     assert mcp_packet["source_text_is_untrusted"] is True
     assert len(json.dumps(mcp_packet, sort_keys=True, separators=(",", ":"))) <= 20_000

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -19,6 +19,7 @@ from worktrace.mcp_server.limits import enforce_total_limit
 from worktrace.mcp_server.server import SERVER_INSTRUCTIONS, build_mcp_server
 from worktrace.mcp_server.tools import WorkTraceTools
 from worktrace.normalize.redaction import Redactor
+from worktrace.packets.schema import PHASE4_QUESTIONS
 from worktrace.services import export_app
 
 
@@ -210,6 +211,94 @@ def test_unconfigured_apps_and_malicious_cursors_are_rejected(tmp_path: Path) ->
         tools.list_contribution_candidates(
             app_id="sample_store", cursor="offset:0;DELETE FROM apps"
         )
+
+
+def test_mcp_candidate_cursor_remains_the_existing_opaque_offset_contract(
+    tmp_path: Path,
+) -> None:
+    _, _, tools = _mcp_state(tmp_path)
+
+    first = tools.list_contribution_candidates(app_id="sample_store", limit=5)
+    assert first["next_cursor"] == "offset:5"
+    second = tools.list_contribution_candidates(
+        app_id="sample_store", limit=5, cursor=first["next_cursor"]
+    )
+
+    first_ids = {item["candidate_id"] for item in first["candidates"]}
+    second_ids = {item["candidate_id"] for item in second["candidates"]}
+    assert first_ids.isdisjoint(second_ids)
+
+
+def test_mcp_phase4_packet_keeps_all_v2_questions_within_the_existing_limit(
+    tmp_path: Path,
+) -> None:
+    _, _, tools = _mcp_state(tmp_path)
+
+    packet = tools.build_phase4_packet(contribution_id="candidate:manual_1")
+    question_ids = [
+        item["question_id"] for questions in packet["sections"].values() for item in questions
+    ]
+
+    assert packet["schema_version"] == 2
+    assert question_ids == [question.question_id for question in PHASE4_QUESTIONS]
+    assert len(json.dumps(packet, sort_keys=True, separators=(",", ":"))) <= MAX_RESPONSE_CHARS
+
+
+def test_oversized_phase4_packet_compacts_content_but_keeps_question_contract() -> None:
+    sections: dict[str, list[dict[str, object]]] = {}
+    original_citations: dict[str, str] = {}
+    for index, specification in enumerate(PHASE4_QUESTIONS):
+        evidence_id = f"obs:phase4-{index}"
+        original_citations[specification.question_id] = evidence_id
+        sections.setdefault(specification.section, []).append(
+            {
+                "question_id": specification.question_id,
+                "question": specification.text,
+                "answer_draft": "Synthetic answer content. " * 50,
+                "status": "supported",
+                "observation_types": ["source_asserted"],
+                "supporting_evidence_ids": [evidence_id, f"obs:secondary-{index}"],
+                "contradicting_evidence_ids": [],
+                "limitations": ["Synthetic limitation. " * 50],
+                "missing_information": [],
+            }
+        )
+
+    bounded = WorkTraceTools._bounded_response(
+        {
+            "schema_version": 2,
+            "sections": sections,
+            "limitations": [],
+        },
+        preserve_phase4_questions=True,
+    )
+    bounded_questions = [
+        question for section in bounded["sections"].values() for question in section
+    ]
+
+    assert bounded["response_truncated"] is True
+    assert (
+        len(
+            json.dumps(
+                bounded,
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        )
+        <= MAX_RESPONSE_CHARS
+    )
+    assert [question["question_id"] for question in bounded_questions] == [
+        specification.question_id for specification in PHASE4_QUESTIONS
+    ]
+    assert [question["question"] for question in bounded_questions] == [
+        specification.text for specification in PHASE4_QUESTIONS
+    ]
+    assert all(
+        original_citations[str(question["question_id"])] in question["supporting_evidence_ids"]
+        for question in bounded_questions
+        if question["answer_draft"] is not None
+    )
 
 
 def test_mcp_database_connection_is_query_only_and_rejects_real_writes(

--- a/tests/test_packets_golden.py
+++ b/tests/test_packets_golden.py
@@ -17,6 +17,39 @@ from worktrace.db.queries import source_status as query_source_status
 from worktrace.mcp_server.tools import WorkTraceTools
 from worktrace.packets.builder import PacketBuilder
 
+EXPECTED_PHASE4_IDS = (
+    "identity.what",
+    "identity.app_flow",
+    "identity.when",
+    "identity.origin",
+    "identity.ownership",
+    "problem.what",
+    "problem.before",
+    "problem.severity",
+    "problem.affected",
+    "problem.blocked",
+    "problem.constraints",
+    "problem.ambiguity",
+    "action.implemented",
+    "action.decisions",
+    "action.technology",
+    "action.reuse",
+    "action.architecture",
+    "action.coordination",
+    "action.quality",
+    "action.review",
+    "result.change",
+    "result.measurement",
+    "result.scope",
+    "result.errors_time",
+    "result.business",
+    "result.release",
+    "result.current_use",
+    "result.reuse",
+    "result.feedback",
+    "result.defensibility",
+)
+
 
 def _config(tmp_path: Path) -> WorkTraceConfig:
     app = AppConfig(
@@ -341,7 +374,24 @@ def test_phase4_packet_preserves_claim_authority_and_independent_release_rungs(
         connection.close()
 
     questions = _all_questions(packet)
+    assert packet["schema_version"] == 2
+    assert tuple(packet) == (
+        "schema_version",
+        "contribution",
+        "as_of",
+        "source_status",
+        "evidence_summary",
+        "sections",
+        "participation",
+        "release_ladder",
+        "contradictions",
+        "defensibility",
+        "limitations",
+    )
     assert questions
+    assert tuple(question["question_id"] for question in questions) == EXPECTED_PHASE4_IDS
+    assert len({question["question_id"] for question in questions}) == 30
+    assert "legacy_question_id_aliases" not in packet
     assert all(
         question["supporting_evidence_ids"]
         for question in questions
@@ -400,14 +450,39 @@ def test_packet_reports_partial_stale_contradictory_and_module_rule_state(
     assert source_status["jira"]["complete"] is False
     assert source_status["jira"]["instances"][0]["status"] == "failed"
     assert any(item["kind"] == "recorded_revert" for item in summary["contradictions"])
-    result_changed = next(
+    result_change = next(
         question
         for question in packet["sections"]["result"]
-        if question["question_id"] == "result.changed"
+        if question["question_id"] == "result.change"
     )
-    assert result_changed["status"] == "contradicted"
-    assert result_changed["contradicting_evidence_ids"]
-    assert "result.changed" not in packet["defensibility"]["well_supported_question_ids"]
+    assert result_change["status"] == "contradicted"
+    assert result_change["contradicting_evidence_ids"]
+    assert "result.change" not in packet["defensibility"]["well_supported_question_ids"]
+
+
+def test_review_participation_supports_review_but_not_coordination(tmp_path: Path) -> None:
+    connection, _, config, candidate_id = _packet_state(tmp_path)
+    connection.execute("DELETE FROM participations WHERE id='participation:author'")
+    connection.execute(
+        """
+        INSERT INTO participations(
+            id, source_object_id, observation_id, actor_id, role, effective_from
+        ) VALUES ('participation:reviewer', 'obj:commit', 'obs:commit', 'actor:self',
+                  'reviewer', '2026-08-25T23:59:59+00:00')
+        """
+    )
+    connection.commit()
+    try:
+        packet = PacketBuilder(connection, config).build_packet(candidate_id)
+    finally:
+        connection.close()
+
+    questions = {item["question_id"]: item for item in _all_questions(packet)}
+    assert questions["action.review"]["status"] == "supported"
+    assert questions["action.review"]["supporting_evidence_ids"] == ["participation:reviewer"]
+    assert questions["action.coordination"]["status"] == "unknown"
+    assert questions["action.coordination"]["answer_draft"] is None
+    assert questions["action.coordination"]["supporting_evidence_ids"] == []
 
 
 def test_selection_biased_changed_paths_do_not_support_scope_claims(tmp_path: Path) -> None:

--- a/tests/test_phase4_schema.py
+++ b/tests/test_phase4_schema.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from worktrace.packets.schema import PHASE4_QUESTIONS, PHASE4_SCHEMA_VERSION
+
+EXPECTED_QUESTIONS = (
+    ("contribution_identity", "identity.what", "What was the contribution?"),
+    ("contribution_identity", "identity.app_flow", "Which app and business flow?"),
+    ("contribution_identity", "identity.when", "When did it occur?"),
+    (
+        "contribution_identity",
+        "identity.origin",
+        "Assigned, proposed, inherited, or discovered?",
+    ),
+    (
+        "contribution_identity",
+        "identity.ownership",
+        "Sole, main, or contributing role?",
+    ),
+    ("problem_context", "problem.what", "What problem existed?"),
+    ("problem_context", "problem.before", "What happened before the change?"),
+    ("problem_context", "problem.severity", "How serious was it?"),
+    ("problem_context", "problem.affected", "Who or what was affected?"),
+    ("problem_context", "problem.blocked", "What did it block?"),
+    ("problem_context", "problem.constraints", "What constraints existed?"),
+    ("problem_context", "problem.ambiguity", "Was the requirement unclear?"),
+    ("action", "action.implemented", "What did the user implement?"),
+    (
+        "action",
+        "action.decisions",
+        "Which technical decisions did the user make?",
+    ),
+    ("action", "action.technology", "Which tools or frameworks were involved?"),
+    ("action", "action.reuse", "Was a reusable component produced?"),
+    ("action", "action.architecture", "Which layers or data flow changed?"),
+    ("action", "action.coordination", "What coordination occurred?"),
+    ("action", "action.quality", "What tests, docs, or monitoring changed?"),
+    ("action", "action.review", "Did the user review others?"),
+    ("result", "result.change", "What changed?"),
+    ("result", "result.measurement", "Is there a measurable before/after?"),
+    (
+        "result",
+        "result.scope",
+        "Which modules, screens, app, or market were affected?",
+    ),
+    ("result", "result.errors_time", "Were errors or time reduced?"),
+    (
+        "result",
+        "result.business",
+        "Was conversion, stability, or another outcome improved?",
+    ),
+    ("result", "result.release", "How far did delivery progress?"),
+    ("result", "result.current_use", "Is it still used or enabled?"),
+    ("result", "result.reuse", "Was it reused later?"),
+    ("result", "result.feedback", "Was feedback recorded?"),
+    (
+        "result",
+        "result.defensibility",
+        "Which parts are defensible in an interview?",
+    ),
+)
+
+
+def test_phase4_v2_schema_has_exact_approved_questions_in_order() -> None:
+    assert PHASE4_SCHEMA_VERSION == 2
+    assert (
+        tuple(
+            (question.section, question.question_id, question.text) for question in PHASE4_QUESTIONS
+        )
+        == EXPECTED_QUESTIONS
+    )
+    assert len(PHASE4_QUESTIONS) == 30
+    assert len({question.question_id for question in PHASE4_QUESTIONS}) == 30
+    assert [
+        sum(question.section == section for question in PHASE4_QUESTIONS)
+        for section in ("contribution_identity", "problem_context", "action", "result")
+    ] == [5, 7, 8, 10]
+
+
+def test_phase4_documentation_matches_runtime_ids_and_wording() -> None:
+    documentation = (Path(__file__).resolve().parents[1] / "docs" / "phase4-schema.md").read_text(
+        encoding="utf-8"
+    )
+    question_map = documentation.split("## Question map", 1)[1].split(
+        "## Participation summary", 1
+    )[0]
+    documented = tuple(
+        (match.group(1), match.group(2).strip())
+        for match in re.finditer(
+            r"^\| `((?:identity|problem|action|result)\.[^`]+)` \| ([^|]+) \|",
+            question_map,
+            flags=re.MULTILINE,
+        )
+    )
+
+    assert documented == tuple((question_id, text) for _, question_id, text in EXPECTED_QUESTIONS)


### PR DESCRIPTION
## Summary

- establish one canonical ordered Phase 4 v2 inventory with exactly 30 questions
- emit `schema_version: 2` and rename the eight drifted question IDs without a dual-version or per-packet alias layer
- separate reviewer participation from coordination while preserving citations, contradictions, unknown answers, and release-ladder independence
- keep all six MCP tools, their schemas, limits, and opaque `offset:` cursor unchanged
- compact oversized MCP packet details without dropping canonical questions or all citations
- synchronize the packet documentation, CLI/MCP regressions, golden tests, and installed-wheel contract

## Why

The runtime packet had drifted from the documented worksheet: it emitted 29 questions, combined review with coordination, used eight legacy IDs, and lacked an explicit packet version. This atomic correction gives the later read-only TUI one defensible read contract instead of adding UI-specific aliases.

## Compatibility

This is the deliberate breaking read-model correction recorded by AgDR-0006:

- packet schema is now version 2
- generated packets use the 30 canonical IDs only
- no SQLite migration is required
- CLI command shapes remain unchanged
- MCP remains exactly six read-only tools with unchanged schemas and cursor behavior

## Verification

- `uv run pytest` — 216 passed
- `uv run coverage run -m pytest`
- `uv run coverage report` — 86%
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv build`
- isolated wheel smoke — schema v2 and all 30 questions import successfully
- `git diff --check`

Live Jira, GitLab, proprietary-repository, and unknown external-consumer compatibility were not exercised.

## Glossary

| Term | Definition |
|---|---|
| Phase 4 packet | Generated evidence-backed worksheet for one contribution. |
| Packet schema v2 | The canonical 30-question packet response with explicit version 2. |
| Review participation | Self-participation centrally classified as reviewing another implementation. |
| Coordination | Assignment, merge, submission/context, or reporting participation kept separate from review-only evidence. |
| Protected question collection | MCP compaction rule that retains the canonical question list and wording while bounding oversized details. |

Closes #9
Refs #6
Refs AgDR-0006