### PR TITLE
perf(#10): add generation-bound candidate paging

### DIFF
--- a/docs/benchmarks/candidate-paging.md
+++ b/docs/benchmarks/candidate-paging.md
@@ -6,10 +6,12 @@ Measured on 2026-08-31 for issue #10 using the deterministic fixture in
 ## Fixture
 
 - 3,000 candidates in one transactional generation.
+- 3,000 authoritative current observations and 3,000 coherent participations spanning manual,
+  Git, Jira, and GitLab sources.
 - 1,000 ignored candidates.
-- 100 confirmed lineages whose current evidence is unsupported.
-- 1,850 additional candidates without authoritative current evidence.
-- 50 current candidates spanning manual, Git, Jira, and GitLab evidence.
+- 100 confirmed lineages, 50 of which retain an additional unsupported member.
+- 1,900 ordinary current candidates.
+- One current availability event and one separately scoped application fixture.
 - Default page size 25, batch size 50, and scan budget 100.
 
 This deliberately measures a short first page whose first 100 raw candidates are all skipped. It
@@ -46,27 +48,27 @@ read-only connections were measured for each case.
 
 | Measure | Result |
 |---|---:|
-| Median page build | 127.646 ms |
-| P95 page build | 132.768 ms |
-| Minimum / maximum | 126.149 / 134.196 ms |
+| Median page build | 67.618 ms |
+| P95 page build | 70.873 ms |
+| Minimum / maximum | 65.112 / 71.011 ms |
 | Raw candidates scanned | 100 |
 | Candidate projections | 100 |
-| Traced SQLite statements | 1,909 |
+| Traced SQLite statements | 2,011 |
 
 ### Full visible page
 
-The cursor starts immediately before the 50 current mixed-source candidates in the same fixture.
+The cursor starts immediately before a mixed-source current candidate window in the same fixture.
 The page fills after projecting 25 raw rows:
 
 | Measure | Result |
 |---|---:|
-| Median page build | 78.021 ms |
-| P95 page build | 80.325 ms |
-| Minimum / maximum | 77.390 / 81.054 ms |
+| Median page build | 66.132 ms |
+| P95 page build | 79.594 ms |
+| Minimum / maximum | 63.536 / 81.815 ms |
 | Visible candidates | 25 |
 | Raw candidates scanned | 25 |
 | Candidate projections | 25 |
-| Traced SQLite statements | 1,808 |
+| Traced SQLite statements | 1,710 |
 
 ### Decision-projection correction
 
@@ -83,11 +85,33 @@ to one page-level decision projection rather than 25 repeated global projections
 `PacketBuilder` and `project_candidate` callers retain their original behavior when no context is
 supplied, and contextual/default projection parity is tested directly.
 
+### Authority/evidence-projection correction
+
+Independent dense review found that every raw row rebuilt the application-wide authoritative
+observation projection and every material member separately rebuilt the observation plus
+availability projection. Before correction, a 3,000-current-observation fixture took about
+4.859 seconds for a fully skipped default page and 1.437 seconds for a visible page. A separate
+300-current probe counted 200 authority-CTE executions in one default scan window.
+
+The final implementation builds one immutable, application-scoped authority/evidence context
+inside each page transaction. It projects authoritative current observations plus availability
+once, converts those rows to frozen `EvidenceRecord` values once, and derives coherent
+participations once against the already-canonical current-observation IDs. Per-row candidate,
+record, and participation projection uses those maps; context-only membership creates a replaced
+record and never mutates the shared value.
+
+The dense trace now records exactly one authority/evidence context query, one participation-context
+query, one active-decision stream, zero legacy per-row authoritative-participation CTEs, and zero
+per-member `WHERE current.source_object_id=...` queries. Low/dense evidence fixtures contain 25 and
+3,000 current observations respectively; each still builds exactly one context and produces
+field-identical selected candidate rows. Contextual/default parity covers visible, ignored,
+confirmed-plus-unsupported, cross-application, availability, title, participation, decision/undo,
+and context-only cases.
+
 There is intentionally no CI wall-clock assertion. Correctness tests enforce the scan and
-projection bounds, one page-level decision projection, contextual/default output parity, and the
-query-plan shape. A later performance ticket should still be based on measured human usage before
-changing canonical evidence/participation projection or adding an index; issue #10 does not create
-a second, semantically weaker row projection to improve a local timing result.
+projection bounds, one page-level decision projection, one page-level authority/evidence context,
+contextual/default output parity, and the query-plan shape. Issue #10 does not create a second,
+semantically weaker row projection to improve a local timing result.
 
 ## Residual limitation
 
@@ -96,3 +120,11 @@ candidate ID. The primary-key keyset query may step over rows for other applicat
 before collecting its bounded matching batch. The public scan budget still bounds rows projected
 for the selected application. A composite index is intentionally deferred until a representative
 multi-application ledger demonstrates a material problem.
+
+Three operations remain proportional to selected-application history, but each runs exactly once
+per page transaction: the authority/availability projection (3,000 rows in this fixture), coherent
+participation projection (3,000 rows), and active decision/scope/lineage projection (1,100
+decisions). They are never retained across pages. On the measured dense fixture their combined
+cost remains within a 70.873 ms P95 worst-case page and a 79.594 ms P95 visible page. A later
+change should revisit them only if representative portfolios exceed the interaction target; this
+PR intentionally adds no index, materialization, or persistent cache.

--- a/docs/benchmarks/candidate-paging.md
+++ b/docs/benchmarks/candidate-paging.md
@@ -1,0 +1,98 @@
+# Candidate paging benchmark
+
+Measured on 2026-08-31 for issue #10 using the deterministic fixture in
+`tests/test_candidate_paging.py`.
+
+## Fixture
+
+- 3,000 candidates in one transactional generation.
+- 1,000 ignored candidates.
+- 100 confirmed lineages whose current evidence is unsupported.
+- 1,850 additional candidates without authoritative current evidence.
+- 50 current candidates spanning manual, Git, Jira, and GitLab evidence.
+- Default page size 25, batch size 50, and scan budget 100.
+
+This deliberately measures a short first page whose first 100 raw candidates are all skipped. It
+is a bounded worst case for the default scan budget, not a forecast of every real portfolio.
+
+## Query plan
+
+SQLite 3.53.1 reports:
+
+```text
+Active generation
+SEARCH candidate_groups USING INDEX idx_candidates_app_time (app_id=?)
+
+Mixed-timestamp probes
+SEARCH candidate_groups USING COVERING INDEX idx_candidates_app_time
+    (app_id=? AND generated_at<?)
+SEARCH candidate_groups USING COVERING INDEX idx_candidates_app_time
+    (app_id=? AND generated_at>?)
+
+Raw keyset batch
+SEARCH candidate_groups USING INDEX sqlite_autoindex_candidate_groups_1 (id>?)
+```
+
+Neither query performs a full `candidate_groups` table scan or uses a temporary B-tree. The raw
+query deliberately uses the existing primary-key index to preserve `id > after_candidate_id`
+ordering without a migration.
+
+## Local results
+
+Environment: Apple M2, arm64, macOS 26.7, Python 3.12.12. After three warm-up reads, 20 fresh
+read-only connections were measured for each case.
+
+### Fully skipped default window
+
+| Measure | Result |
+|---|---:|
+| Median page build | 127.646 ms |
+| P95 page build | 132.768 ms |
+| Minimum / maximum | 126.149 / 134.196 ms |
+| Raw candidates scanned | 100 |
+| Candidate projections | 100 |
+| Traced SQLite statements | 1,909 |
+
+### Full visible page
+
+The cursor starts immediately before the 50 current mixed-source candidates in the same fixture.
+The page fills after projecting 25 raw rows:
+
+| Measure | Result |
+|---|---:|
+| Median page build | 78.021 ms |
+| P95 page build | 80.325 ms |
+| Minimum / maximum | 77.390 / 81.054 ms |
+| Visible candidates | 25 |
+| Raw candidates scanned | 25 |
+| Candidate projections | 25 |
+| Traced SQLite statements | 1,808 |
+
+### Decision-projection correction
+
+The first visible-page measurement exposed 115,482 statements, a 1,610.941 ms median, and a
+1,739.408 ms P95. Each visible row was independently rebuilding the global active-decision stream,
+scope map, and lineage graph. That violated the page-proportional work invariant even though the
+candidate scan itself was bounded.
+
+The final implementation builds that canonical decision projection once per page transaction,
+groups decisions by target, and maps lineages by candidate/contribution before projecting rows.
+The high-decision fixture now reads the global decision stream exactly once. A paired test compares
+the same 25-row page with zero and 1,100 unrelated decisions and bounds the additional statements
+to one page-level decision projection rather than 25 repeated global projections. Default
+`PacketBuilder` and `project_candidate` callers retain their original behavior when no context is
+supplied, and contextual/default projection parity is tested directly.
+
+There is intentionally no CI wall-clock assertion. Correctness tests enforce the scan and
+projection bounds, one page-level decision projection, contextual/default output parity, and the
+query-plan shape. A later performance ticket should still be based on measured human usage before
+changing canonical evidence/participation projection or adding an index; issue #10 does not create
+a second, semantically weaker row projection to improve a local timing result.
+
+## Residual limitation
+
+Candidate IDs are globally unique, but the existing indexes do not combine application and
+candidate ID. The primary-key keyset query may step over rows for other applications internally
+before collecting its bounded matching batch. The public scan budget still bounds rows projected
+for the selected application. A composite index is intentionally deferred until a representative
+multi-application ledger demonstrates a material problem.

--- a/src/worktrace/candidates/decisions.py
+++ b/src/worktrace/candidates/decisions.py
@@ -6,6 +6,7 @@ import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from types import MappingProxyType
 
 from worktrace.errors import NotFound, ScopeViolation
 from worktrace.normalize.redaction import Redactor
@@ -39,6 +40,7 @@ class _DecisionProjectionContext:
     active_decisions: tuple[Decision, ...]
     decisions_by_target: Mapping[str, tuple[Decision, ...]]
     decision_scopes: Mapping[str, str | None]
+    lineages: tuple[DecisionLineage, ...]
     lineages_by_identifier: Mapping[str, tuple[DecisionLineage, ...]]
 
     def for_target(self, target_id: str) -> tuple[Decision, ...]:
@@ -614,9 +616,14 @@ def _build_decision_projection_context(
             by_identifier.setdefault(identifier, []).append(lineage)
     return _DecisionProjectionContext(
         active_decisions=decisions,
-        decisions_by_target={key: tuple(value) for key, value in by_target.items()},
-        decision_scopes=scopes,
-        lineages_by_identifier={key: tuple(value) for key, value in by_identifier.items()},
+        decisions_by_target=MappingProxyType(
+            {key: tuple(value) for key, value in by_target.items()}
+        ),
+        decision_scopes=MappingProxyType(dict(scopes)),
+        lineages=lineages,
+        lineages_by_identifier=MappingProxyType(
+            {key: tuple(value) for key, value in by_identifier.items()}
+        ),
     )
 
 

--- a/src/worktrace/candidates/decisions.py
+++ b/src/worktrace/candidates/decisions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import uuid
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
@@ -30,6 +30,39 @@ class DecisionLineage:
     contribution_ids: frozenset[str]
     canonical_candidate_id: str
     decisions: tuple[Decision, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _DecisionProjectionContext:
+    """One read-snapshot projection shared by every candidate on a bounded page."""
+
+    active_decisions: tuple[Decision, ...]
+    decisions_by_target: Mapping[str, tuple[Decision, ...]]
+    decision_scopes: Mapping[str, str | None]
+    lineages_by_identifier: Mapping[str, tuple[DecisionLineage, ...]]
+
+    def for_target(self, target_id: str) -> tuple[Decision, ...]:
+        return self.decisions_by_target.get(target_id, ())
+
+    def resolve_lineage(
+        self,
+        identifier: str,
+        *,
+        app_id: str | None = None,
+    ) -> DecisionLineage | None:
+        matches = [
+            lineage
+            for lineage in self.lineages_by_identifier.get(identifier, ())
+            if app_id is None or lineage.app_id == app_id
+        ]
+        matched_apps = {lineage.app_id for lineage in matches}
+        if len(matched_apps) > 1:
+            raise ScopeViolation("contribution identifier belongs to more than one configured app")
+        if not matches:
+            return None
+        if len(matches) > 1:
+            raise ScopeViolation("contribution identifier has ambiguous decision lineage")
+        return matches[0]
 
 
 VALID_ACTIONS = {
@@ -243,7 +276,14 @@ def undo_decision(connection: sqlite3.Connection, decision_id: str) -> str:
     )
 
 
-def active_decisions(connection: sqlite3.Connection, target_id: str) -> list[Decision]:
+def active_decisions(
+    connection: sqlite3.Connection,
+    target_id: str,
+    *,
+    context: _DecisionProjectionContext | None = None,
+) -> list[Decision]:
+    if context is not None:
+        return list(context.for_target(target_id))
     return [
         decision
         for decision in decision_stream(connection, active_only=True)
@@ -367,8 +407,18 @@ def decision_node_apps(
 ) -> dict[str, set[str]]:
     """Map every declared candidate/contribution lineage identifier to owning apps."""
 
+    return _decision_node_apps(
+        connection,
+        decision_stream(connection, active_only=active_only),
+    )
+
+
+def _decision_node_apps(
+    connection: sqlite3.Connection,
+    decisions: Sequence[Decision],
+) -> dict[str, set[str]]:
     result: dict[str, set[str]] = {}
-    for decision in decision_stream(connection, active_only=active_only):
+    for decision in decisions:
         if decision.action not in CREATION_ACTIONS:
             continue
         app_id = creation_decision_scope_app(
@@ -403,7 +453,15 @@ def decision_scope_map(
     """
 
     decisions = decision_stream(connection, active_only=active_only)
-    node_apps = decision_node_apps(connection, active_only=active_only)
+    node_apps = _decision_node_apps(connection, decisions)
+    return _decision_scope_map(connection, decisions, node_apps)
+
+
+def _decision_scope_map(
+    connection: sqlite3.Connection,
+    decisions: Sequence[Decision],
+    node_apps: Mapping[str, set[str]],
+) -> dict[str, str | None]:
     decisions_by_id = {decision.id: decision for decision in decisions}
     result: dict[str, str | None] = {}
     for decision in decisions:
@@ -453,6 +511,16 @@ def decision_lineages(
     """Build app-scoped lineage components for the selected decision projection."""
 
     decisions = decision_stream(connection, active_only=active_only)
+    node_apps = _decision_node_apps(connection, decisions)
+    decision_scopes = _decision_scope_map(connection, decisions, node_apps)
+    return _decision_lineages(connection, decisions, decision_scopes)
+
+
+def _decision_lineages(
+    connection: sqlite3.Connection,
+    decisions: Sequence[Decision],
+    decision_scopes: Mapping[str, str | None],
+) -> tuple[DecisionLineage, ...]:
     adjacency: dict[tuple[str, str], set[tuple[str, str]]] = {}
     node_kind: dict[tuple[str, str], str] = {}
     for decision in decisions:
@@ -485,8 +553,6 @@ def decision_lineages(
             adjacency[candidate_node].update(
                 other for other in candidate_nodes if other != candidate_node
             )
-
-    decision_scopes = decision_scope_map(connection, active_only=active_only)
 
     result: list[DecisionLineage] = []
     visited: set[tuple[str, str]] = set()
@@ -530,6 +596,28 @@ def decision_lineages(
             )
         )
     return tuple(result)
+
+
+def _build_decision_projection_context(
+    connection: sqlite3.Connection,
+) -> _DecisionProjectionContext:
+    decisions = tuple(decision_stream(connection, active_only=True))
+    by_target: dict[str, list[Decision]] = {}
+    for decision in decisions:
+        by_target.setdefault(decision.target_id, []).append(decision)
+    node_apps = _decision_node_apps(connection, decisions)
+    scopes = _decision_scope_map(connection, decisions, node_apps)
+    lineages = _decision_lineages(connection, decisions, scopes)
+    by_identifier: dict[str, list[DecisionLineage]] = {}
+    for lineage in lineages:
+        for identifier in lineage.candidate_ids | lineage.contribution_ids:
+            by_identifier.setdefault(identifier, []).append(lineage)
+    return _DecisionProjectionContext(
+        active_decisions=decisions,
+        decisions_by_target={key: tuple(value) for key, value in by_target.items()},
+        decision_scopes=scopes,
+        lineages_by_identifier={key: tuple(value) for key, value in by_identifier.items()},
+    )
 
 
 def resolve_decision_lineage(

--- a/src/worktrace/candidates/projector.py
+++ b/src/worktrace/candidates/projector.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from worktrace.candidates.builder import SEED_PRIORITY, suggest_contribution_type
 from worktrace.candidates.decisions import (
     CREATION_ACTIONS,
+    _DecisionProjectionContext,
     active_decisions,
     creation_decision_scope_app,
 )
@@ -28,7 +29,12 @@ class CandidateView:
     decisions: tuple[dict[str, object], ...]
 
 
-def project_candidate(connection: sqlite3.Connection, candidate_id: str) -> CandidateView:
+def project_candidate(
+    connection: sqlite3.Connection,
+    candidate_id: str,
+    *,
+    decision_context: _DecisionProjectionContext | None = None,
+) -> CandidateView:
     row = connection.execute(
         "SELECT * FROM candidate_groups WHERE id=?", (candidate_id,)
     ).fetchone()
@@ -51,7 +57,7 @@ def project_candidate(connection: sqlite3.Connection, candidate_id: str) -> Cand
     status = str(row["status"])
     human_title = False
     human_type = False
-    decisions = active_decisions(connection, candidate_id)
+    decisions = active_decisions(connection, candidate_id, context=decision_context)
     for decision in decisions:
         payload = decision.payload
         is_creation = (
@@ -62,7 +68,12 @@ def project_candidate(connection: sqlite3.Connection, candidate_id: str) -> Cand
         if decision.action == "confirm" or is_creation:
             if (
                 is_creation
-                and creation_decision_scope_app(connection, candidate_id, payload) != app_id
+                and (
+                    decision_context.decision_scopes.get(decision.id)
+                    if decision_context is not None
+                    else creation_decision_scope_app(connection, candidate_id, payload)
+                )
+                != app_id
             ):
                 continue
             status = "confirmed"

--- a/src/worktrace/candidates/projector.py
+++ b/src/worktrace/candidates/projector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 from worktrace.candidates.builder import SEED_PRIORITY, suggest_contribution_type
@@ -34,6 +35,7 @@ def project_candidate(
     candidate_id: str,
     *,
     decision_context: _DecisionProjectionContext | None = None,
+    current_observations: Mapping[str, sqlite3.Row] | None = None,
 ) -> CandidateView:
     row = connection.execute(
         "SELECT * FROM candidate_groups WHERE id=?", (candidate_id,)
@@ -167,11 +169,15 @@ def project_candidate(
             if isinstance(keep, list):
                 allowed = {str(value) for value in keep}
                 members = {key: value for key, value in members.items() if key in allowed}
-    current = {
-        str(observation["source_object_id"]): observation
-        for observation in authoritative_current_observations(connection, app_id)
-    }
-    eligible_member_ids = sorted(set(members) & set(current))
+    current = (
+        current_observations
+        if current_observations is not None
+        else {
+            str(observation["source_object_id"]): observation
+            for observation in authoritative_current_observations(connection, app_id)
+        }
+    )
+    eligible_member_ids = sorted(object_id for object_id in members if object_id in current)
     has_authoritative_support = bool(eligible_member_ids)
     if not has_authoritative_support and status != "confirmed":
         raise NotFound(f"candidate has no authoritative current evidence: {candidate_id}")
@@ -212,7 +218,9 @@ def project_candidate(
         for object_id in eligible_member_ids
     )
     unsupported_member_ids = (
-        tuple(sorted(set(members) - set(eligible_member_ids))) if status == "confirmed" else ()
+        tuple(sorted(object_id for object_id in members if object_id not in current))
+        if status == "confirmed"
+        else ()
     )
     return CandidateView(
         id=candidate_id,

--- a/src/worktrace/db/authority.py
+++ b/src/worktrace/db/authority.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 
 REMOTE_POLICY_SOURCES = frozenset({"jira", "gitlab"})
 CURRENT_SELECTION_POLICY_VERSION = 2
@@ -256,6 +256,42 @@ def authoritative_current_observation_ids(
     return frozenset(
         str(row["id"]) for row in authoritative_current_observations(connection, app_id)
     )
+
+
+def authoritative_participations_for_current_observations(
+    connection: sqlite3.Connection,
+    app_id: str,
+    current_observation_ids: Collection[str],
+) -> list[sqlite3.Row]:
+    """Project coherent participations against an already canonical current-observation set."""
+
+    if not current_observation_ids:
+        return []
+    current_ids = frozenset(current_observation_ids)
+    rows = connection.execute(
+        """
+        /* worktrace_page_participation_context */
+        SELECT participation.id, participation.source_object_id,
+            participation.observation_id, participation.role,
+            participation.effective_from, participation.effective_to,
+            actor.id AS actor_id, actor.display_name, actor.is_self,
+            object.source, object.kind, object.external_id
+        FROM participations participation
+        JOIN observations observation
+          ON observation.id=participation.observation_id
+         AND observation.source_object_id=participation.source_object_id
+        JOIN source_objects object
+          ON object.id=participation.source_object_id
+         AND object.app_id=?
+        JOIN actors actor
+          ON actor.id=participation.actor_id
+         AND actor.source=object.source
+         AND actor.source_instance=object.source_instance
+        ORDER BY participation.effective_from, participation.id
+        """,
+        (app_id,),
+    )
+    return [row for row in rows if str(row["observation_id"]) in current_ids]
 
 
 def authoritative_current_object_ids(

--- a/src/worktrace/db/connection.py
+++ b/src/worktrace/db/connection.py
@@ -4,11 +4,17 @@ import sqlite3
 from pathlib import Path
 
 
-def _configure(connection: sqlite3.Connection) -> sqlite3.Connection:
+def _configure(
+    connection: sqlite3.Connection,
+    *,
+    busy_timeout_ms: int = 10_000,
+) -> sqlite3.Connection:
+    if busy_timeout_ms < 0:
+        raise ValueError("busy_timeout_ms must be non-negative")
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")
     connection.execute("PRAGMA trusted_schema = OFF")
-    connection.execute("PRAGMA busy_timeout = 10000")
+    connection.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
     return connection
 
 
@@ -18,8 +24,20 @@ def connect(path: Path) -> sqlite3.Connection:
     return connection
 
 
-def connect_read_only(path: Path) -> sqlite3.Connection:
+def connect_read_only(
+    path: Path,
+    *,
+    busy_timeout_ms: int = 10_000,
+) -> sqlite3.Connection:
     uri = f"file:{path.resolve().as_posix()}?mode=ro"
-    connection = _configure(sqlite3.connect(uri, uri=True, autocommit=True, timeout=10))
+    connection = _configure(
+        sqlite3.connect(
+            uri,
+            uri=True,
+            autocommit=True,
+            timeout=busy_timeout_ms / 1_000,
+        ),
+        busy_timeout_ms=busy_timeout_ms,
+    )
     connection.execute("PRAGMA query_only = ON")
     return connection

--- a/src/worktrace/db/connection.py
+++ b/src/worktrace/db/connection.py
@@ -29,7 +29,7 @@ def connect_read_only(
     *,
     busy_timeout_ms: int = 10_000,
 ) -> sqlite3.Connection:
-    uri = f"file:{path.resolve().as_posix()}?mode=ro"
+    uri = f"{path.resolve().as_uri()}?mode=ro"
     connection = _configure(
         sqlite3.connect(
             uri,

--- a/src/worktrace/db/readiness.py
+++ b/src/worktrace/db/readiness.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from enum import StrEnum
+
+from worktrace.db.migrations import migrations, user_version
+
+
+class DatabaseReadinessStatus(StrEnum):
+    READY = "ready"
+    UPGRADE_REQUIRED = "upgrade_required"
+    UNSUPPORTED_NEWER = "unsupported_newer"
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseReadiness:
+    status: DatabaseReadinessStatus
+    current_version: int
+    supported_version: int
+
+
+def database_readiness(connection: sqlite3.Connection) -> DatabaseReadiness:
+    """Compare the ledger schema with the latest packaged migration without writing."""
+
+    packaged = migrations()
+    supported_version = packaged[-1].version if packaged else 0
+    current_version = user_version(connection)
+    if current_version < supported_version:
+        status = DatabaseReadinessStatus.UPGRADE_REQUIRED
+    elif current_version > supported_version:
+        status = DatabaseReadinessStatus.UNSUPPORTED_NEWER
+    else:
+        status = DatabaseReadinessStatus.READY
+    return DatabaseReadiness(
+        status=status,
+        current_version=current_version,
+        supported_version=supported_version,
+    )

--- a/src/worktrace/packets/builder.py
+++ b/src/worktrace/packets/builder.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from fnmatch import fnmatchcase
+from types import MappingProxyType
 from typing import cast
 
 from worktrace.candidates.decisions import (
@@ -25,6 +27,7 @@ from worktrace.db.authority import (
     authoritative_current_observation_ctes,
     authoritative_current_participation_ctes,
     authoritative_current_reference_ctes,
+    authoritative_participations_for_current_observations,
     completeness_is_full_scope,
     parse_scope,
     run_authority_limitation,
@@ -118,6 +121,102 @@ def _single_member(payload: dict[str, object]) -> str | None:
     return None
 
 
+@dataclass(frozen=True, slots=True)
+class _AuthorityEvidenceContext:
+    app_id: str
+    current_observations: Mapping[str, sqlite3.Row]
+    evidence_records: Mapping[str, EvidenceRecord]
+    participation_rows_by_observation: Mapping[str, tuple[sqlite3.Row, ...]]
+
+
+def _evidence_record_from_row(
+    row: sqlite3.Row,
+    *,
+    context_only: bool,
+) -> EvidenceRecord:
+    return EvidenceRecord(
+        observation_id=str(row["id"]),
+        object_id=str(row["source_object_id"]),
+        app_id=str(row["app_id"]),
+        source=str(row["source"]),
+        source_instance=str(row["source_instance"]),
+        kind=str(row["kind"]),
+        external_id=str(row["external_id"]),
+        title=str(row["title"]) if row["title"] is not None else None,
+        body_text=str(row["body_text"]) if row["body_text"] is not None else None,
+        data=_parse_json_object(row["data_json"]),
+        completeness=str(row["completeness"]),
+        fetched_at=str(row["fetched_at"]),
+        source_updated_at=(
+            str(row["source_updated_at"]) if row["source_updated_at"] is not None else None
+        ),
+        availability=str(row["availability"]),
+        availability_evidence_id=(
+            str(row["availability_evidence_id"])
+            if row["availability_evidence_id"] is not None
+            else None
+        ),
+        availability_reason=(
+            str(row["availability_reason"]) if row["availability_reason"] is not None else None
+        ),
+        availability_observed_at=(
+            str(row["availability_observed_at"])
+            if row["availability_observed_at"] is not None
+            else None
+        ),
+        is_current=True,
+        context_only=context_only,
+    )
+
+
+def _build_authority_evidence_context(
+    connection: sqlite3.Connection,
+    app_id: str,
+) -> _AuthorityEvidenceContext:
+    rows = list(
+        connection.execute(
+            f"""
+            /* worktrace_page_authority_evidence_context */
+            WITH {authoritative_current_observation_ctes()},
+                 {authoritative_availability_event_ctes()}
+            SELECT current.*, so.app_id, so.source, so.source_instance, so.kind, so.external_id,
+                so.availability, so.availability_reason, so.availability_observed_at,
+                (
+                    SELECT event.id
+                    FROM authoritative_current_availability_events event
+                    WHERE event.source_object_id=so.id
+                    LIMIT 1
+                ) AS availability_evidence_id
+            FROM authoritative_current_observations current
+            JOIN source_objects so ON so.id=current.source_object_id
+            WHERE so.app_id=?
+            """,
+            (app_id,),
+        )
+    )
+    current = {str(row["source_object_id"]): row for row in rows}
+    records = {
+        object_id: _evidence_record_from_row(row, context_only=False)
+        for object_id, row in current.items()
+    }
+    participation_rows = authoritative_participations_for_current_observations(
+        connection,
+        app_id,
+        {str(row["id"]) for row in rows},
+    )
+    participation_by_observation: dict[str, list[sqlite3.Row]] = {}
+    for row in participation_rows:
+        participation_by_observation.setdefault(str(row["observation_id"]), []).append(row)
+    return _AuthorityEvidenceContext(
+        app_id=app_id,
+        current_observations=MappingProxyType(current),
+        evidence_records=MappingProxyType(records),
+        participation_rows_by_observation=MappingProxyType(
+            {key: tuple(value) for key, value in participation_by_observation.items()}
+        ),
+    )
+
+
 class PacketBuilder:
     """Read model over the SQLite ledger; this class never mutates state."""
 
@@ -127,10 +226,12 @@ class PacketBuilder:
         config: WorkTraceConfig,
         *,
         decision_context: _DecisionProjectionContext | None = None,
+        authority_context: _AuthorityEvidenceContext | None = None,
     ) -> None:
         self.connection = connection
         self.config = config
         self._decision_projection = decision_context
+        self._authority_context = authority_context
 
     def _app(self, app_id: str) -> AppConfig:
         return self.config.app(app_id)
@@ -141,6 +242,11 @@ class PacketBuilder:
                 self.connection,
                 candidate_id,
                 decision_context=self._decision_projection,
+                current_observations=(
+                    self._authority_context.current_observations
+                    if self._authority_context is not None
+                    else None
+                ),
             )
         except NotFound:
             return None
@@ -325,6 +431,9 @@ class PacketBuilder:
         return state
 
     def _record_for_object(self, object_id: str, context_only: bool) -> EvidenceRecord | None:
+        if self._authority_context is not None:
+            record = self._authority_context.evidence_records.get(object_id)
+            return replace(record, context_only=context_only) if record is not None else None
         row = self.connection.execute(
             f"""
             WITH {authoritative_current_observation_ctes()},
@@ -345,39 +454,7 @@ class PacketBuilder:
         ).fetchone()
         if row is None:
             return None
-        return EvidenceRecord(
-            observation_id=str(row["id"]),
-            object_id=str(row["source_object_id"]),
-            app_id=str(row["app_id"]),
-            source=str(row["source"]),
-            source_instance=str(row["source_instance"]),
-            kind=str(row["kind"]),
-            external_id=str(row["external_id"]),
-            title=str(row["title"]) if row["title"] is not None else None,
-            body_text=str(row["body_text"]) if row["body_text"] is not None else None,
-            data=_parse_json_object(row["data_json"]),
-            completeness=str(row["completeness"]),
-            fetched_at=str(row["fetched_at"]),
-            source_updated_at=(
-                str(row["source_updated_at"]) if row["source_updated_at"] is not None else None
-            ),
-            availability=str(row["availability"]),
-            availability_evidence_id=(
-                str(row["availability_evidence_id"])
-                if row["availability_evidence_id"] is not None
-                else None
-            ),
-            availability_reason=(
-                str(row["availability_reason"]) if row["availability_reason"] is not None else None
-            ),
-            availability_observed_at=(
-                str(row["availability_observed_at"])
-                if row["availability_observed_at"] is not None
-                else None
-            ),
-            is_current=True,
-            context_only=context_only,
-        )
+        return _evidence_record_from_row(row, context_only=context_only)
 
     def _records(self, contribution: ContributionView) -> list[EvidenceRecord]:
         records: list[EvidenceRecord] = []
@@ -777,7 +854,14 @@ class PacketBuilder:
         records = self._records(contribution)
         title_provenance = self._title_provenance(contribution, records)
         participation = build_participation_summary(
-            self.connection, records, contribution.attestations
+            self.connection,
+            records,
+            contribution.attestations,
+            current_participation_rows=(
+                self._authority_context.participation_rows_by_observation
+                if self._authority_context is not None
+                else None
+            ),
         )
         release_ladder = build_release_ladder(
             records,
@@ -1370,10 +1454,17 @@ class PacketBuilder:
         """Project one candidate with the canonical list-row evidence semantics."""
 
         self._app(app_id)
+        if self._authority_context is not None and self._authority_context.app_id != app_id:
+            raise ScopeViolation("authority context belongs to another application")
         projected: CandidateView = project_candidate(
             self.connection,
             candidate_id,
             decision_context=self._decision_projection,
+            current_observations=(
+                self._authority_context.current_observations
+                if self._authority_context is not None
+                else None
+            ),
         )
         if projected.app_id != app_id:
             raise ScopeViolation("candidate belongs to another application")
@@ -1385,9 +1476,16 @@ class PacketBuilder:
             raise NotFound(f"candidate has no current evidence records: {candidate_id}")
         period_from, period_to = self._date_range(records)
         coverage = sorted({record.source for record in records})
-        raw_roles = build_participation_summary(self.connection, records, []).get(
-            "self_participations", []
-        )
+        raw_roles = build_participation_summary(
+            self.connection,
+            records,
+            [],
+            current_participation_rows=(
+                self._authority_context.participation_rows_by_observation
+                if self._authority_context is not None
+                else None
+            ),
+        ).get("self_participations", [])
         roles = raw_roles if isinstance(raw_roles, list) else []
         indicators = sorted(
             {str(item.get("role")) for item in roles if isinstance(item, dict) and item.get("role")}

--- a/src/worktrace/packets/builder.py
+++ b/src/worktrace/packets/builder.py
@@ -9,6 +9,7 @@ from typing import cast
 
 from worktrace.candidates.decisions import (
     CREATION_ACTIONS,
+    _DecisionProjectionContext,
     compensating_decision_ids,
     decision_lineages,
     decision_scope_map,
@@ -120,16 +121,27 @@ def _single_member(payload: dict[str, object]) -> str | None:
 class PacketBuilder:
     """Read model over the SQLite ledger; this class never mutates state."""
 
-    def __init__(self, connection: sqlite3.Connection, config: WorkTraceConfig) -> None:
+    def __init__(
+        self,
+        connection: sqlite3.Connection,
+        config: WorkTraceConfig,
+        *,
+        decision_context: _DecisionProjectionContext | None = None,
+    ) -> None:
         self.connection = connection
         self.config = config
+        self._decision_projection = decision_context
 
     def _app(self, app_id: str) -> AppConfig:
         return self.config.app(app_id)
 
     def _candidate(self, candidate_id: str) -> ContributionView | None:
         try:
-            projected = project_candidate(self.connection, candidate_id)
+            projected = project_candidate(
+                self.connection,
+                candidate_id,
+                decision_context=self._decision_projection,
+            )
         except NotFound:
             return None
         if projected.status == "ignored":
@@ -156,13 +168,26 @@ class PacketBuilder:
         )
 
     def _resolve_contribution(self, identifier: str) -> ContributionView:
-        lineage = resolve_decision_lineage(self.connection, identifier)
+        lineage = (
+            self._decision_projection.resolve_lineage(identifier)
+            if self._decision_projection is not None
+            else resolve_decision_lineage(self.connection, identifier)
+        )
         if lineage is None:
             candidate = self._candidate(identifier)
             if candidate is None:
                 raise NotFound(f"contribution not found: {identifier}")
-            scopes = decision_scope_map(self.connection, active_only=True)
-            for decision in decision_stream(self.connection, active_only=True):
+            scopes = (
+                self._decision_projection.decision_scopes
+                if self._decision_projection is not None
+                else decision_scope_map(self.connection, active_only=True)
+            )
+            decisions = (
+                self._decision_projection.for_target(identifier)
+                if self._decision_projection is not None
+                else decision_stream(self.connection, active_only=True)
+            )
+            for decision in decisions:
                 if decision.target_id != identifier or scopes.get(decision.id) != candidate.app_id:
                     continue
                 candidate.decision_evidence_ids.add(decision.id)
@@ -1341,6 +1366,64 @@ class PacketBuilder:
     def evidence_gaps(self, identifier: str) -> dict[str, object]:
         return build_gap_report(self.build_packet(identifier))
 
+    def candidate_list_item(self, app_id: str, candidate_id: str) -> dict[str, object]:
+        """Project one candidate with the canonical list-row evidence semantics."""
+
+        self._app(app_id)
+        projected: CandidateView = project_candidate(
+            self.connection,
+            candidate_id,
+            decision_context=self._decision_projection,
+        )
+        if projected.app_id != app_id:
+            raise ScopeViolation("candidate belongs to another application")
+        candidate = self._resolve_contribution(candidate_id)
+        if projected.status == "ignored":
+            raise NotFound(f"candidate was ignored by a human decision: {candidate_id}")
+        records = self._records(candidate)
+        if not records:
+            raise NotFound(f"candidate has no current evidence records: {candidate_id}")
+        period_from, period_to = self._date_range(records)
+        coverage = sorted({record.source for record in records})
+        raw_roles = build_participation_summary(self.connection, records, []).get(
+            "self_participations", []
+        )
+        roles = raw_roles if isinstance(raw_roles, list) else []
+        indicators = sorted(
+            {str(item.get("role")) for item in roles if isinstance(item, dict) and item.get("role")}
+        )
+        lineage = (
+            self._decision_projection.resolve_lineage(candidate_id, app_id=app_id)
+            if self._decision_projection is not None
+            else resolve_decision_lineage(
+                self.connection,
+                candidate_id,
+                app_id=app_id,
+            )
+        )
+        confirmed = None
+        if lineage is not None:
+            confirmed = next(
+                (
+                    str(decision.payload["contribution_id"])
+                    for decision in reversed(lineage.decisions)
+                    if decision.action in CREATION_ACTIONS
+                    and isinstance(decision.payload.get("contribution_id"), str)
+                ),
+                None,
+            )
+        return {
+            "candidate_id": candidate_id,
+            "confirmed_contribution_id": confirmed,
+            **self._title_provenance(candidate, records).as_fields(),
+            "period_from": period_from,
+            "period_to": period_to,
+            "suggested_type": candidate.contribution_type,
+            "status": projected.status,
+            "source_coverage": coverage,
+            "participation_indicators": indicators,
+        }
+
     def list_candidates(
         self,
         app_id: str,
@@ -1363,61 +1446,18 @@ class PacketBuilder:
         visible_items: list[dict[str, object]] = []
         for row in rows:
             try:
-                projected: CandidateView = project_candidate(self.connection, str(row["id"]))
-                candidate = self._resolve_contribution(str(row["id"]))
+                item = self.candidate_list_item(app_id, str(row["id"]))
             except NotFound:
                 continue
-            if projected.status == "ignored":
-                continue
-            records = self._records(candidate)
-            if not records:
-                continue
-            period_from, period_to = self._date_range(records)
-            period_from_date = _calendar_date(period_from)
-            period_to_date = _calendar_date(period_to)
+            period_from_date = _calendar_date(cast(str | None, item["period_from"]))
+            period_to_date = _calendar_date(cast(str | None, item["period_to"]))
             if date_from and period_to_date and period_to_date < date_from:
                 continue
             if date_to and period_from_date and period_from_date > date_to:
                 continue
-            coverage = sorted({record.source for record in records})
-            raw_roles = build_participation_summary(self.connection, records, []).get(
-                "self_participations", []
-            )
-            roles = raw_roles if isinstance(raw_roles, list) else []
-            indicators = sorted(
-                {
-                    str(item.get("role"))
-                    for item in roles
-                    if isinstance(item, dict) and item.get("role")
-                }
-            )
-            lineage = resolve_decision_lineage(
-                self.connection,
-                str(row["id"]),
-                app_id=app_id,
-            )
-            confirmed = None
-            if lineage is not None:
-                confirmed = next(
-                    (
-                        str(decision.payload["contribution_id"])
-                        for decision in reversed(lineage.decisions)
-                        if decision.action in CREATION_ACTIONS
-                        and isinstance(decision.payload.get("contribution_id"), str)
-                    ),
-                    None,
-                )
             visible_items.append(
                 {
-                    "candidate_id": str(row["id"]),
-                    "confirmed_contribution_id": confirmed,
-                    **self._title_provenance(candidate, records).as_fields(),
-                    "period_from": period_from,
-                    "period_to": period_to,
-                    "suggested_type": candidate.contribution_type,
-                    "status": projected.status,
-                    "source_coverage": coverage,
-                    "participation_indicators": indicators,
+                    **item,
                     "warnings": [
                         "Candidate grouping is deterministic derived state, not contribution truth."
                     ],

--- a/src/worktrace/packets/ownership.py
+++ b/src/worktrace/packets/ownership.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 
 from worktrace.db.authority import authoritative_current_participation_ctes
 from worktrace.packets.authority import find_attestation
@@ -23,28 +23,44 @@ def build_participation_summary(
     connection: sqlite3.Connection,
     records: Sequence[EvidenceRecord],
     attestations: Sequence[HumanAttestation],
+    *,
+    current_participation_rows: Mapping[str, tuple[sqlite3.Row, ...]] | None = None,
 ) -> dict[str, object]:
     """Return role observations without converting them into ownership labels."""
 
     observation_ids = [record.observation_id for record in records]
     rows: list[sqlite3.Row] = []
     if observation_ids:
-        rows = list(
-            connection.execute(
-                f"""
-                WITH {authoritative_current_participation_ctes()}
-                SELECT p.id, p.source_object_id, p.observation_id, p.role,
-                    p.effective_from, p.effective_to, a.id AS actor_id,
-                    a.display_name, a.is_self, so.source, so.kind, so.external_id
-                FROM authoritative_current_participations p
-                JOIN actors a ON a.id=p.actor_id
-                JOIN source_objects so ON so.id=p.source_object_id
-                WHERE p.observation_id IN ({_placeholders(observation_ids)})
-                ORDER BY p.effective_from, p.id
-                """,
-                observation_ids,
+        if current_participation_rows is not None:
+            rows = [
+                row
+                for observation_id in observation_ids
+                for row in current_participation_rows.get(observation_id, ())
+            ]
+            rows.sort(
+                key=lambda row: (
+                    row["effective_from"] is not None,
+                    str(row["effective_from"] or ""),
+                    str(row["id"]),
+                )
             )
-        )
+        else:
+            rows = list(
+                connection.execute(
+                    f"""
+                    WITH {authoritative_current_participation_ctes()}
+                    SELECT p.id, p.source_object_id, p.observation_id, p.role,
+                        p.effective_from, p.effective_to, a.id AS actor_id,
+                        a.display_name, a.is_self, so.source, so.kind, so.external_id
+                    FROM authoritative_current_participations p
+                    JOIN actors a ON a.id=p.actor_id
+                    JOIN source_objects so ON so.id=p.source_object_id
+                    WHERE p.observation_id IN ({_placeholders(observation_ids)})
+                    ORDER BY p.effective_from, p.id
+                    """,
+                    observation_ids,
+                )
+            )
 
     self_rows = [row for row in rows if bool(row["is_self"])]
     other_rows = [row for row in rows if not bool(row["is_self"])]

--- a/src/worktrace/read_models/__init__.py
+++ b/src/worktrace/read_models/__init__.py
@@ -1,0 +1,17 @@
+from worktrace.read_models.candidates import (
+    CandidateCursor,
+    CandidateGenerationChanged,
+    CandidateGenerationInconsistent,
+    CandidateListItem,
+    CandidatePage,
+    candidate_page,
+)
+
+__all__ = [
+    "CandidateCursor",
+    "CandidateGenerationChanged",
+    "CandidateGenerationInconsistent",
+    "CandidateListItem",
+    "CandidatePage",
+    "candidate_page",
+]

--- a/src/worktrace/read_models/candidates.py
+++ b/src/worktrace/read_models/candidates.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass, field
+
+from worktrace.candidates.decisions import _build_decision_projection_context
+from worktrace.config import WorkTraceConfig
+from worktrace.errors import DatabaseError, NotFound, WorkTraceError
+
+DEFAULT_PAGE_SIZE = 25
+MAX_PAGE_SIZE = 50
+MAX_SCAN_BUDGET = 200
+
+_ACTIVE_GENERATION_SQL = """
+    SELECT generated_at, generator_version
+    FROM candidate_groups INDEXED BY idx_candidates_app_time
+    WHERE app_id=?
+    ORDER BY generated_at DESC
+    LIMIT 1
+"""
+_OLDER_GENERATION_SQL = """
+    SELECT 1
+    FROM candidate_groups INDEXED BY idx_candidates_app_time
+    WHERE app_id=? AND generated_at < ?
+    LIMIT 1
+"""
+_NEWER_GENERATION_SQL = """
+    SELECT 1
+    FROM candidate_groups INDEXED BY idx_candidates_app_time
+    WHERE app_id=? AND generated_at > ?
+    LIMIT 1
+"""
+_RAW_CANDIDATE_SQL = """
+    SELECT id, generator_version
+    FROM candidate_groups INDEXED BY sqlite_autoindex_candidate_groups_1
+    WHERE id > ? AND app_id=? AND generated_at=?
+    ORDER BY id
+    LIMIT ?
+"""
+
+
+class CandidateGenerationChanged(WorkTraceError):
+    """The caller's cursor belongs to a different candidate rebuild."""
+
+
+class CandidateGenerationInconsistent(DatabaseError):
+    """Candidate rows do not describe one transactional rebuild generation."""
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateCursor:
+    generation_token: str
+    after_candidate_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateListItem:
+    candidate_id: str
+    confirmed_contribution_id: str | None
+    title: str | None
+    source_text_is_untrusted: bool
+    title_content_type: str | None
+    title_authority: str
+    title_status: str
+    title_observation_types: tuple[str, ...]
+    title_supporting_evidence_ids: tuple[str, ...]
+    title_limitations: tuple[str, ...]
+    contribution_type: str
+    status: str
+    period_from: str | None
+    period_to: str | None
+    source_coverage: tuple[str, ...]
+    participation_indicators: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class CandidatePage:
+    generation_token: str | None
+    items: tuple[CandidateListItem, ...]
+    next_cursor: CandidateCursor | None
+
+
+@dataclass(slots=True)
+class _PageDiagnostics:
+    scanned_candidate_ids: list[str] = field(default_factory=list)
+    projected_candidate_ids: list[str] = field(default_factory=list)
+    batch_limits: list[int] = field(default_factory=list)
+
+    @property
+    def raw_scan_count(self) -> int:
+        return len(self.scanned_candidate_ids)
+
+    @property
+    def projection_count(self) -> int:
+        return len(self.projected_candidate_ids)
+
+
+@dataclass(frozen=True, slots=True)
+class _Generation:
+    generated_at: str
+    generator_version: str
+    token: str
+
+
+def _generation_token(app_id: str, generated_at: str, generator_version: str) -> str:
+    payload = json.dumps(
+        [app_id, generated_at, generator_version],
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _active_generation(
+    connection: sqlite3.Connection,
+    app_id: str,
+) -> _Generation | None:
+    row = connection.execute(
+        _ACTIVE_GENERATION_SQL,
+        (app_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    generated_at = str(row["generated_at"])
+    generator_version = str(row["generator_version"])
+
+    # Transactional rebuilds replace every candidate for an application with one
+    # generated_at value. Range probes use the existing app/time index and reject
+    # reachable mixed-timestamp corruption without scanning the full generation.
+    older = connection.execute(
+        _OLDER_GENERATION_SQL,
+        (app_id, generated_at),
+    ).fetchone()
+    newer = connection.execute(
+        _NEWER_GENERATION_SQL,
+        (app_id, generated_at),
+    ).fetchone()
+    if older is not None or newer is not None:
+        raise CandidateGenerationInconsistent("candidate rows contain mixed rebuild timestamps")
+    return _Generation(
+        generated_at=generated_at,
+        generator_version=generator_version,
+        token=_generation_token(app_id, generated_at, generator_version),
+    )
+
+
+def _raw_candidate_batch(
+    connection: sqlite3.Connection,
+    *,
+    app_id: str,
+    generation: _Generation,
+    after_candidate_id: str,
+    limit: int,
+) -> list[sqlite3.Row]:
+    return list(
+        connection.execute(
+            _RAW_CANDIDATE_SQL,
+            (after_candidate_id, app_id, generation.generated_at, limit),
+        )
+    )
+
+
+def _validate_row_generation(row: sqlite3.Row, generation: _Generation) -> None:
+    if str(row["generator_version"]) != generation.generator_version:
+        raise CandidateGenerationInconsistent("candidate rows contain mixed generator versions")
+
+
+def _has_raw_candidate_after(
+    connection: sqlite3.Connection,
+    *,
+    app_id: str,
+    generation: _Generation,
+    after_candidate_id: str,
+) -> bool:
+    rows = _raw_candidate_batch(
+        connection,
+        app_id=app_id,
+        generation=generation,
+        after_candidate_id=after_candidate_id,
+        limit=1,
+    )
+    if not rows:
+        return False
+    _validate_row_generation(rows[0], generation)
+    return True
+
+
+def _tuple_of_strings(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    return tuple(str(item) for item in value)
+
+
+def _item_from_projection(projection: dict[str, object]) -> CandidateListItem:
+    return CandidateListItem(
+        candidate_id=str(projection["candidate_id"]),
+        confirmed_contribution_id=(
+            str(projection["confirmed_contribution_id"])
+            if projection.get("confirmed_contribution_id") is not None
+            else None
+        ),
+        title=str(projection["title"]) if projection.get("title") is not None else None,
+        source_text_is_untrusted=bool(projection["source_text_is_untrusted"]),
+        title_content_type=(
+            str(projection["title_content_type"])
+            if projection.get("title_content_type") is not None
+            else None
+        ),
+        title_authority=str(projection["title_authority"]),
+        title_status=str(projection["title_status"]),
+        title_observation_types=_tuple_of_strings(projection["title_observation_types"]),
+        title_supporting_evidence_ids=_tuple_of_strings(
+            projection["title_supporting_evidence_ids"]
+        ),
+        title_limitations=_tuple_of_strings(projection["title_limitations"]),
+        contribution_type=str(projection["suggested_type"]),
+        status=str(projection["status"]),
+        period_from=(
+            str(projection["period_from"]) if projection.get("period_from") is not None else None
+        ),
+        period_to=(
+            str(projection["period_to"]) if projection.get("period_to") is not None else None
+        ),
+        source_coverage=_tuple_of_strings(projection["source_coverage"]),
+        participation_indicators=_tuple_of_strings(projection["participation_indicators"]),
+    )
+
+
+def candidate_page(
+    connection: sqlite3.Connection,
+    config: WorkTraceConfig,
+    app_id: str,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    cursor: CandidateCursor | None = None,
+) -> CandidatePage:
+    return _candidate_page(
+        connection,
+        config,
+        app_id,
+        page_size=page_size,
+        cursor=cursor,
+        diagnostics=None,
+    )
+
+
+def _candidate_page(
+    connection: sqlite3.Connection,
+    config: WorkTraceConfig,
+    app_id: str,
+    *,
+    page_size: int = DEFAULT_PAGE_SIZE,
+    cursor: CandidateCursor | None = None,
+    diagnostics: _PageDiagnostics | None,
+) -> CandidatePage:
+    if not 1 <= page_size <= MAX_PAGE_SIZE:
+        raise ValueError(f"page_size must be between 1 and {MAX_PAGE_SIZE}")
+    if connection.in_transaction:
+        raise DatabaseError("candidate page requires a connection outside a transaction")
+
+    config.app(app_id)
+    batch_size = page_size * 2
+    scan_budget = min(page_size * 4, MAX_SCAN_BUDGET)
+    from worktrace.packets.builder import PacketBuilder
+
+    connection.execute("BEGIN")
+    try:
+        generation = _active_generation(connection, app_id)
+        if generation is None:
+            if cursor is not None:
+                raise CandidateGenerationChanged(
+                    "candidate generation changed; restart from the first page"
+                )
+            result = CandidatePage(generation_token=None, items=(), next_cursor=None)
+        else:
+            if cursor is not None and cursor.generation_token != generation.token:
+                raise CandidateGenerationChanged(
+                    "candidate generation changed; restart from the first page"
+                )
+            after_candidate_id = cursor.after_candidate_id if cursor is not None else ""
+            items: list[CandidateListItem] = []
+            raw_scans = 0
+            decision_context = _build_decision_projection_context(connection)
+            builder = PacketBuilder(
+                connection,
+                config,
+                decision_context=decision_context,
+            )
+
+            while len(items) < page_size and raw_scans < scan_budget:
+                batch_limit = min(batch_size, scan_budget - raw_scans)
+                if diagnostics is not None:
+                    diagnostics.batch_limits.append(batch_limit)
+                rows = _raw_candidate_batch(
+                    connection,
+                    app_id=app_id,
+                    generation=generation,
+                    after_candidate_id=after_candidate_id,
+                    limit=batch_limit,
+                )
+                if not rows:
+                    break
+                for row in rows:
+                    _validate_row_generation(row, generation)
+                    candidate_id = str(row["id"])
+                    after_candidate_id = candidate_id
+                    raw_scans += 1
+                    if diagnostics is not None:
+                        diagnostics.scanned_candidate_ids.append(candidate_id)
+                        diagnostics.projected_candidate_ids.append(candidate_id)
+                    try:
+                        projection = builder.candidate_list_item(app_id, candidate_id)
+                    except NotFound:
+                        continue
+                    items.append(_item_from_projection(projection))
+                    if len(items) == page_size or raw_scans == scan_budget:
+                        break
+
+            has_more = bool(after_candidate_id) and _has_raw_candidate_after(
+                connection,
+                app_id=app_id,
+                generation=generation,
+                after_candidate_id=after_candidate_id,
+            )
+            next_cursor = (
+                CandidateCursor(
+                    generation_token=generation.token,
+                    after_candidate_id=after_candidate_id,
+                )
+                if has_more
+                else None
+            )
+            result = CandidatePage(
+                generation_token=generation.token,
+                items=tuple(items),
+                next_cursor=next_cursor,
+            )
+        connection.execute("COMMIT")
+        return result
+    except Exception:
+        if connection.in_transaction:
+            connection.execute("ROLLBACK")
+        raise

--- a/src/worktrace/read_models/candidates.py
+++ b/src/worktrace/read_models/candidates.py
@@ -87,6 +87,13 @@ class _PageDiagnostics:
     scanned_candidate_ids: list[str] = field(default_factory=list)
     projected_candidate_ids: list[str] = field(default_factory=list)
     batch_limits: list[int] = field(default_factory=list)
+    decision_context_builds: int = 0
+    active_decision_count: int = 0
+    decision_scope_count: int = 0
+    decision_lineage_count: int = 0
+    authority_context_builds: int = 0
+    authority_observation_count: int = 0
+    authority_participation_count: int = 0
 
     @property
     def raw_scan_count(self) -> int:
@@ -263,7 +270,7 @@ def _candidate_page(
     config.app(app_id)
     batch_size = page_size * 2
     scan_budget = min(page_size * 4, MAX_SCAN_BUDGET)
-    from worktrace.packets.builder import PacketBuilder
+    from worktrace.packets.builder import PacketBuilder, _build_authority_evidence_context
 
     connection.execute("BEGIN")
     try:
@@ -283,10 +290,25 @@ def _candidate_page(
             items: list[CandidateListItem] = []
             raw_scans = 0
             decision_context = _build_decision_projection_context(connection)
+            authority_context = _build_authority_evidence_context(connection, app_id)
+            if diagnostics is not None:
+                diagnostics.decision_context_builds = 1
+                diagnostics.active_decision_count = len(decision_context.active_decisions)
+                diagnostics.decision_scope_count = len(decision_context.decision_scopes)
+                diagnostics.decision_lineage_count = len(decision_context.lineages)
+                diagnostics.authority_context_builds = 1
+                diagnostics.authority_observation_count = len(
+                    authority_context.current_observations
+                )
+                diagnostics.authority_participation_count = sum(
+                    len(rows)
+                    for rows in authority_context.participation_rows_by_observation.values()
+                )
             builder = PacketBuilder(
                 connection,
                 config,
                 decision_context=decision_context,
+                authority_context=authority_context,
             )
 
             while len(items) < page_size and raw_scans < scan_budget:

--- a/tests/test_candidate_paging.py
+++ b/tests/test_candidate_paging.py
@@ -1,0 +1,729 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import sqlite3
+import threading
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from worktrace.candidates.decisions import _build_decision_projection_context
+from worktrace.candidates.projector import project_candidate
+from worktrace.config import AppConfig, IdentityConfig, WorkTraceConfig
+from worktrace.db.connection import connect, connect_read_only
+from worktrace.db.migrations import migrate
+from worktrace.packets.builder import PacketBuilder
+from worktrace.read_models.candidates import (
+    _ACTIVE_GENERATION_SQL,
+    _NEWER_GENERATION_SQL,
+    _OLDER_GENERATION_SQL,
+    _RAW_CANDIDATE_SQL,
+    CandidateCursor,
+    CandidateGenerationChanged,
+    CandidateGenerationInconsistent,
+    _candidate_page,
+    _PageDiagnostics,
+    candidate_page,
+)
+
+_APP_ID = "sample_store"
+_GENERATED_AT = "2026-08-30T12:00:00+00:00"
+_GENERATOR_VERSION = "fixture-v1"
+_SOURCES = (
+    ("manual", "local", "manual_evidence", {}),
+    ("git", "repo", "git_commit", {}),
+    ("jira", "jira.example", "jira_issue", {"selection_policy_version": 2}),
+    ("gitlab", "gitlab.example", "gitlab_mr", {"selection_policy_version": 2}),
+)
+
+
+def _config(data_directory: Path) -> WorkTraceConfig:
+    return WorkTraceConfig(
+        schema_version=1,
+        data_directory=data_directory,
+        employment_from=date(2020, 1, 1),
+        employment_to=date(2026, 12, 31),
+        identity=IdentityConfig(
+            display_name="Fixture Engineer",
+            git_author_emails=(),
+            git_author_names=("Fixture Engineer",),
+            jira_account_id="fixture-self",
+            gitlab_user_id=7,
+            gitlab_username="fixture-engineer",
+        ),
+        apps=(
+            AppConfig(
+                id=_APP_ID,
+                name="Sample Store",
+                market="XX",
+                business_type="fixture",
+                jira_project_keys=("DEMO",),
+                gitlab_project_ids=(101,),
+                repo_paths=(data_directory / "repo",),
+                jira_key_patterns=(r"DEMO-[0-9]+",),
+                production_environments=("production",),
+                release_tag_patterns=(r"v[0-9]+.*",),
+                ignored_paths=(),
+            ),
+        ),
+        config_path=data_directory / "config.toml",
+    )
+
+
+def _initialize(database_path: Path) -> sqlite3.Connection:
+    connection = connect(database_path)
+    migrate(connection, database_path)
+    connection.execute(
+        "INSERT INTO apps(id, name, market, business_type) VALUES (?, ?, ?, ?)",
+        (_APP_ID, "Sample Store", "XX", "fixture"),
+    )
+    return connection
+
+
+def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) -> None:
+    connection = _initialize(database_path)
+    try:
+        run_rows: list[tuple[object, ...]] = []
+        for source, source_instance, _, scope in _SOURCES:
+            run_rows.extend(
+                (
+                    (
+                        f"run:{source}:old",
+                        source,
+                        source_instance,
+                        "2026-08-29T12:00:00+00:00",
+                        json.dumps(scope),
+                    ),
+                    (
+                        f"run:{source}:current",
+                        source,
+                        source_instance,
+                        "2026-08-30T12:00:00+00:00",
+                        json.dumps(scope),
+                    ),
+                )
+            )
+        connection.executemany(
+            """
+            INSERT INTO sync_runs(
+                id, app_id, source, source_instance, status, started_at, completed_at,
+                adapter_version, scope_json, completeness
+            ) VALUES (?, 'sample_store', ?, ?, 'complete', ?, ?, 'fixture', ?,
+                      'complete_for_scope')
+            """,
+            [(*row[:3], row[3], row[3], row[4]) for row in run_rows],
+        )
+
+        object_rows: list[tuple[object, ...]] = []
+        candidate_rows: list[tuple[object, ...]] = []
+        member_rows: list[tuple[str, str]] = []
+        for index in range(candidate_count):
+            source, source_instance, kind, _ = _SOURCES[index % len(_SOURCES)]
+            object_id = f"obj:scale-{index:04d}"
+            candidate_id = f"candidate:scale-{index:04d}"
+            object_rows.append(
+                (
+                    object_id,
+                    source,
+                    source_instance,
+                    kind,
+                    f"external-{index:04d}",
+                    f"run:{source}:old",
+                    f"run:{source}:current"
+                    if index >= candidate_count - 50
+                    else f"run:{source}:old",
+                )
+            )
+            candidate_rows.append(
+                (
+                    candidate_id,
+                    object_id,
+                    _GENERATOR_VERSION,
+                    f"Candidate {index:04d}",
+                    "feature",
+                    _GENERATED_AT,
+                )
+            )
+            member_rows.append((candidate_id, object_id))
+        connection.executemany(
+            """
+            INSERT INTO source_objects(
+                id, app_id, source, source_instance, kind, external_id,
+                first_seen_run_id, last_seen_run_id
+            ) VALUES (?, 'sample_store', ?, ?, ?, ?, ?, ?)
+            """,
+            object_rows,
+        )
+        connection.executemany(
+            """
+            INSERT INTO candidate_groups(
+                id, app_id, seed_object_id, generator_version, suggested_title,
+                suggested_type, generated_at
+            ) VALUES (?, 'sample_store', ?, ?, ?, ?, ?)
+            """,
+            candidate_rows,
+        )
+        connection.executemany(
+            """
+            INSERT INTO candidate_members(
+                candidate_id, source_object_id, membership_reason, context_only
+            ) VALUES (?, ?, 'fixture', 0)
+            """,
+            member_rows,
+        )
+
+        visible_start = candidate_count - 50
+        observation_rows: list[tuple[object, ...]] = []
+        actor_rows: list[tuple[object, ...]] = []
+        participation_rows: list[tuple[object, ...]] = []
+        for source, source_instance, _, _ in _SOURCES:
+            actor_rows.append(
+                (
+                    f"actor:self:{source}",
+                    source,
+                    source_instance,
+                    f"self-{source}",
+                    "Fixture Engineer",
+                )
+            )
+        for index in range(visible_start, candidate_count):
+            source, _, _, _ = _SOURCES[index % len(_SOURCES)]
+            object_id = f"obj:scale-{index:04d}"
+            observation_id = f"obs:scale-{index:04d}"
+            observation_rows.append(
+                (
+                    observation_id,
+                    object_id,
+                    f"run:{source}:current",
+                    f"hash-{index:04d}",
+                    f"Candidate {index:04d}",
+                )
+            )
+            participation_rows.append(
+                (
+                    f"participation:scale-{index:04d}",
+                    object_id,
+                    observation_id,
+                    f"actor:self:{source}",
+                    "authored" if index % 2 == 0 else "reviewed",
+                )
+            )
+        connection.executemany(
+            """
+            INSERT INTO observations(
+                id, source_object_id, sync_run_id, source_updated_at, fetched_at,
+                payload_hash, title, body_text, data_json, completeness,
+                adapter_version, normalization_version, redaction_version
+            ) VALUES (?, ?, ?, '2026-08-30T11:00:00+00:00',
+                      '2026-08-30T12:00:00+00:00', ?, ?, 'Synthetic body', '{}',
+                      'complete', 'fixture', '1', '1')
+            """,
+            observation_rows,
+        )
+        connection.executemany(
+            """
+            INSERT INTO actors(
+                id, source, source_instance, external_actor_id, display_name, is_self
+            ) VALUES (?, ?, ?, ?, ?, 1)
+            """,
+            actor_rows,
+        )
+        connection.executemany(
+            """
+            INSERT INTO participations(
+                id, source_object_id, observation_id, actor_id, role, details_json
+            ) VALUES (?, ?, ?, ?, ?, '{}')
+            """,
+            participation_rows,
+        )
+
+        ignored = [
+            (
+                f"decision:ignore-{index:04d}",
+                f"candidate:scale-{index:04d}",
+                f"2026-08-30T13:{index // 60:02d}:{index % 60:02d}+00:00",
+            )
+            for index in range(1_000)
+        ]
+        connection.executemany(
+            """
+            INSERT INTO human_decisions(
+                id, action, target_id, payload_json, actor_label, created_at
+            ) VALUES (?, 'ignore_candidate', ?, '{}', 'local-user', ?)
+            """,
+            ignored,
+        )
+        confirmed = [
+            (
+                f"decision:confirm-{index:04d}",
+                f"candidate:scale-{index:04d}",
+                json.dumps(
+                    {
+                        "app_id": _APP_ID,
+                        "contribution_id": f"contribution:scale-{index:04d}",
+                        "members": [f"obj:scale-{index:04d}"],
+                        "title": f"Confirmed {index:04d}",
+                    },
+                    separators=(",", ":"),
+                ),
+                f"2026-08-30T14:{(index - 1_000) // 60:02d}:{index % 60:02d}+00:00",
+            )
+            for index in range(1_000, 1_100)
+        ]
+        connection.executemany(
+            """
+            INSERT INTO human_decisions(
+                id, action, target_id, payload_json, actor_label, created_at
+            ) VALUES (?, 'confirm_candidate', ?, ?, 'local-user', ?)
+            """,
+            confirmed,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+@pytest.fixture(scope="module")
+def scale_state(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> tuple[Path, WorkTraceConfig]:
+    directory = tmp_path_factory.mktemp("candidate-scale")
+    database_path = directory / "worktrace.sqlite3"
+    _build_scale_database(database_path)
+    return database_path, _config(directory)
+
+
+def _copy_database(source: Path, destination: Path) -> Path:
+    shutil.copy2(source, destination)
+    return destination
+
+
+def test_default_page_is_scan_bounded_and_advances_by_the_last_raw_row(
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    database_path, config = scale_state
+    connection = connect_read_only(database_path)
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
+    diagnostics = _PageDiagnostics()
+    try:
+        page = _candidate_page(
+            connection,
+            config,
+            _APP_ID,
+            diagnostics=diagnostics,
+        )
+    finally:
+        connection.close()
+
+    assert page.items == ()
+    assert diagnostics.raw_scan_count == 100
+    assert diagnostics.projection_count == 100
+    assert diagnostics.batch_limits == [50, 50]
+    assert all("COUNT(" not in statement.upper() for statement in statements)
+    expected_token = hashlib.sha256(
+        json.dumps(
+            [_APP_ID, _GENERATED_AT, _GENERATOR_VERSION],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    assert page.generation_token == expected_token
+    assert page.next_cursor is not None
+    assert page.next_cursor.generation_token == expected_token
+    assert page.next_cursor.after_candidate_id == diagnostics.scanned_candidate_ids[-1]
+    assert page.next_cursor.after_candidate_id == "candidate:scale-0099"
+
+
+def test_scale_fixture_contains_the_intended_decision_and_authority_mix(
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    database_path, _ = scale_state
+    connection = connect_read_only(database_path)
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM candidate_groups").fetchone()[0] == 3_000
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM human_decisions WHERE action='ignore_candidate'"
+            ).fetchone()[0]
+            == 1_000
+        )
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM human_decisions WHERE action='confirm_candidate'"
+            ).fetchone()[0]
+            == 100
+        )
+        assert {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT DISTINCT source FROM source_objects WHERE id >= 'obj:scale-2950'"
+            )
+        } == {"manual", "git", "jira", "gitlab"}
+        unsupported = project_candidate(connection, "candidate:scale-1000")
+    finally:
+        connection.close()
+
+    assert unsupported.status == "confirmed"
+    assert unsupported.members == ()
+    assert unsupported.unsupported_member_ids == ("obj:scale-1000",)
+
+
+def test_maximum_page_never_scans_or_projects_more_than_two_hundred_rows(
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    database_path, config = scale_state
+    connection = connect_read_only(database_path)
+    diagnostics = _PageDiagnostics()
+    try:
+        page = _candidate_page(
+            connection,
+            config,
+            _APP_ID,
+            page_size=50,
+            diagnostics=diagnostics,
+        )
+        with pytest.raises(ValueError, match="between 1 and 50"):
+            candidate_page(connection, config, _APP_ID, page_size=51)
+    finally:
+        connection.close()
+
+    assert page.items == ()
+    assert diagnostics.raw_scan_count == 200
+    assert diagnostics.projection_count == 200
+    assert diagnostics.batch_limits == [100, 100]
+
+
+def test_short_pages_continue_without_duplicate_or_omitted_raw_candidates(
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    database_path, config = scale_state
+    connection = connect_read_only(database_path)
+    cursor: CandidateCursor | None = None
+    scanned_ids: list[str] = []
+    visible_ids: list[str] = []
+    try:
+        while True:
+            diagnostics = _PageDiagnostics()
+            page = _candidate_page(
+                connection,
+                config,
+                _APP_ID,
+                cursor=cursor,
+                diagnostics=diagnostics,
+            )
+            scanned_ids.extend(diagnostics.scanned_candidate_ids)
+            visible_ids.extend(item.candidate_id for item in page.items)
+            if page.next_cursor is None:
+                break
+            assert page.next_cursor.after_candidate_id == diagnostics.scanned_candidate_ids[-1]
+            cursor = page.next_cursor
+    finally:
+        connection.close()
+
+    assert scanned_ids == [f"candidate:scale-{index:04d}" for index in range(3_000)]
+    assert len(scanned_ids) == len(set(scanned_ids))
+    assert visible_ids == [f"candidate:scale-{index:04d}" for index in range(2_950, 3_000)]
+
+
+def test_visible_items_keep_canonical_title_source_and_participation_projection(
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    database_path, config = scale_state
+    connection = connect_read_only(database_path)
+    cursor: CandidateCursor | None = None
+    page = None
+    try:
+        while page is None or not page.items:
+            page = candidate_page(connection, config, _APP_ID, cursor=cursor)
+            cursor = page.next_cursor
+            assert cursor is not None or page.items
+    finally:
+        connection.close()
+
+    item = page.items[0]
+    assert item.title == "Candidate 2950"
+    assert item.title_authority == "provider_observed"
+    assert item.title_supporting_evidence_ids == ("obs:scale-2950",)
+    assert item.source_coverage == ("jira",)
+    assert item.participation_indicators == ("authored",)
+    assert item.confirmed_contribution_id is None
+
+
+def test_page_builds_the_global_decision_projection_once_not_once_per_row(
+    tmp_path: Path,
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    source, config = scale_state
+    high_decision_path = _copy_database(source, tmp_path / "high-decisions.sqlite3")
+    low_decision_path = _copy_database(source, tmp_path / "low-decisions.sqlite3")
+    writer = connect(low_decision_path)
+    try:
+        writer.execute("DELETE FROM human_decisions")
+        writer.commit()
+    finally:
+        writer.close()
+
+    token = hashlib.sha256(
+        json.dumps(
+            [_APP_ID, _GENERATED_AT, _GENERATOR_VERSION],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    cursor = CandidateCursor(token, "candidate:scale-2949")
+
+    def trace_page(database_path: Path) -> list[str]:
+        statements: list[str] = []
+        connection = connect_read_only(database_path)
+        connection.set_trace_callback(statements.append)
+        try:
+            page = candidate_page(connection, config, _APP_ID, cursor=cursor)
+            assert len(page.items) == 25
+        finally:
+            connection.close()
+        return statements
+
+    low_statements = trace_page(low_decision_path)
+    high_statements = trace_page(high_decision_path)
+    stream_sql = "SELECT * FROM human_decisions ORDER BY created_at, id"
+    assert sum(stream_sql in statement for statement in low_statements) == 1
+    assert sum(stream_sql in statement for statement in high_statements) == 1
+
+    decision_count = 1_100
+    assert len(high_statements) <= len(low_statements) + (2 * decision_count)
+
+
+def test_page_decision_context_preserves_canonical_projection_output(
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    database_path, config = scale_state
+    connection = connect_read_only(database_path)
+    try:
+        context = _build_decision_projection_context(connection)
+        regular = project_candidate(connection, "candidate:scale-2950")
+        contextual = project_candidate(
+            connection,
+            "candidate:scale-2950",
+            decision_context=context,
+        )
+        regular_confirmed = project_candidate(connection, "candidate:scale-1000")
+        contextual_confirmed = project_candidate(
+            connection,
+            "candidate:scale-1000",
+            decision_context=context,
+        )
+        regular_item = PacketBuilder(connection, config).candidate_list_item(
+            _APP_ID,
+            "candidate:scale-2950",
+        )
+        contextual_item = PacketBuilder(
+            connection,
+            config,
+            decision_context=context,
+        ).candidate_list_item(
+            _APP_ID,
+            "candidate:scale-2950",
+        )
+    finally:
+        connection.close()
+
+    assert contextual == regular
+    assert contextual_confirmed == regular_confirmed
+    assert contextual_item == regular_item
+
+
+def test_empty_generation_has_no_token_or_cursor(tmp_path: Path) -> None:
+    database_path = tmp_path / "empty.sqlite3"
+    connection = _initialize(database_path)
+    connection.commit()
+    connection.close()
+
+    read_only = connect_read_only(database_path)
+    try:
+        page = candidate_page(read_only, _config(tmp_path), _APP_ID)
+        assert page.generation_token is None
+        assert page.items == ()
+        assert page.next_cursor is None
+        with pytest.raises(CandidateGenerationChanged):
+            candidate_page(
+                read_only,
+                _config(tmp_path),
+                _APP_ID,
+                cursor=CandidateCursor("stale-token", "candidate:old"),
+            )
+    finally:
+        read_only.close()
+
+
+def test_rebuild_generation_invalidates_an_existing_cursor(
+    tmp_path: Path,
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    source, config = scale_state
+    database_path = _copy_database(source, tmp_path / "rebuilt.sqlite3")
+    read_only = connect_read_only(database_path)
+    try:
+        first = candidate_page(read_only, config, _APP_ID)
+        assert first.next_cursor is not None
+    finally:
+        read_only.close()
+
+    writer = connect(database_path)
+    try:
+        writer.execute("UPDATE candidate_groups SET generated_at='2026-08-31T12:00:00+00:00'")
+        writer.commit()
+    finally:
+        writer.close()
+
+    read_only = connect_read_only(database_path)
+    try:
+        with pytest.raises(CandidateGenerationChanged, match="restart"):
+            candidate_page(read_only, config, _APP_ID, cursor=first.next_cursor)
+    finally:
+        read_only.close()
+
+
+def test_mixed_generation_metadata_fails_explicitly(
+    tmp_path: Path,
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    source, config = scale_state
+    mixed_timestamp = _copy_database(source, tmp_path / "mixed-timestamp.sqlite3")
+    writer = connect(mixed_timestamp)
+    try:
+        writer.execute(
+            "UPDATE candidate_groups SET generated_at='2026-08-29T12:00:00+00:00' "
+            "WHERE id='candidate:scale-2999'"
+        )
+        writer.commit()
+    finally:
+        writer.close()
+    read_only = connect_read_only(mixed_timestamp)
+    try:
+        with pytest.raises(CandidateGenerationInconsistent, match="timestamps"):
+            candidate_page(read_only, config, _APP_ID)
+    finally:
+        read_only.close()
+
+    mixed_version = _copy_database(source, tmp_path / "mixed-version.sqlite3")
+    writer = connect(mixed_version)
+    try:
+        writer.execute(
+            "UPDATE candidate_groups SET generator_version='fixture-v2' "
+            "WHERE id='candidate:scale-0001'"
+        )
+        writer.commit()
+    finally:
+        writer.close()
+    read_only = connect_read_only(mixed_version)
+    try:
+        with pytest.raises(CandidateGenerationInconsistent, match="versions"):
+            candidate_page(read_only, config, _APP_ID)
+    finally:
+        read_only.close()
+
+
+def test_page_transaction_keeps_one_snapshot_and_next_page_detects_rebuild(
+    tmp_path: Path,
+    scale_state: tuple[Path, WorkTraceConfig],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source, config = scale_state
+    database_path = _copy_database(source, tmp_path / "snapshot.sqlite3")
+    writer_started = threading.Event()
+    writer_updated = threading.Event()
+    original = PacketBuilder.candidate_list_item
+    first_projection = True
+
+    def pause_after_snapshot(
+        builder: PacketBuilder,
+        app_id: str,
+        candidate_id: str,
+    ) -> dict[str, object]:
+        nonlocal first_projection
+        if first_projection:
+            first_projection = False
+            writer_started.set()
+            assert writer_updated.wait(timeout=5)
+        return original(builder, app_id, candidate_id)
+
+    monkeypatch.setattr(PacketBuilder, "candidate_list_item", pause_after_snapshot)
+
+    def rebuild() -> None:
+        assert writer_started.wait(timeout=5)
+        writer = connect(database_path)
+        try:
+            writer.autocommit = True
+            writer.execute("BEGIN IMMEDIATE")
+            writer.execute("UPDATE candidate_groups SET generated_at='2026-08-31T12:00:00+00:00'")
+            writer_updated.set()
+            writer.execute("COMMIT")
+        finally:
+            writer.close()
+
+    thread = threading.Thread(target=rebuild, daemon=True)
+    thread.start()
+    read_only = connect_read_only(database_path)
+    try:
+        first = candidate_page(read_only, config, _APP_ID)
+        assert first.next_cursor is not None
+    finally:
+        read_only.close()
+    thread.join(timeout=5)
+    assert not thread.is_alive()
+
+    read_only = connect_read_only(database_path)
+    try:
+        with pytest.raises(CandidateGenerationChanged):
+            candidate_page(read_only, config, _APP_ID, cursor=first.next_cursor)
+    finally:
+        read_only.close()
+
+
+def test_candidate_scan_query_plan_uses_existing_indexes_without_a_temp_sort(
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    database_path, _ = scale_state
+    connection = connect_read_only(database_path)
+    try:
+        active_plan = [
+            str(row["detail"])
+            for row in connection.execute(
+                f"EXPLAIN QUERY PLAN {_ACTIVE_GENERATION_SQL}", (_APP_ID,)
+            )
+        ]
+        older_plan = [
+            str(row["detail"])
+            for row in connection.execute(
+                f"EXPLAIN QUERY PLAN {_OLDER_GENERATION_SQL}",
+                (_APP_ID, _GENERATED_AT),
+            )
+        ]
+        newer_plan = [
+            str(row["detail"])
+            for row in connection.execute(
+                f"EXPLAIN QUERY PLAN {_NEWER_GENERATION_SQL}",
+                (_APP_ID, _GENERATED_AT),
+            )
+        ]
+        scan_plan = [
+            str(row["detail"])
+            for row in connection.execute(
+                f"EXPLAIN QUERY PLAN {_RAW_CANDIDATE_SQL}",
+                ("", _APP_ID, _GENERATED_AT, 50),
+            )
+        ]
+    finally:
+        connection.close()
+
+    assert any("idx_candidates_app_time" in detail for detail in active_plan)
+    assert any("idx_candidates_app_time" in detail for detail in older_plan)
+    assert any("idx_candidates_app_time" in detail for detail in newer_plan)
+    assert any("sqlite_autoindex_candidate_groups_1" in detail for detail in scan_plan)
+    plans = active_plan + older_plan + newer_plan + scan_plan
+    assert all("SCAN candidate_groups" not in detail for detail in plans)
+    assert all("USE TEMP B-TREE" not in detail for detail in plans)

--- a/tests/test_candidate_paging.py
+++ b/tests/test_candidate_paging.py
@@ -7,15 +7,21 @@ import sqlite3
 import threading
 from datetime import date
 from pathlib import Path
+from types import MappingProxyType
 
 import pytest
 
-from worktrace.candidates.decisions import _build_decision_projection_context
+from worktrace.candidates.decisions import (
+    _build_decision_projection_context,
+    append_decision,
+    undo_decision,
+)
 from worktrace.candidates.projector import project_candidate
 from worktrace.config import AppConfig, IdentityConfig, WorkTraceConfig
 from worktrace.db.connection import connect, connect_read_only
 from worktrace.db.migrations import migrate
-from worktrace.packets.builder import PacketBuilder
+from worktrace.errors import ScopeViolation
+from worktrace.packets.builder import PacketBuilder, _build_authority_evidence_context
 from worktrace.read_models.candidates import (
     _ACTIVE_GENERATION_SQL,
     _NEWER_GENERATION_SQL,
@@ -24,6 +30,7 @@ from worktrace.read_models.candidates import (
     CandidateCursor,
     CandidateGenerationChanged,
     CandidateGenerationInconsistent,
+    CandidateListItem,
     _candidate_page,
     _PageDiagnostics,
     candidate_page,
@@ -66,6 +73,19 @@ def _config(data_directory: Path) -> WorkTraceConfig:
                 jira_key_patterns=(r"DEMO-[0-9]+",),
                 production_environments=("production",),
                 release_tag_patterns=(r"v[0-9]+.*",),
+                ignored_paths=(),
+            ),
+            AppConfig(
+                id="other_app",
+                name="Other App",
+                market="YY",
+                business_type="fixture",
+                jira_project_keys=(),
+                gitlab_project_ids=(),
+                repo_paths=(data_directory / "other-repo",),
+                jira_key_patterns=(),
+                production_environments=(),
+                release_tag_patterns=(),
                 ignored_paths=(),
             ),
         ),
@@ -116,6 +136,20 @@ def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) 
             """,
             [(*row[:3], row[3], row[3], row[4]) for row in run_rows],
         )
+        connection.execute(
+            "INSERT INTO apps(id, name, market, business_type) "
+            "VALUES ('other_app', 'Other App', 'YY', 'fixture')"
+        )
+        connection.execute(
+            """
+            INSERT INTO sync_runs(
+                id, app_id, source, source_instance, status, started_at, completed_at,
+                adapter_version, scope_json, completeness
+            ) VALUES ('run:other:current', 'other_app', 'manual', 'other-local', 'complete',
+                      '2026-08-30T12:00:00+00:00', '2026-08-30T12:00:00+00:00',
+                      'fixture', '{}', 'complete_for_scope')
+            """
+        )
 
         object_rows: list[tuple[object, ...]] = []
         candidate_rows: list[tuple[object, ...]] = []
@@ -132,9 +166,7 @@ def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) 
                     kind,
                     f"external-{index:04d}",
                     f"run:{source}:old",
-                    f"run:{source}:current"
-                    if index >= candidate_count - 50
-                    else f"run:{source}:old",
+                    f"run:{source}:current",
                 )
             )
             candidate_rows.append(
@@ -148,6 +180,19 @@ def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) 
                 )
             )
             member_rows.append((candidate_id, object_id))
+        for index in range(1_000, 1_050):
+            source, source_instance, kind, _ = _SOURCES[index % len(_SOURCES)]
+            object_rows.append(
+                (
+                    f"obj:unsupported-{index:04d}",
+                    source,
+                    source_instance,
+                    kind,
+                    f"unsupported-{index:04d}",
+                    f"run:{source}:old",
+                    f"run:{source}:old",
+                )
+            )
         connection.executemany(
             """
             INSERT INTO source_objects(
@@ -174,8 +219,41 @@ def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) 
             """,
             member_rows,
         )
+        connection.execute(
+            """
+            INSERT INTO source_objects(
+                id, app_id, source, source_instance, kind, external_id,
+                first_seen_run_id, last_seen_run_id
+            ) VALUES ('obj:other', 'other_app', 'manual', 'other-local',
+                      'manual_evidence', 'other', 'run:other:current', 'run:other:current')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO observations(
+                id, source_object_id, sync_run_id, source_updated_at, fetched_at,
+                payload_hash, title, body_text, data_json, completeness,
+                adapter_version, normalization_version, redaction_version
+            ) VALUES ('obs:other', 'obj:other', 'run:other:current',
+                      '2026-08-30T11:00:00+00:00', '2026-08-30T12:00:00+00:00',
+                      'hash-other', 'Other title', 'Other body', '{}', 'complete',
+                      'fixture', '1', '1')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO candidate_groups(
+                id, app_id, seed_object_id, generator_version, suggested_title,
+                suggested_type, generated_at
+            ) VALUES ('candidate:other', 'other_app', 'obj:other', 'fixture-v1',
+                      'Other title', 'feature', ?)
+            """,
+            (_GENERATED_AT,),
+        )
+        connection.execute(
+            "INSERT INTO candidate_members VALUES ('candidate:other', 'obj:other', 'fixture', 0)"
+        )
 
-        visible_start = candidate_count - 50
         observation_rows: list[tuple[object, ...]] = []
         actor_rows: list[tuple[object, ...]] = []
         participation_rows: list[tuple[object, ...]] = []
@@ -189,7 +267,7 @@ def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) 
                     "Fixture Engineer",
                 )
             )
-        for index in range(visible_start, candidate_count):
+        for index in range(candidate_count):
             source, _, _, _ = _SOURCES[index % len(_SOURCES)]
             object_id = f"obj:scale-{index:04d}"
             observation_id = f"obs:scale-{index:04d}"
@@ -239,6 +317,51 @@ def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) 
             """,
             participation_rows,
         )
+        connection.execute(
+            """
+            INSERT INTO observations(
+                id, source_object_id, sync_run_id, source_updated_at, fetched_at,
+                payload_hash, title, body_text, data_json, completeness,
+                adapter_version, normalization_version, redaction_version
+            ) VALUES ('obs:scale-2950-old', 'obj:scale-2950', 'run:jira:old',
+                      '2026-08-29T11:00:00+00:00', '2026-08-29T12:00:00+00:00',
+                      'hash-2950-old', 'Stale title', 'Stale body', '{}', 'complete',
+                      'fixture', '1', '1')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO participations(
+                id, source_object_id, observation_id, actor_id, role, details_json
+            ) VALUES ('participation:scale-2950-old', 'obj:scale-2950',
+                      'obs:scale-2950-old', 'actor:self:jira', 'assigned', '{}')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO participations(
+                id, source_object_id, observation_id, actor_id, role, details_json
+            ) VALUES ('participation:scale-2950-mismatch', 'obj:scale-2950',
+                      'obs:scale-2950', 'actor:self:git', 'reviewed', '{}')
+            """
+        )
+        connection.execute(
+            """
+            UPDATE source_objects
+            SET availability='unavailable', availability_reason='fixture_unavailable',
+                availability_observed_at='2026-08-30T12:00:00+00:00'
+            WHERE id='obj:scale-2950'
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_object_availability_events(
+                id, source_object_id, sync_run_id, state, reason, observed_at
+            ) VALUES ('availability:scale-2950', 'obj:scale-2950', 'run:jira:current',
+                      'unavailable', 'fixture_unavailable',
+                      '2026-08-30T12:00:00+00:00')
+            """
+        )
 
         ignored = [
             (
@@ -264,7 +387,10 @@ def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) 
                     {
                         "app_id": _APP_ID,
                         "contribution_id": f"contribution:scale-{index:04d}",
-                        "members": [f"obj:scale-{index:04d}"],
+                        "members": [
+                            f"obj:scale-{index:04d}",
+                            *([f"obj:unsupported-{index:04d}"] if index < 1_050 else []),
+                        ],
                         "title": f"Confirmed {index:04d}",
                     },
                     separators=(",", ":"),
@@ -323,6 +449,19 @@ def test_default_page_is_scan_bounded_and_advances_by_the_last_raw_row(
     assert diagnostics.raw_scan_count == 100
     assert diagnostics.projection_count == 100
     assert diagnostics.batch_limits == [50, 50]
+    assert diagnostics.decision_context_builds == 1
+    assert diagnostics.active_decision_count == 1_100
+    assert diagnostics.decision_scope_count == 1_100
+    assert diagnostics.decision_lineage_count == 100
+    assert diagnostics.authority_context_builds == 1
+    assert sum(statement.strip() == "BEGIN" for statement in statements) == 1
+    assert sum(statement.strip() == "COMMIT" for statement in statements) == 1
+    assert sum("worktrace_page_authority_evidence_context" in value for value in statements) == 1
+    assert sum("authoritative_current_observations AS" in value for value in statements) == 1
+    assert sum("authoritative_current_availability_events AS" in value for value in statements) == 1
+    assert sum("worktrace_page_participation_context" in value for value in statements) == 1
+    assert sum("authoritative_current_participations AS" in value for value in statements) == 0
+    assert sum("WHERE current.source_object_id=" in value for value in statements) == 0
     assert all("COUNT(" not in statement.upper() for statement in statements)
     expected_token = hashlib.sha256(
         json.dumps(
@@ -344,7 +483,18 @@ def test_scale_fixture_contains_the_intended_decision_and_authority_mix(
     database_path, _ = scale_state
     connection = connect_read_only(database_path)
     try:
-        assert connection.execute("SELECT COUNT(*) FROM candidate_groups").fetchone()[0] == 3_000
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM candidate_groups WHERE app_id='sample_store'"
+            ).fetchone()[0]
+            == 3_000
+        )
+        authority_context = _build_authority_evidence_context(connection, _APP_ID)
+        assert len(authority_context.current_observations) == 3_000
+        assert (
+            sum(len(rows) for rows in authority_context.participation_rows_by_observation.values())
+            == 3_000
+        )
         assert (
             connection.execute(
                 "SELECT COUNT(*) FROM human_decisions WHERE action='ignore_candidate'"
@@ -368,8 +518,10 @@ def test_scale_fixture_contains_the_intended_decision_and_authority_mix(
         connection.close()
 
     assert unsupported.status == "confirmed"
-    assert unsupported.members == ()
-    assert unsupported.unsupported_member_ids == ("obj:scale-1000",)
+    assert tuple(member["source_object_id"] for member in unsupported.members) == (
+        "obj:scale-1000",
+    )
+    assert unsupported.unsupported_member_ids == ("obj:unsupported-1000",)
 
 
 def test_maximum_page_never_scans_or_projects_more_than_two_hundred_rows(
@@ -426,7 +578,7 @@ def test_short_pages_continue_without_duplicate_or_omitted_raw_candidates(
 
     assert scanned_ids == [f"candidate:scale-{index:04d}" for index in range(3_000)]
     assert len(scanned_ids) == len(set(scanned_ids))
-    assert visible_ids == [f"candidate:scale-{index:04d}" for index in range(2_950, 3_000)]
+    assert visible_ids == [f"candidate:scale-{index:04d}" for index in range(1_000, 3_000)]
 
 
 def test_visible_items_keep_canonical_title_source_and_participation_projection(
@@ -445,12 +597,12 @@ def test_visible_items_keep_canonical_title_source_and_participation_projection(
         connection.close()
 
     item = page.items[0]
-    assert item.title == "Candidate 2950"
-    assert item.title_authority == "provider_observed"
-    assert item.title_supporting_evidence_ids == ("obs:scale-2950",)
-    assert item.source_coverage == ("jira",)
+    assert item.title == "Confirmed 1000"
+    assert item.title_authority == "human_decision"
+    assert item.title_supporting_evidence_ids == ("decision:confirm-1000",)
+    assert item.source_coverage == ("manual",)
     assert item.participation_indicators == ("authored",)
-    assert item.confirmed_contribution_id is None
+    assert item.confirmed_contribution_id == "contribution:scale-1000"
 
 
 def test_page_builds_the_global_decision_projection_once_not_once_per_row(
@@ -497,24 +649,109 @@ def test_page_builds_the_global_decision_projection_once_not_once_per_row(
     assert len(high_statements) <= len(low_statements) + (2 * decision_count)
 
 
-def test_page_decision_context_preserves_canonical_projection_output(
+def test_page_builds_authority_evidence_context_once_for_low_and_dense_corpora(
+    tmp_path: Path,
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    source, config = scale_state
+    dense_path = _copy_database(source, tmp_path / "dense-evidence.sqlite3")
+    low_path = _copy_database(source, tmp_path / "low-evidence.sqlite3")
+    retained_observations = [f"obs:scale-{index:04d}" for index in range(2_950, 2_975)]
+    placeholders = ",".join("?" for _ in retained_observations)
+    writer = connect(low_path)
+    try:
+        writer.execute(
+            f"DELETE FROM participations WHERE observation_id NOT IN ({placeholders})",
+            retained_observations,
+        )
+        writer.execute(
+            f"DELETE FROM observations WHERE id NOT IN ({placeholders})",
+            retained_observations,
+        )
+        writer.commit()
+    finally:
+        writer.close()
+
+    token = hashlib.sha256(
+        json.dumps(
+            [_APP_ID, _GENERATED_AT, _GENERATOR_VERSION],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    cursor = CandidateCursor(token, "candidate:scale-2949")
+
+    def trace_page(
+        database_path: Path,
+    ) -> tuple[list[str], _PageDiagnostics, tuple[CandidateListItem, ...]]:
+        statements: list[str] = []
+        diagnostics = _PageDiagnostics()
+        connection = connect_read_only(database_path)
+        connection.set_trace_callback(statements.append)
+        try:
+            page = _candidate_page(
+                connection,
+                config,
+                _APP_ID,
+                cursor=cursor,
+                diagnostics=diagnostics,
+            )
+        finally:
+            connection.close()
+        return statements, diagnostics, page.items
+
+    low_statements, low_diagnostics, low_items = trace_page(low_path)
+    dense_statements, dense_diagnostics, dense_items = trace_page(dense_path)
+    combined_authority_context = "worktrace_page_authority_evidence_context"
+    participation_context = "worktrace_page_participation_context"
+
+    assert sum(combined_authority_context in value for value in low_statements) == 1
+    assert sum(combined_authority_context in value for value in dense_statements) == 1
+    assert sum(participation_context in value for value in low_statements) == 1
+    assert sum(participation_context in value for value in dense_statements) == 1
+    assert low_diagnostics.authority_context_builds == 1
+    assert dense_diagnostics.authority_context_builds == 1
+    assert low_diagnostics.authority_observation_count == 25
+    assert dense_diagnostics.authority_observation_count == 3_000
+    assert low_diagnostics.authority_participation_count == 25
+    assert dense_diagnostics.authority_participation_count == 3_000
+    assert dense_items == low_items
+
+
+def test_page_contexts_preserve_canonical_candidate_and_evidence_output(
     scale_state: tuple[Path, WorkTraceConfig],
 ) -> None:
     database_path, config = scale_state
     connection = connect_read_only(database_path)
     try:
-        context = _build_decision_projection_context(connection)
+        decision_context = _build_decision_projection_context(connection)
+        authority_context = _build_authority_evidence_context(connection, _APP_ID)
+        assert isinstance(decision_context.decisions_by_target, MappingProxyType)
+        assert isinstance(decision_context.decision_scopes, MappingProxyType)
+        assert isinstance(decision_context.lineages_by_identifier, MappingProxyType)
+        assert isinstance(authority_context.current_observations, MappingProxyType)
+        assert isinstance(authority_context.evidence_records, MappingProxyType)
+        assert isinstance(authority_context.participation_rows_by_observation, MappingProxyType)
         regular = project_candidate(connection, "candidate:scale-2950")
         contextual = project_candidate(
             connection,
             "candidate:scale-2950",
-            decision_context=context,
+            decision_context=decision_context,
+            current_observations=authority_context.current_observations,
         )
         regular_confirmed = project_candidate(connection, "candidate:scale-1000")
         contextual_confirmed = project_candidate(
             connection,
             "candidate:scale-1000",
-            decision_context=context,
+            decision_context=decision_context,
+            current_observations=authority_context.current_observations,
+        )
+        regular_ignored = project_candidate(connection, "candidate:scale-0000")
+        contextual_ignored = project_candidate(
+            connection,
+            "candidate:scale-0000",
+            decision_context=decision_context,
+            current_observations=authority_context.current_observations,
         )
         regular_item = PacketBuilder(connection, config).candidate_list_item(
             _APP_ID,
@@ -523,17 +760,103 @@ def test_page_decision_context_preserves_canonical_projection_output(
         contextual_item = PacketBuilder(
             connection,
             config,
-            decision_context=context,
+            decision_context=decision_context,
+            authority_context=authority_context,
         ).candidate_list_item(
             _APP_ID,
             "candidate:scale-2950",
+        )
+        regular_confirmed_item = PacketBuilder(connection, config).candidate_list_item(
+            _APP_ID,
+            "candidate:scale-1000",
+        )
+        contextual_confirmed_item = PacketBuilder(
+            connection,
+            config,
+            decision_context=decision_context,
+            authority_context=authority_context,
+        ).candidate_list_item(
+            _APP_ID,
+            "candidate:scale-1000",
+        )
+        regular_record = PacketBuilder(connection, config)._record_for_object(
+            "obj:scale-2950",
+            context_only=False,
+        )
+        contextual_builder = PacketBuilder(
+            connection,
+            config,
+            authority_context=authority_context,
+        )
+        contextual_record = contextual_builder._record_for_object(
+            "obj:scale-2950",
+            context_only=False,
+        )
+        contextual_context_only = contextual_builder._record_for_object(
+            "obj:scale-2950",
+            context_only=True,
         )
     finally:
         connection.close()
 
     assert contextual == regular
     assert contextual_confirmed == regular_confirmed
+    assert contextual_ignored == regular_ignored
+    assert contextual_ignored.status == "ignored"
+    assert contextual_confirmed.unsupported_member_ids == ("obj:unsupported-1000",)
     assert contextual_item == regular_item
+    assert json.dumps(contextual_item, separators=(",", ":")) == json.dumps(
+        regular_item,
+        separators=(",", ":"),
+    )
+    assert contextual_item["participation_indicators"] == ["authored"]
+    assert contextual_confirmed_item == regular_confirmed_item
+    assert contextual_record == regular_record
+    assert contextual_record is not None
+    assert contextual_record.availability == "unavailable"
+    assert contextual_record.availability_evidence_id == "availability:scale-2950"
+    assert contextual_record.availability_reason == "fixture_unavailable"
+    assert contextual_record.context_only is False
+    assert contextual_context_only is not None
+    assert contextual_context_only.context_only is True
+    assert authority_context.evidence_records["obj:scale-2950"].context_only is False
+
+
+def test_authority_context_is_application_scoped_without_cross_app_projection_drift(
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    database_path, config = scale_state
+    connection = connect_read_only(database_path)
+    try:
+        sample_context = _build_authority_evidence_context(connection, _APP_ID)
+        other_context = _build_authority_evidence_context(connection, "other_app")
+        regular = PacketBuilder(connection, config).candidate_list_item(
+            "other_app",
+            "candidate:other",
+        )
+        contextual = PacketBuilder(
+            connection,
+            config,
+            authority_context=other_context,
+        ).candidate_list_item(
+            "other_app",
+            "candidate:other",
+        )
+        with pytest.raises(ScopeViolation, match="another application"):
+            PacketBuilder(
+                connection,
+                config,
+                authority_context=sample_context,
+            ).candidate_list_item(
+                "other_app",
+                "candidate:other",
+            )
+    finally:
+        connection.close()
+
+    assert "obj:other" not in sample_context.current_observations
+    assert set(other_context.current_observations) == {"obj:other"}
+    assert contextual == regular
 
 
 def test_empty_generation_has_no_token_or_cursor(tmp_path: Path) -> None:
@@ -682,6 +1005,94 @@ def test_page_transaction_keeps_one_snapshot_and_next_page_detects_rebuild(
             candidate_page(read_only, config, _APP_ID, cursor=first.next_cursor)
     finally:
         read_only.close()
+
+
+def test_each_page_rebuilds_context_and_observes_decision_then_undo(
+    tmp_path: Path,
+    scale_state: tuple[Path, WorkTraceConfig],
+) -> None:
+    source, config = scale_state
+    database_path = _copy_database(source, tmp_path / "decision-refresh.sqlite3")
+    token = hashlib.sha256(
+        json.dumps(
+            [_APP_ID, _GENERATED_AT, _GENERATOR_VERSION],
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    cursor = CandidateCursor(token, "candidate:scale-2974")
+
+    read_only = connect_read_only(database_path)
+    first_diagnostics = _PageDiagnostics()
+    try:
+        before = _candidate_page(
+            read_only,
+            config,
+            _APP_ID,
+            cursor=cursor,
+            diagnostics=first_diagnostics,
+        )
+    finally:
+        read_only.close()
+    before_item = next(item for item in before.items if item.candidate_id == "candidate:scale-2975")
+    assert before_item.title == "Candidate 2975"
+
+    writer = connect(database_path)
+    try:
+        rename_id = append_decision(
+            writer,
+            "rename_contribution",
+            "candidate:scale-2975",
+            {"app_id": _APP_ID, "title": "Reviewed 2975"},
+        )
+    finally:
+        writer.close()
+
+    read_only = connect_read_only(database_path)
+    second_diagnostics = _PageDiagnostics()
+    try:
+        renamed = _candidate_page(
+            read_only,
+            config,
+            _APP_ID,
+            cursor=cursor,
+            diagnostics=second_diagnostics,
+        )
+    finally:
+        read_only.close()
+    renamed_item = next(
+        item for item in renamed.items if item.candidate_id == "candidate:scale-2975"
+    )
+    assert renamed.generation_token == before.generation_token
+    assert renamed_item.title == "Reviewed 2975"
+    assert renamed_item.title_authority == "human_decision"
+
+    writer = connect(database_path)
+    try:
+        undo_decision(writer, rename_id)
+    finally:
+        writer.close()
+
+    read_only = connect_read_only(database_path)
+    third_diagnostics = _PageDiagnostics()
+    try:
+        undone = _candidate_page(
+            read_only,
+            config,
+            _APP_ID,
+            cursor=cursor,
+            diagnostics=third_diagnostics,
+        )
+    finally:
+        read_only.close()
+    undone_item = next(item for item in undone.items if item.candidate_id == "candidate:scale-2975")
+    assert undone_item.title == "Candidate 2975"
+    assert undone_item.title_authority == "provider_observed"
+    assert (
+        first_diagnostics.authority_context_builds,
+        second_diagnostics.authority_context_builds,
+        third_diagnostics.authority_context_builds,
+    ) == (1, 1, 1)
 
 
 def test_candidate_scan_query_plan_uses_existing_indexes_without_a_temp_sort(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -87,6 +87,46 @@ def test_read_only_connection_accepts_an_exact_short_busy_timeout(tmp_path: Path
         read_only.close()
 
 
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "ledger ?mode=rw&x=.sqlite3",
+        "ledger#fragment.sqlite3",
+        "ledger with spaces.sqlite3",
+    ),
+)
+def test_read_only_connection_encodes_uri_metacharacters_and_keeps_os_read_only(
+    tmp_path: Path,
+    filename: str,
+) -> None:
+    database_path = tmp_path / filename
+    writer = connect(database_path)
+    try:
+        migrate(writer, database_path)
+    finally:
+        writer.close()
+    entries_before = {path.name for path in tmp_path.iterdir()}
+
+    read_only = connect_read_only(database_path, busy_timeout_ms=500)
+    try:
+        assert read_only.execute("PRAGMA database_list").fetchone()[2] == str(
+            database_path.resolve()
+        )
+        assert read_only.execute("PRAGMA query_only").fetchone()[0] == 1
+
+        read_only.execute("PRAGMA query_only = OFF")
+        assert read_only.execute("PRAGMA query_only").fetchone()[0] == 0
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            read_only.execute(
+                "INSERT INTO apps(id, name, market, business_type) "
+                "VALUES ('blocked', 'Blocked', '', '')"
+            )
+    finally:
+        read_only.close()
+
+    assert {path.name for path in tmp_path.iterdir()} == entries_before
+
+
 def test_read_only_lock_contention_obeys_the_short_timeout(tmp_path: Path) -> None:
     database_path = tmp_path / "worktrace.sqlite3"
     writer = connect(database_path)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import sqlite3
+import time
 from pathlib import Path
 
 import pytest
 
 from worktrace.db.connection import connect, connect_read_only
 from worktrace.db.migrations import migrate, user_version
+from worktrace.db.readiness import DatabaseReadinessStatus, database_readiness
 
 
 def test_init_and_migrations_are_idempotent(tmp_path: Path) -> None:
@@ -57,5 +59,98 @@ def test_read_only_connection_rejects_mutation(tmp_path: Path) -> None:
             read_only.execute(
                 "INSERT INTO apps(id, name, market, business_type) VALUES ('x', 'X', '', '')"
             )
+    finally:
+        read_only.close()
+
+
+def test_read_only_connection_accepts_an_exact_short_busy_timeout(tmp_path: Path) -> None:
+    database_path = tmp_path / "worktrace.sqlite3"
+    writer = connect(database_path)
+    try:
+        migrate(writer, database_path)
+    finally:
+        writer.close()
+
+    read_only = connect_read_only(database_path, busy_timeout_ms=500)
+    try:
+        assert read_only.execute("PRAGMA query_only").fetchone()[0] == 1
+        assert read_only.execute("PRAGMA busy_timeout").fetchone()[0] == 500
+        assert read_only.execute("PRAGMA database_list").fetchone()[2] == str(
+            database_path.resolve()
+        )
+        with pytest.raises(sqlite3.OperationalError, match="readonly"):
+            read_only.execute(
+                "INSERT INTO apps(id, name, market, business_type) "
+                "VALUES ('blocked', 'Blocked', '', '')"
+            )
+    finally:
+        read_only.close()
+
+
+def test_read_only_lock_contention_obeys_the_short_timeout(tmp_path: Path) -> None:
+    database_path = tmp_path / "worktrace.sqlite3"
+    writer = connect(database_path)
+    migrate(writer, database_path)
+    writer.autocommit = True
+    writer.execute("BEGIN EXCLUSIVE")
+    try:
+        read_only = connect_read_only(database_path, busy_timeout_ms=500)
+        started = time.monotonic()
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                read_only.execute("SELECT * FROM apps").fetchall()
+        finally:
+            read_only.close()
+        assert 0.4 <= time.monotonic() - started < 1.5
+    finally:
+        writer.execute("ROLLBACK")
+        writer.close()
+
+
+def test_database_readiness_is_read_only_and_distinguishes_schema_drift(
+    tmp_path: Path,
+) -> None:
+    database_path = tmp_path / "worktrace.sqlite3"
+    writer = connect(database_path)
+    try:
+        migrate(writer, database_path)
+    finally:
+        writer.close()
+
+    read_only = connect_read_only(database_path)
+    try:
+        ready = database_readiness(read_only)
+        assert ready.status is DatabaseReadinessStatus.READY
+        assert ready.current_version == ready.supported_version == 3
+    finally:
+        read_only.close()
+
+    writer = connect(database_path)
+    try:
+        writer.execute("PRAGMA user_version = 2")
+        writer.commit()
+    finally:
+        writer.close()
+    read_only = connect_read_only(database_path)
+    try:
+        older = database_readiness(read_only)
+        assert older.status is DatabaseReadinessStatus.UPGRADE_REQUIRED
+        assert older.current_version == 2
+        assert user_version(read_only) == 2
+    finally:
+        read_only.close()
+
+    writer = connect(database_path)
+    try:
+        writer.execute("PRAGMA user_version = 99")
+        writer.commit()
+    finally:
+        writer.close()
+    read_only = connect_read_only(database_path)
+    try:
+        newer = database_readiness(read_only)
+        assert newer.status is DatabaseReadinessStatus.UNSUPPORTED_NEWER
+        assert newer.current_version == 99
+        assert user_version(read_only) == 99
     finally:
         read_only.close()


### PR DESCRIPTION
## Summary

- add a TUI-only generation token, keyset cursor, and scan-budgeted candidate-page DTO so one human page performs bounded candidate work instead of projecting the full application
- reuse one immutable, transaction-scoped authority, availability, participation, and decision context per page so bounded candidate rows do not repeat application-wide canonical queries
- add configurable read-only SQLite busy timeout and schema-readiness reporting so the future TUI can fail quickly without gaining migration authority
- preserve `PacketBuilder.list_candidates()`, all six MCP tools, and MCP's opaque `offset:` cursor so existing automation and agent contracts remain unchanged
- prove query-plan shape and deterministic 3,000-candidate behavior without adding an index, migration, dependency, or cross-page cache

## Why

The existing candidate list slices only after projecting the complete application. That makes a small human page perform work proportional to the full candidate history. This PR adds a separate read path whose raw scans and projections are fixed by the requested page size while retaining the existing CLI and MCP contracts.

The first bounded implementation still repeated global decision and authoritative-evidence projection for each candidate. The final design constructs one frozen page context from the existing canonical queries inside the page transaction, then threads it through the existing projectors. This keeps default callers unchanged and preserves attribution, availability, unsupported-member, context-only, lineage, and evidence-record semantics.

On the dense 3,000-observation corpus, the corrected default page now measures about 68–80 ms P95 rather than the previously observed 1.44–4.86 seconds. Deterministic SQL tracing proves one authority/availability context, one participation context, and one decision stream per page, with no per-row total-history authority CTE.

## Bounds and compatibility

- default page size: 25
- maximum page size: 50
- batch size: 2x requested size
- scan budget: 4x requested size, capped at 200
- generation token: application ID + active generated timestamp + generator version
- stale generations fail explicitly
- page work uses one short read transaction
- cursor advancement follows the last raw candidate consumed, including skipped candidates
- read-only timeout can be set to exactly 500 ms
- no database migration, index, dependency, MCP, or CLI surface change

## Query and benchmark evidence

The active-generation probes use `idx_candidates_app_time`; the raw keyset query uses the existing candidate primary-key index with `id > after_candidate_id`. The measured plans contain neither a full candidate-table scan nor a temporary sort.

The dense synthetic corpus contains 3,000 current observations and participations, stale and mismatched participation traps, 1,100 active decisions, confirmed unsupported members, availability evidence, context-only conversion, and cross-application data.

- skipped 100-row scan window: median 67.618 ms, P95 70.873 ms
- visible 25-row page: median 66.132 ms, P95 79.594 ms
- canonical authority/availability context: once per page
- canonical participation context: once per page
- decision stream: once per page
- legacy per-candidate authoritative participation query: zero
- per-member authority lookup query: zero

The existing indexes do not combine application and candidate ID, so SQLite may step over other-application IDs internally. The once-per-page contexts still read total current authority, participation, and decision history for the application. Both residual costs are documented and intentionally deferred until representative evidence justifies a new index or narrower canonical query.

## Verification

- `uv run pytest` — 237 passed
- `uv run coverage run -m pytest`
- `uv run coverage report` — 86%
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src`
- `uv build`
- isolated installed-wheel smoke — read-model import, 500 ms query-only connection, readiness, and page-context behavior passed
- `git diff --check`
- GitHub Quality workflow — passed at `3b773b3f03f9591a6590731d1b7121c398a2350e`

Synthetic tests and local timings do not establish live-provider, proprietary-repository, real-terminal, or every multi-application performance characteristic.

## Glossary

| Term | Definition |
|---|---|
| Generation token | Digest binding a cursor to one application's candidate rebuild. |
| Keyset cursor | Cursor that continues strictly after the last raw candidate ID consumed. |
| Scan budget | Maximum raw candidates projected while filling one page. |
| Page context | Immutable canonical authority, participation, and decision data reused only within one read transaction. |
| Short page | A page with fewer visible items and a continuation cursor because skipped rows exhausted its scan budget. |
| Readiness | Read-only comparison of the ledger user version with packaged migrations. |

Closes #10
Refs #6
Refs AgDR-0005
