### PR TITLE
feat(#11): add read-only contribution review TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,21 @@ uv run worktrace gaps candidate:stable-id
 Use `worktrace --help` and each subcommand's `--help` for all commands. Human corrections are
 append-only events; `undo` writes a compensating event rather than deleting history.
 
+## Human review UI
+
+Launch the keyboard-first, read-only evidence workstation in an interactive terminal:
+
+```console
+uv run worktrace ui
+uv run worktrace ui --app sample_store_b2c
+uv run worktrace ui --app sample_store_b2c --candidate candidate:stable-id
+```
+
+The UI reviews source-attempt status, bounded candidate pages, contribution evidence,
+participation, seven independent delivery states, Phase 4 questions and gaps, and bounded source
+excerpts. It does not import evidence, contact providers, write decisions, rebuild data, or perform
+maintenance; those operations remain explicit CLI commands.
+
 ## MCP
 
 `worktrace serve-mcp` exposes exactly six bounded, read-only tools over stdio. See

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -11,10 +11,9 @@ This document records intentional v0.1 boundaries and validation gaps. It must n
 
 ## Read-only human TUI boundary
 
-- The approved first TUI is a review surface only. Until its complete vertical-slice issue is
-  merged, WorkTrace remains operated through the existing CLI and MCP interfaces; a technical
-  design does not itself make `worktrace ui` available.
-- The TUI will not import, confirm, ignore, rename, merge, split, edit membership, add evidence or
+- The first TUI is a review surface only. It complements the existing CLI and MCP interfaces and
+  does not broaden their authority boundaries.
+- The TUI does not import, confirm, ignore, rename, merge, split, edit membership, add evidence or
   attestations, rebuild, migrate, export, back up, purge, edit configuration, contact providers, or
   watch the database.
 - Candidate pages are internally consistent for one short read transaction. Another CLI process
@@ -28,7 +27,7 @@ This document records intentional v0.1 boundaries and validation gaps. It must n
 - Removing screenshot and broad clipboard actions reduces accidental disclosure. It cannot stop an
   authorized local user from taking an operating-system screenshot, selecting terminal text,
   photographing the screen, logging the terminal, or otherwise capturing displayed information.
-- The Textual interface will support keyboard operation, visible focus, text/symbol states,
+- The Textual interface supports keyboard operation, visible focus, text/symbol states,
   `NO_COLOR`, and an 80x24 compact layout, but it does not claim full screen-reader accessibility.
   CLI JSON and MCP remain the structured alternatives.
 - Synthetic headless tests cannot establish behavior across every real terminal emulator,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [{ name = "Amr Mohamad" }]
 dependencies = [
   "httpx>=0.28,<1",
   "mcp>=2,<3",
+  "textual>=8.2.8,<9",
   "typer>=0.16,<1",
 ]
 
@@ -35,6 +36,7 @@ packages = ["src/worktrace"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "migrations" = "worktrace/migrations"
+"src/worktrace/tui/worktrace.tcss" = "worktrace/tui/worktrace.tcss"
 
 [tool.pytest.ini_options]
 addopts = "-ra --strict-config --strict-markers"

--- a/src/worktrace/cli.py
+++ b/src/worktrace/cli.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import sys
 from dataclasses import asdict, dataclass
 from datetime import date
 from pathlib import Path
@@ -58,6 +60,25 @@ app.add_typer(rebuild_app, name="rebuild")
 
 ConfigOption = Annotated[Path | None, typer.Option("--config", exists=True, dir_okay=False)]
 DateArgument = Annotated[str | None, typer.Argument()]
+
+_TUI_ENVIRONMENT_VARIABLES = (
+    "WORKTRACE_JIRA_BASE_URL",
+    "WORKTRACE_JIRA_EMAIL",
+    "WORKTRACE_JIRA_API_TOKEN",
+    "WORKTRACE_GITLAB_BASE_URL",
+    "WORKTRACE_GITLAB_TOKEN",
+    "WORKTRACE_EMAIL_HMAC_KEY",
+    "TEXTUAL",
+    "TEXTUAL_DEBUG",
+    "TEXTUAL_DRIVER",
+    "TEXTUAL_LOG",
+    "TEXTUAL_DEVTOOLS_HOST",
+    "TEXTUAL_DEVTOOLS_PORT",
+    "TEXTUAL_PRESS",
+    "TEXTUAL_SCREENSHOT",
+    "TEXTUAL_SCREENSHOT_LOCATION",
+    "TEXTUAL_SCREENSHOT_FILENAME",
+)
 
 
 def _emit(value: object) -> None:
@@ -240,6 +261,57 @@ def main() -> None:
 def version() -> None:
     """Print the WorkTrace version."""
     typer.echo(__version__)
+
+
+def _sanitize_tui_environment() -> None:
+    for name in _TUI_ENVIRONMENT_VARIABLES:
+        os.environ.pop(name, None)
+
+
+@app.command("ui")
+def launch_ui(
+    app_id: Annotated[str | None, typer.Option("--app")] = None,
+    candidate_id: Annotated[str | None, typer.Option("--candidate")] = None,
+    config: ConfigOption = None,
+) -> None:
+    """Review contribution evidence in an interactive, read-only terminal UI."""
+
+    if candidate_id is not None and app_id is None:
+        typer.echo("error: --candidate requires --app", err=True)
+        raise typer.Exit(2)
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        typer.echo("error: worktrace ui requires an interactive terminal", err=True)
+        typer.echo("Use `worktrace --help` for non-interactive commands.", err=True)
+        raise typer.Exit(2)
+
+    try:
+        configuration = load_config(config)
+        if app_id is not None:
+            configuration.app(app_id)
+        if candidate_id is not None:
+            from worktrace.mcp_server.schemas import stable_id
+
+            stable_id(candidate_id, "candidate_id")
+    except WorkTraceError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        typer.echo("Run `worktrace doctor` from the CLI, then retry.", err=True)
+        raise typer.Exit(1) from exc
+
+    if not configuration.database_path.is_file():
+        typer.echo("error: WorkTrace has not been initialized", err=True)
+        typer.echo("Run `worktrace init`, then `worktrace doctor`.", err=True)
+        raise typer.Exit(1)
+
+    _sanitize_tui_environment()
+
+    from worktrace.read_workspace import ReadOnlyWorkspace
+    from worktrace.tui.app import run_worktrace_ui
+
+    run_worktrace_ui(
+        ReadOnlyWorkspace(configuration),
+        initial_app_id=app_id,
+        initial_candidate_id=candidate_id,
+    )
 
 
 @app.command("init")

--- a/src/worktrace/read_workspace.py
+++ b/src/worktrace/read_workspace.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from worktrace.candidates.projector import project_candidate
+from worktrace.config import WorkTraceConfig
+from worktrace.constants import MAX_EXCERPT_CHARS
+from worktrace.db.connection import connect_read_only
+from worktrace.db.readiness import DatabaseReadinessStatus, database_readiness
+from worktrace.errors import DatabaseError, ScopeViolation
+from worktrace.packets.builder import PacketBuilder
+from worktrace.packets.gaps import build_gap_report
+from worktrace.read_models.candidates import CandidateCursor, CandidatePage, candidate_page
+
+TUI_BUSY_TIMEOUT_MS = 500
+
+
+class DatabaseBusy(DatabaseError):
+    """The ledger could not be read within the TUI contention budget."""
+
+
+class DatabaseUpgradeRequired(DatabaseError):
+    """The ledger is older than the packaged read model."""
+
+
+class DatabaseVersionUnsupported(DatabaseError):
+    """The ledger is newer than the packaged read model."""
+
+
+@dataclass(frozen=True, slots=True)
+class ApplicationSummary:
+    app_id: str
+    name: str
+    market: str
+    business_type: str
+    sources: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class UnsupportedMember:
+    object_id: str
+    source: str
+    kind: str
+    external_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ContributionReview:
+    app_id: str
+    candidate_id: str
+    resolved_contribution_id: str
+    status: str
+    packet: dict[str, object]
+    gaps: dict[str, object]
+    unsupported_members: tuple[UnsupportedMember, ...]
+
+
+class ReadOnlyWorkspace:
+    """Narrow, connection-per-call composition root for the human TUI."""
+
+    def __init__(
+        self,
+        config: WorkTraceConfig,
+        *,
+        busy_timeout_ms: int = TUI_BUSY_TIMEOUT_MS,
+    ) -> None:
+        if busy_timeout_ms < 0:
+            raise ValueError("busy_timeout_ms must be non-negative")
+        self._config = config
+        self._database_path = config.database_path
+        self._busy_timeout_ms = busy_timeout_ms
+
+    @property
+    def database_path(self) -> Path:
+        return self._database_path
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        connection: sqlite3.Connection | None = None
+        try:
+            connection = connect_read_only(
+                self._database_path,
+                busy_timeout_ms=self._busy_timeout_ms,
+            )
+            query_only = connection.execute("PRAGMA query_only").fetchone()
+            if query_only is None or int(query_only[0]) != 1:
+                raise DatabaseError("read-only ledger connection did not enter query-only mode")
+            readiness = database_readiness(connection)
+            if readiness.status is DatabaseReadinessStatus.UPGRADE_REQUIRED:
+                raise DatabaseUpgradeRequired(
+                    "WorkTrace database is older than this version; run `worktrace init` "
+                    "from the CLI, then retry `worktrace ui`."
+                )
+            if readiness.status is DatabaseReadinessStatus.UNSUPPORTED_NEWER:
+                raise DatabaseVersionUnsupported(
+                    "WorkTrace database is newer than this installed version; upgrade "
+                    "WorkTrace before opening the UI."
+                )
+            yield connection
+        except sqlite3.OperationalError as exc:
+            message = str(exc).casefold()
+            if "locked" in message or "busy" in message:
+                raise DatabaseBusy(
+                    "WorkTrace data is busy. Another process may be importing or rebuilding; "
+                    "retry after it finishes."
+                ) from exc
+            raise DatabaseError(
+                "WorkTrace could not read the configured database. Run `worktrace doctor` "
+                "from the CLI and retry."
+            ) from exc
+        finally:
+            if connection is not None:
+                connection.close()
+
+    def applications(self) -> tuple[ApplicationSummary, ...]:
+        with self._connection():
+            return tuple(
+                ApplicationSummary(
+                    app_id=app.id,
+                    name=app.name,
+                    market=app.market,
+                    business_type=app.business_type,
+                    sources=tuple(
+                        source
+                        for source, enabled in (
+                            ("git", bool(app.repo_paths)),
+                            ("jira", bool(app.jira_project_keys)),
+                            ("gitlab", bool(app.gitlab_project_ids)),
+                        )
+                        if enabled
+                    ),
+                )
+                for app in self._config.apps
+            )
+
+    def source_status(self, app_id: str) -> dict[str, object]:
+        self._config.app(app_id)
+        with self._connection() as connection:
+            return PacketBuilder(connection, self._config).source_status(app_id)
+
+    def candidate_page(
+        self,
+        app_id: str,
+        *,
+        page_size: int = 25,
+        cursor: CandidateCursor | None = None,
+    ) -> CandidatePage:
+        self._config.app(app_id)
+        with self._connection() as connection:
+            return candidate_page(
+                connection,
+                self._config,
+                app_id,
+                page_size=page_size,
+                cursor=cursor,
+            )
+
+    def contribution_review(self, app_id: str, candidate_id: str) -> ContributionReview:
+        self._config.app(app_id)
+        with self._connection() as connection:
+            projected = project_candidate(connection, candidate_id)
+            if projected.app_id != app_id:
+                raise ScopeViolation("candidate belongs to another application")
+            packet = PacketBuilder(connection, self._config).build_packet(candidate_id)
+            contribution = packet.get("contribution")
+            if not isinstance(contribution, dict) or contribution.get("app_id") != app_id:
+                raise ScopeViolation("candidate belongs to another application")
+            contribution_id = contribution.get("id")
+            if not isinstance(contribution_id, str) or not contribution_id:
+                raise DatabaseError("contribution packet is missing its stable ID")
+            evidence_summary = packet.get("evidence_summary")
+            raw_unsupported = (
+                evidence_summary.get("unsupported_member_ids", [])
+                if isinstance(evidence_summary, dict)
+                else []
+            )
+            unsupported_ids = tuple(
+                value for value in raw_unsupported if isinstance(value, str) and value
+            )
+            unsupported: tuple[UnsupportedMember, ...] = ()
+            if unsupported_ids:
+                placeholders = ",".join("?" for _ in unsupported_ids)
+                rows = connection.execute(
+                    f"""
+                    SELECT id, source, kind, external_id
+                    FROM source_objects
+                    WHERE app_id=? AND id IN ({placeholders})
+                    ORDER BY id
+                    """,
+                    (app_id, *unsupported_ids),
+                )
+                unsupported = tuple(
+                    UnsupportedMember(
+                        object_id=str(row["id"]),
+                        source=str(row["source"]),
+                        kind=str(row["kind"]),
+                        external_id=str(row["external_id"]),
+                    )
+                    for row in rows
+                )
+            return ContributionReview(
+                app_id=app_id,
+                candidate_id=candidate_id,
+                resolved_contribution_id=contribution_id,
+                status=projected.status,
+                packet=packet,
+                gaps=build_gap_report(packet),
+                unsupported_members=unsupported,
+            )
+
+    def evidence_excerpt(
+        self,
+        app_id: str,
+        evidence_id: str,
+        *,
+        max_chars: int,
+    ) -> dict[str, object]:
+        if not 1 <= max_chars <= MAX_EXCERPT_CHARS:
+            raise ValueError(f"max_chars must be between 1 and {MAX_EXCERPT_CHARS}")
+        self._config.app(app_id)
+        with self._connection() as connection:
+            excerpt = PacketBuilder(connection, self._config).evidence_excerpt(
+                evidence_id,
+                max_chars,
+            )
+            if excerpt.get("app_id") != app_id:
+                raise ScopeViolation("evidence belongs to another application")
+            return excerpt

--- a/src/worktrace/tui/__init__.py
+++ b/src/worktrace/tui/__init__.py
@@ -1,0 +1,1 @@
+"""Read-only Textual contribution-review interface."""

--- a/src/worktrace/tui/app.py
+++ b/src/worktrace/tui/app.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import ClassVar
+
+from textual import work
+from textual.app import App, ComposeResult, SystemCommand
+from textual.binding import Binding, BindingType
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Footer, Static
+
+from worktrace.mcp_server.schemas import stable_id
+from worktrace.read_workspace import ApplicationSummary, ReadOnlyWorkspace
+from worktrace.tui.messages import ApplicationsLoaded, FailureKind, ReadFailed, failure_kind
+from worktrace.tui.screens.applications import ApplicationScreen
+from worktrace.tui.screens.base import WorkTraceModal, WorkTraceScreen
+from worktrace.tui.screens.candidates import CandidateScreen
+
+_HELP_TEXT = """WorkTrace read-only review
+
+?       Help
+Ctrl+P  Safe command palette
+Tab     Move focus between panels
+a       Switch application
+r       Refresh current data
+q/Esc   Back, or quit from candidates
+Ctrl+Q  Quit
+y       Copy the selected validated WorkTrace ID
+j/k     Move selection
+Arrows  Scroll focused details
+Enter   Open
+n/p     Next/previous candidate page
+1-5     Contribution tabs
+
+The UI cannot import, modify, rebuild, export, or contact providers.
+"""
+
+_INITIAL_FAILURE_TEXT = {
+    FailureKind.BUSY: (
+        "WorkTrace data is busy. Another process may be importing or rebuilding.\n\n"
+        "Next: wait for it to finish, then press r to retry."
+    ),
+    FailureKind.UPGRADE_REQUIRED: (
+        "The database is older than this WorkTrace version.\n\n"
+        "Next: exit and run `worktrace init`, then retry."
+    ),
+    FailureKind.UNSUPPORTED_NEWER: (
+        "The database is newer than this WorkTrace version.\n\nNext: upgrade WorkTrace, then retry."
+    ),
+    FailureKind.DATABASE: (
+        "WorkTrace could not read the configured database.\n\n"
+        "Next: exit and run `worktrace doctor`."
+    ),
+    FailureKind.NOT_FOUND: "The requested review record is unavailable. Press r to restart.",
+    FailureKind.OUT_OF_SCOPE: (
+        "The requested review record is outside the configured application.\n\n"
+        "Next: press a to select a configured application or q to quit."
+    ),
+    FailureKind.GENERATION_CHANGED: "Candidate suggestions changed. Press r to restart.",
+    FailureKind.UNEXPECTED: (
+        "WorkTrace could not complete the read. No data was changed.\n\n"
+        "Next: press r to retry or q to quit."
+    ),
+}
+
+
+class LoadingScreen(WorkTraceScreen):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [Binding("q,escape", "app.quit", "Quit")]
+
+    def compose(self) -> ComposeResult:
+        yield Static("Loading WorkTrace read-only data…", classes="loading", markup=False)
+        yield Footer()
+
+
+class InitialErrorScreen(WorkTraceScreen):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("r", "app.restart", "Retry"),
+        Binding("a", "app.switch_application", "Switch app"),
+        Binding("q,escape", "app.quit", "Quit"),
+    ]
+
+    def __init__(self, kind: FailureKind) -> None:
+        super().__init__()
+        self._kind = kind
+
+    def compose(self) -> ComposeResult:
+        yield Static("WorkTrace", classes="page-title", markup=False)
+        yield Static(_INITIAL_FAILURE_TEXT[self._kind], classes="error", markup=False)
+        yield Footer()
+
+
+class HelpModal(WorkTraceModal):
+    ALLOW_SELECT = False
+
+    def compose(self) -> ComposeResult:
+        yield Static(_HELP_TEXT, id="help-dialog", markup=False)
+
+
+class SmallTerminalScreen(ModalScreen[bool], inherit_bindings=False):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("c", "continue_compact", "Continue compact"),
+        Binding("r", "recheck", "Recheck"),
+        Binding("q,escape", "quit", "Quit"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Terminal size is limited\n\n"
+            "Recommended minimum: 80 columns x 24 rows\n\n"
+            "c  Continue in compact mode\n"
+            "r  Recheck size\n"
+            "q  Quit",
+            id="terminal-dialog",
+            markup=False,
+        )
+
+    def action_copy_text(self) -> None:
+        """Disable Textual's inherited selected-text clipboard path."""
+
+    def action_continue_compact(self) -> None:
+        self.dismiss(True)
+
+    def action_recheck(self) -> None:
+        if self.app.size.width >= 80 and self.app.size.height >= 24:
+            self.dismiss(True)
+
+    def action_quit(self) -> None:
+        self.app.exit()
+
+
+class WorkTraceApp(App[None], inherit_bindings=False):
+    CSS_PATH = Path(__file__).with_name("worktrace.tcss")
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("ctrl+p", "command_palette", "Commands"),
+        Binding("ctrl+q", "quit", "Quit"),
+        Binding("y", "copy_selected_id", "Copy ID", show=False),
+    ]
+
+    def __init__(
+        self,
+        workspace: ReadOnlyWorkspace,
+        *,
+        initial_app_id: str | None = None,
+        initial_candidate_id: str | None = None,
+    ) -> None:
+        super().__init__()
+        self.workspace = workspace
+        self.initial_app_id = initial_app_id
+        self.initial_candidate_id = initial_candidate_id
+        self._applications: tuple[ApplicationSummary, ...] = ()
+        self._applications_request_id = 0
+        self.current_app_id: str | None = None
+        self.compact_mode = False
+
+    def on_mount(self) -> None:
+        if self.size.width < 80 or self.size.height < 24:
+            self.push_screen(SmallTerminalScreen(), self._after_terminal_check)
+        else:
+            self.action_restart()
+
+    def _after_terminal_check(self, proceed: bool | None) -> None:
+        if proceed:
+            self.compact_mode = self.size.width < 80 or self.size.height < 24
+            self.action_restart()
+
+    def get_system_commands(self, screen: Screen[object]) -> Iterable[SystemCommand]:
+        yield SystemCommand("Quit", "Quit WorkTrace", self.action_quit)
+        yield SystemCommand("Keyboard help", "Show safe keyboard commands", self.action_show_help)
+        yield SystemCommand(
+            "Switch application",
+            "Select another configured application",
+            self.action_switch_application,
+        )
+        yield SystemCommand("Refresh", "Refresh the current read-only view", self.action_refresh)
+        if isinstance(screen, (CandidateScreen,)) is False and self.current_app_id is not None:
+            yield SystemCommand(
+                "Return to candidates",
+                "Return to the selected application's candidate page",
+                self.action_return_to_candidates,
+            )
+
+    def action_copy_text(self) -> None:
+        """No selected-text clipboard path exists in WorkTrace."""
+
+    def action_restart(self) -> None:
+        self._applications_request_id += 1
+        request_id = self._applications_request_id
+        self._show_screen(LoadingScreen())
+        self.load_applications(request_id)
+
+    def _show_screen(self, screen: Screen[None]) -> None:
+        if self.screen.id == "_default":
+            self.push_screen(screen)
+        else:
+            self.switch_screen(screen)
+
+    def action_show_help(self) -> None:
+        self.push_screen(HelpModal())
+
+    def action_switch_application(self) -> None:
+        self.show_applications()
+
+    def action_refresh(self) -> None:
+        refresh = getattr(self.screen, "refresh_data", None)
+        if callable(refresh):
+            refresh()
+        else:
+            self.action_restart()
+
+    def action_return_to_candidates(self) -> None:
+        if self.current_app_id is not None:
+            self.open_application(self.current_app_id)
+
+    def action_copy_selected_id(self) -> None:
+        selected = getattr(self.screen, "selected_stable_id", lambda: None)()
+        if selected is None:
+            self.notify("No stable WorkTrace ID is selected.", markup=False)
+            return
+        value, allowed_prefixes = selected
+        prefix = value.partition(":")[0]
+        if prefix not in allowed_prefixes:
+            self.notify("The selected value is not an allowed WorkTrace ID.", markup=False)
+            return
+        try:
+            stable_id(value, "selected_id")
+        except Exception:
+            self.notify("The selected value is not a valid WorkTrace ID.", markup=False)
+            return
+        self.copy_to_clipboard(value)
+        self.notify("Stable WorkTrace ID copied.", markup=False)
+
+    @work(thread=True, exclusive=True, group="applications", exit_on_error=False)
+    def load_applications(self, request_id: int) -> None:
+        try:
+            applications = self.workspace.applications()
+        except Exception as error:
+            self.post_message(ReadFailed("applications", request_id, failure_kind(error)))
+        else:
+            self.post_message(ApplicationsLoaded(request_id, applications))
+
+    def on_applications_loaded(self, message: ApplicationsLoaded) -> None:
+        if message.request_id != self._applications_request_id:
+            return
+        self._applications = message.applications
+        if not self._applications:
+            self._show_screen(InitialErrorScreen(FailureKind.NOT_FOUND))
+            return
+        available = {application.app_id for application in self._applications}
+        if self.initial_app_id is not None:
+            if self.initial_app_id not in available:
+                self._show_screen(InitialErrorScreen(FailureKind.OUT_OF_SCOPE))
+                return
+            initial_app_id = self.initial_app_id
+            initial_candidate_id = self.initial_candidate_id
+            self.initial_app_id = None
+            self.initial_candidate_id = None
+            if initial_candidate_id is not None:
+                self.current_app_id = initial_app_id
+                self.open_contribution(
+                    initial_app_id,
+                    initial_candidate_id,
+                    return_to_existing=False,
+                )
+            else:
+                self.open_application(initial_app_id)
+            return
+        if len(self._applications) == 1:
+            self.open_application(self._applications[0].app_id)
+        else:
+            self.show_applications()
+
+    def on_read_failed(self, message: ReadFailed) -> None:
+        if (
+            message.operation != "applications"
+            or message.request_id != self._applications_request_id
+        ):
+            return
+        self._show_screen(InitialErrorScreen(message.kind))
+
+    def show_applications(self) -> None:
+        if not self._applications:
+            self.action_restart()
+            return
+        self._show_screen(ApplicationScreen(self._applications))
+
+    def _application(self, app_id: str) -> ApplicationSummary | None:
+        return next(
+            (application for application in self._applications if application.app_id == app_id),
+            None,
+        )
+
+    def open_application(self, app_id: str) -> None:
+        application = self._application(app_id)
+        if application is None:
+            self._show_screen(InitialErrorScreen(FailureKind.OUT_OF_SCOPE))
+            return
+        self.current_app_id = app_id
+        self._show_screen(CandidateScreen(application))
+
+    def open_contribution(
+        self,
+        app_id: str,
+        candidate_id: str,
+        *,
+        return_to_existing: bool,
+    ) -> None:
+        from worktrace.tui.screens.contribution import ContributionScreen
+
+        self.current_app_id = app_id
+        screen = ContributionScreen(
+            app_id,
+            candidate_id,
+            return_to_existing=return_to_existing,
+        )
+        if return_to_existing:
+            self.push_screen(screen)
+        else:
+            self._show_screen(screen)
+
+
+def run_worktrace_ui(
+    workspace: ReadOnlyWorkspace,
+    *,
+    initial_app_id: str | None = None,
+    initial_candidate_id: str | None = None,
+) -> None:
+    WorkTraceApp(
+        workspace,
+        initial_app_id=initial_app_id,
+        initial_candidate_id=initial_candidate_id,
+    ).run()

--- a/src/worktrace/tui/app.py
+++ b/src/worktrace/tui/app.py
@@ -7,6 +7,7 @@ from typing import ClassVar
 from textual import work
 from textual.app import App, ComposeResult, SystemCommand
 from textual.binding import Binding, BindingType
+from textual.containers import VerticalScroll
 from textual.screen import ModalScreen, Screen
 from textual.widgets import Footer, Static
 
@@ -94,9 +95,16 @@ class InitialErrorScreen(WorkTraceScreen):
 
 class HelpModal(WorkTraceModal):
     ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("q,escape", "dismiss", "Close"),
+    ]
 
     def compose(self) -> ComposeResult:
-        yield Static(_HELP_TEXT, id="help-dialog", markup=False)
+        with VerticalScroll(id="help-dialog", can_focus=True):
+            yield Static(_HELP_TEXT, id="help-content", markup=False)
+
+    def on_mount(self) -> None:
+        self.query_one("#help-dialog", VerticalScroll).focus()
 
 
 class SmallTerminalScreen(ModalScreen[bool], inherit_bindings=False):

--- a/src/worktrace/tui/messages.py
+++ b/src/worktrace/tui/messages.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from textual.message import Message
+
+from worktrace.errors import DatabaseError, NotFound, ScopeViolation
+from worktrace.read_models.candidates import CandidateGenerationChanged, CandidatePage
+from worktrace.read_workspace import (
+    ApplicationSummary,
+    ContributionReview,
+    DatabaseBusy,
+    DatabaseUpgradeRequired,
+    DatabaseVersionUnsupported,
+)
+
+
+class FailureKind(StrEnum):
+    BUSY = "busy"
+    GENERATION_CHANGED = "generation_changed"
+    NOT_FOUND = "not_found"
+    OUT_OF_SCOPE = "out_of_scope"
+    UPGRADE_REQUIRED = "upgrade_required"
+    UNSUPPORTED_NEWER = "unsupported_newer"
+    DATABASE = "database"
+    UNEXPECTED = "unexpected"
+
+
+def failure_kind(error: Exception) -> FailureKind:
+    if isinstance(error, DatabaseBusy):
+        return FailureKind.BUSY
+    if isinstance(error, CandidateGenerationChanged):
+        return FailureKind.GENERATION_CHANGED
+    if isinstance(error, NotFound):
+        return FailureKind.NOT_FOUND
+    if isinstance(error, ScopeViolation):
+        return FailureKind.OUT_OF_SCOPE
+    if isinstance(error, DatabaseUpgradeRequired):
+        return FailureKind.UPGRADE_REQUIRED
+    if isinstance(error, DatabaseVersionUnsupported):
+        return FailureKind.UNSUPPORTED_NEWER
+    if isinstance(error, DatabaseError):
+        return FailureKind.DATABASE
+    return FailureKind.UNEXPECTED
+
+
+class ApplicationsLoaded(Message):
+    def __init__(self, request_id: int, applications: tuple[ApplicationSummary, ...]) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.applications = applications
+
+
+class SourceStatusLoaded(Message):
+    def __init__(self, request_id: int, status: dict[str, object]) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.status = status
+
+
+class CandidatePageLoaded(Message):
+    def __init__(self, request_id: int, page: CandidatePage) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.page = page
+
+
+class ContributionReviewLoaded(Message):
+    def __init__(self, request_id: int, review: ContributionReview) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.review = review
+
+
+class EvidenceExcerptLoaded(Message):
+    def __init__(self, request_id: int, excerpt: dict[str, object]) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.excerpt = excerpt
+
+
+class ReadFailed(Message):
+    def __init__(self, operation: str, request_id: int, kind: FailureKind) -> None:
+        super().__init__()
+        self.operation = operation
+        self.request_id = request_id
+        self.kind = kind

--- a/src/worktrace/tui/modals/__init__.py
+++ b/src/worktrace/tui/modals/__init__.py
@@ -1,0 +1,1 @@
+"""WorkTrace TUI modals."""

--- a/src/worktrace/tui/modals/evidence.py
+++ b/src/worktrace/tui/modals/evidence.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import VerticalScroll
+from textual.widgets import Static
+
+from worktrace.tui.screens.base import WorkTraceModal
+from worktrace.tui.terminal_text import literal_dynamic_text, terminal_safe_text
+
+_EVIDENCE_PREFIXES = frozenset(
+    {"obs", "participation", "part", "availability", "decision", "ref", "reference"}
+)
+
+
+def _append_field(output: Text, label: str, value: object) -> None:
+    output.append(f"{label}: ")
+    output.append_text(literal_dynamic_text(value))
+    output.append("\n")
+
+
+class EvidenceModal(WorkTraceModal):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("y", "app.copy_selected_id", "Copy evidence ID"),
+        Binding("q,escape", "dismiss", "Close"),
+    ]
+
+    def __init__(self, excerpt: dict[str, object]) -> None:
+        super().__init__()
+        self._excerpt = excerpt
+        evidence_id = excerpt.get("evidence_id")
+        self._evidence_id = evidence_id if isinstance(evidence_id, str) else None
+
+    def compose(self) -> ComposeResult:
+        meta = Text("UNTRUSTED SOURCE TEXT\n\n")
+        _append_field(meta, "Source", self._excerpt.get("source", "unknown"))
+        _append_field(meta, "Kind", self._excerpt.get("kind", "unknown"))
+        _append_field(meta, "Evidence ID", self._excerpt.get("evidence_id", "unknown"))
+        _append_field(meta, "Observed", self._excerpt.get("as_of", "not recorded"))
+        _append_field(meta, "Completeness", self._excerpt.get("completeness", "unknown"))
+        _append_field(
+            meta,
+            "Source excerpt truncated",
+            "yes" if self._excerpt.get("truncated") is True else "no",
+        )
+
+        raw_text = self._excerpt.get("text")
+        if raw_text is None:
+            raw_text = (
+                self._excerpt.get("reason") or "No textual body is available for this evidence."
+            )
+        encoded = terminal_safe_text(str(raw_text), max_output_chars=20_000)
+        _append_field(meta, "Terminal presentation truncated", "yes" if encoded.truncated else "no")
+        _append_field(meta, "Encoded terminal controls", encoded.encoded_control_count)
+
+        with VerticalScroll(id="evidence-dialog", classes="excerpt-scroll"):
+            yield Static(meta, markup=False)
+            yield Static(Text(encoded.text), id="evidence-body", markup=False)
+            yield Static("\ny  Copy evidence ID    Esc  Close", markup=False)
+
+    def selected_stable_id(self) -> tuple[str, frozenset[str]] | None:
+        if self._evidence_id is None:
+            return None
+        return self._evidence_id, _EVIDENCE_PREFIXES

--- a/src/worktrace/tui/screens/__init__.py
+++ b/src/worktrace/tui/screens/__init__.py
@@ -1,0 +1,1 @@
+"""WorkTrace TUI screens."""

--- a/src/worktrace/tui/screens/applications.py
+++ b/src/worktrace/tui/screens/applications.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, cast
+
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.widgets import DataTable, Footer, Static
+
+from worktrace.read_workspace import ApplicationSummary
+from worktrace.tui.screens.base import WorkTraceScreen
+from worktrace.tui.terminal_text import literal_dynamic_text
+
+if TYPE_CHECKING:
+    from worktrace.tui.app import WorkTraceApp
+
+
+class ApplicationScreen(WorkTraceScreen):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("j", "cursor_down", "Next"),
+        Binding("k", "cursor_up", "Previous"),
+        Binding("q,escape", "app.quit", "Quit"),
+    ]
+
+    def __init__(self, applications: tuple[ApplicationSummary, ...]) -> None:
+        super().__init__()
+        self._applications = applications
+
+    def compose(self) -> ComposeResult:
+        yield Static("Select an application", classes="page-title", markup=False)
+        yield DataTable(id="applications-table", cursor_type="row", zebra_stripes=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        table = self.query_one("#applications-table", DataTable)
+        table.add_columns("Application", "Market", "Type", "Sources")
+        for index, application in enumerate(self._applications):
+            table.add_row(
+                literal_dynamic_text(application.name),
+                literal_dynamic_text(application.market or "Unknown"),
+                literal_dynamic_text(application.business_type or "Unknown"),
+                literal_dynamic_text(", ".join(application.sources) or "None"),
+                key=f"application-row-{index}",
+            )
+        if self._applications:
+            table.focus()
+
+    def action_cursor_down(self) -> None:
+        self.query_one("#applications-table", DataTable).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        self.query_one("#applications-table", DataTable).action_cursor_up()
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        index = event.cursor_row
+        if 0 <= index < len(self._applications):
+            cast("WorkTraceApp", self.app).open_application(self._applications[index].app_id)

--- a/src/worktrace/tui/screens/base.py
+++ b/src/worktrace/tui/screens/base.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import ClassVar
+
+from textual.binding import Binding, BindingType
+from textual.screen import ModalScreen, Screen
+
+
+class WorkTraceScreen(Screen[None], inherit_bindings=False):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("tab", "app.focus_next", "Next focus", show=False),
+        Binding("shift+tab", "app.focus_previous", "Previous focus", show=False),
+        Binding("?", "app.show_help", "Help"),
+    ]
+
+    def action_copy_text(self) -> None:
+        """Disable Textual's inherited selected-text clipboard path."""
+
+    def selected_stable_id(self) -> tuple[str, frozenset[str]] | None:
+        return None
+
+
+class WorkTraceModal(ModalScreen[None], inherit_bindings=False):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("escape", "dismiss", "Close"),
+        Binding("tab", "app.focus_next", "Next focus", show=False),
+        Binding("shift+tab", "app.focus_previous", "Previous focus", show=False),
+    ]
+
+    def action_copy_text(self) -> None:
+        """Disable Textual's inherited selected-text clipboard path."""
+
+    def selected_stable_id(self) -> tuple[str, frozenset[str]] | None:
+        return None

--- a/src/worktrace/tui/screens/candidates.py
+++ b/src/worktrace/tui/screens/candidates.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, ClassVar, cast
+
+from rich.text import Text
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import VerticalScroll
+from textual.widgets import DataTable, Footer, Static
+
+from worktrace.read_models.candidates import CandidateCursor, CandidateListItem, CandidatePage
+from worktrace.read_workspace import ApplicationSummary
+from worktrace.tui.messages import (
+    CandidatePageLoaded,
+    FailureKind,
+    ReadFailed,
+    SourceStatusLoaded,
+    failure_kind,
+)
+from worktrace.tui.screens.base import WorkTraceScreen
+from worktrace.tui.terminal_text import literal_dynamic_text
+
+if TYPE_CHECKING:
+    from worktrace.tui.app import WorkTraceApp
+
+
+_FAILURE_TEXT = {
+    FailureKind.BUSY: (
+        "WorkTrace data is busy. Another process may be importing or rebuilding. Press r to retry."
+    ),
+    FailureKind.GENERATION_CHANGED: (
+        "Candidate suggestions changed while this page was open. Restarting at page one."
+    ),
+    FailureKind.UPGRADE_REQUIRED: (
+        "The database is older than this WorkTrace version. Exit and run `worktrace init`."
+    ),
+    FailureKind.UNSUPPORTED_NEWER: (
+        "The database is newer than this WorkTrace version. Upgrade WorkTrace before retrying."
+    ),
+    FailureKind.NOT_FOUND: "The requested candidate is no longer available. Press r to refresh.",
+    FailureKind.OUT_OF_SCOPE: (
+        "The requested data is outside the selected application. Press a to switch application."
+    ),
+    FailureKind.DATABASE: "WorkTrace could not read the database. Run `worktrace doctor`.",
+    FailureKind.UNEXPECTED: "WorkTrace could not complete this read. Press r to retry.",
+}
+
+
+def _append_dynamic(target: Text, value: object) -> None:
+    target.append_text(literal_dynamic_text(value))
+
+
+def _source_status_text(status: dict[str, object]) -> Text:
+    output = Text("Latest source attempts\n")
+    if not status:
+        output.append("No source attempts are recorded.\n")
+        output.append("Next: run an import from the WorkTrace CLI.")
+        return output
+    for source, raw_group in status.items():
+        _append_dynamic(output, source)
+        output.append("\n")
+        group = raw_group if isinstance(raw_group, dict) else {}
+        instances = group.get("instances", [])
+        if not isinstance(instances, list) or not instances:
+            output.append("  status: unavailable | authoritative current: no\n")
+            output.append("  Next: inspect this source with `worktrace status`.\n")
+            continue
+        for raw_instance in instances:
+            instance = raw_instance if isinstance(raw_instance, dict) else {}
+            output.append("  ")
+            _append_dynamic(output, instance.get("source_instance", "unknown"))
+            output.append(" | status: ")
+            _append_dynamic(output, instance.get("status", "unknown"))
+            output.append(" | completeness: ")
+            _append_dynamic(output, instance.get("completeness", "unknown"))
+            output.append(" | completed: ")
+            _append_dynamic(output, instance.get("completed_at") or "not recorded")
+            output.append(" | stale: ")
+            _append_dynamic(output, "yes" if instance.get("stale") is True else "no")
+            output.append(" | authoritative current: ")
+            _append_dynamic(
+                output,
+                "yes" if instance.get("authoritative_current") is True else "no",
+            )
+            output.append("\n")
+            error = instance.get("error_summary")
+            if error:
+                output.append("    error: ")
+                _append_dynamic(output, error)
+                output.append("\n")
+            limitations = instance.get("limitations", [])
+            if isinstance(limitations, list):
+                for limitation in limitations:
+                    output.append("    limitation: ")
+                    _append_dynamic(output, limitation)
+                    output.append("\n")
+    return output
+
+
+class CandidateScreen(WorkTraceScreen):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("j", "cursor_down", "Next"),
+        Binding("k", "cursor_up", "Previous"),
+        Binding("n", "next_page", "Next page"),
+        Binding("p", "previous_page", "Previous page"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("a", "app.switch_application", "Switch app"),
+        Binding("y", "app.copy_selected_id", "Copy ID"),
+        Binding("q,escape", "app.quit", "Quit"),
+    ]
+
+    def __init__(self, application: ApplicationSummary) -> None:
+        super().__init__()
+        self.application = application
+        self._source_request_id = 0
+        self._page_request_id = 0
+        self._cursor_stack: list[CandidateCursor | None] = [None]
+        self._page: CandidatePage | None = None
+        self._items: tuple[CandidateListItem, ...] = ()
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="candidate-title", classes="page-title", markup=False)
+        with VerticalScroll(id="source-status-scroll", can_focus=True):
+            yield Static(id="source-status", markup=False)
+        yield Static(
+            "Candidate groups are deterministic review suggestions, not ownership claims.",
+            classes="notice",
+            markup=False,
+        )
+        yield Static("Loading candidate page…", id="candidate-message", markup=False)
+        yield DataTable(id="candidate-table", cursor_type="row", zebra_stripes=True)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        title = Text("WorkTrace / ")
+        _append_dynamic(title, self.application.name)
+        self.query_one("#candidate-title", Static).update(title)
+        table = self.query_one("#candidate-table", DataTable)
+        if cast("WorkTraceApp", self.app).compact_mode:
+            self.add_class("compact")
+            table.add_columns("State", "Contribution", "Period", "Sources")
+        else:
+            table.add_columns("State", "Contribution", "Authority", "Period", "Sources", "Roles")
+        table.focus()
+        self._load_source_status()
+        self._load_current_page()
+
+    def refresh_data(self) -> None:
+        self.action_refresh()
+
+    def action_refresh(self) -> None:
+        self._cursor_stack = [None]
+        self._page = None
+        self.query_one("#candidate-message", Static).update("Refreshing read-only data…")
+        self._load_source_status()
+        self._load_current_page()
+
+    def action_cursor_down(self) -> None:
+        focused = self.focused
+        if isinstance(focused, VerticalScroll):
+            focused.action_scroll_down()
+        else:
+            self.query_one("#candidate-table", DataTable).action_cursor_down()
+
+    def action_cursor_up(self) -> None:
+        focused = self.focused
+        if isinstance(focused, VerticalScroll):
+            focused.action_scroll_up()
+        else:
+            self.query_one("#candidate-table", DataTable).action_cursor_up()
+
+    def action_next_page(self) -> None:
+        if self._page is None or self._page.next_cursor is None:
+            self.app.notify("No later candidate page is available.", markup=False)
+            return
+        self._cursor_stack.append(self._page.next_cursor)
+        self._load_current_page()
+
+    def action_previous_page(self) -> None:
+        if len(self._cursor_stack) == 1:
+            self.app.notify("Already on the first candidate page.", markup=False)
+            return
+        self._cursor_stack.pop()
+        self._load_current_page()
+
+    def selected_stable_id(self) -> tuple[str, frozenset[str]] | None:
+        table = self.query_one("#candidate-table", DataTable)
+        if 0 <= table.cursor_row < len(self._items):
+            return self._items[table.cursor_row].candidate_id, frozenset({"candidate"})
+        return None
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        if event.data_table.id != "candidate-table":
+            return
+        if 0 <= event.cursor_row < len(self._items):
+            item = self._items[event.cursor_row]
+            cast("WorkTraceApp", self.app).open_contribution(
+                self.application.app_id,
+                item.candidate_id,
+                return_to_existing=True,
+            )
+
+    def _load_current_page(self) -> None:
+        self._page_request_id += 1
+        request_id = self._page_request_id
+        self.query_one("#candidate-message", Static).update("Loading candidate page…")
+        self.load_candidate_page(request_id, self._cursor_stack[-1])
+
+    def _load_source_status(self) -> None:
+        self._source_request_id += 1
+        self.load_source_status(self._source_request_id)
+
+    @work(thread=True, exclusive=True, group="candidate-page", exit_on_error=False)
+    def load_candidate_page(
+        self,
+        request_id: int,
+        cursor: CandidateCursor | None,
+    ) -> None:
+        try:
+            page = cast("WorkTraceApp", self.app).workspace.candidate_page(
+                self.application.app_id,
+                cursor=cursor,
+            )
+        except Exception as error:
+            self.post_message(ReadFailed("candidate_page", request_id, failure_kind(error)))
+        else:
+            self.post_message(CandidatePageLoaded(request_id, page))
+
+    @work(thread=True, exclusive=True, group="source-status", exit_on_error=False)
+    def load_source_status(self, request_id: int) -> None:
+        try:
+            status = cast("WorkTraceApp", self.app).workspace.source_status(self.application.app_id)
+        except Exception as error:
+            self.post_message(ReadFailed("source_status", request_id, failure_kind(error)))
+        else:
+            self.post_message(SourceStatusLoaded(request_id, status))
+
+    def on_source_status_loaded(self, message: SourceStatusLoaded) -> None:
+        if message.request_id != self._source_request_id:
+            return
+        self.query_one("#source-status", Static).update(_source_status_text(message.status))
+
+    def on_candidate_page_loaded(self, message: CandidatePageLoaded) -> None:
+        if message.request_id != self._page_request_id:
+            return
+        self._page = message.page
+        self._items = message.page.items
+        table = self.query_one("#candidate-table", DataTable)
+        table.clear()
+        for index, item in enumerate(self._items):
+            title = item.title or "Untitled candidate"
+            period = item.period_from or "Unknown"
+            if item.period_to and item.period_to != item.period_from:
+                period = f"{period} → {item.period_to}"
+            cells = [
+                literal_dynamic_text(item.status),
+                literal_dynamic_text(title),
+            ]
+            if not cast("WorkTraceApp", self.app).compact_mode:
+                cells.append(literal_dynamic_text(item.title_authority))
+            cells.extend(
+                (
+                    literal_dynamic_text(period),
+                    literal_dynamic_text(" ".join(item.source_coverage) or "None"),
+                )
+            )
+            if not cast("WorkTraceApp", self.app).compact_mode:
+                cells.append(
+                    literal_dynamic_text(" ".join(item.participation_indicators) or "None")
+                )
+            table.add_row(*cells, key=f"candidate-row-{index}")
+        if not self._items:
+            if message.page.next_cursor is not None:
+                state = "No visible candidates in this bounded scan. Press n to continue."
+            else:
+                state = (
+                    "No current contribution candidates. Use `worktrace status` and "
+                    "`worktrace rebuild candidates APP_ID` from the CLI."
+                )
+        else:
+            state = f"Page {len(self._cursor_stack)} · {len(self._items)} candidates"
+            if message.page.next_cursor is not None and len(self._items) < 25:
+                state += " · hidden or unavailable candidates were skipped; press n to continue"
+        self.query_one("#candidate-message", Static).update(state)
+
+    def on_read_failed(self, message: ReadFailed) -> None:
+        if message.operation == "source_status":
+            if message.request_id != self._source_request_id:
+                return
+            self.query_one("#source-status", Static).update(_FAILURE_TEXT[message.kind])
+            return
+        if message.operation != "candidate_page" or message.request_id != self._page_request_id:
+            return
+        if message.kind is FailureKind.GENERATION_CHANGED:
+            self._cursor_stack = [None]
+            self.app.notify(_FAILURE_TEXT[message.kind], markup=False)
+            self._load_current_page()
+            return
+        self.query_one("#candidate-message", Static).update(_FAILURE_TEXT[message.kind])

--- a/src/worktrace/tui/screens/contribution.py
+++ b/src/worktrace/tui/screens/contribution.py
@@ -1,0 +1,543 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, ClassVar, cast
+
+from rich.text import Text
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import VerticalScroll
+from textual.widgets import DataTable, Footer, Static, TabbedContent, TabPane
+
+from worktrace.read_workspace import ContributionReview
+from worktrace.tui.messages import (
+    ContributionReviewLoaded,
+    EvidenceExcerptLoaded,
+    FailureKind,
+    ReadFailed,
+    failure_kind,
+)
+from worktrace.tui.modals.evidence import EvidenceModal
+from worktrace.tui.screens.base import WorkTraceScreen
+from worktrace.tui.terminal_text import literal_dynamic_text
+
+if TYPE_CHECKING:
+    from worktrace.tui.app import WorkTraceApp
+
+_EVIDENCE_PREFIXES = frozenset(
+    {"obs", "participation", "part", "availability", "decision", "ref", "reference"}
+)
+_OBJECT_PREFIXES = frozenset({"obj"})
+_CONTRIBUTION_PREFIXES = frozenset({"candidate", "contribution"})
+_STATUS_SYMBOLS = {
+    "supported": "✓ Supported",
+    "partially_supported": "≈ Partially supported",
+    "human_attested": "H Human-attested",
+    "contradicted": "! Contradicted",
+    "unknown": "? Unknown",
+    "unresolved": "? Unresolved",
+    "requires_human_confirmation": "? Requires human confirmation",
+}
+_FAILURE_TEXT = {
+    FailureKind.BUSY: (
+        "WorkTrace data is busy. Another process may be importing or rebuilding. Press r to retry."
+    ),
+    FailureKind.NOT_FOUND: (
+        "This contribution or evidence is no longer available. Press r to retry."
+    ),
+    FailureKind.OUT_OF_SCOPE: (
+        "The requested record is outside the selected application. Press q to return to candidates."
+    ),
+    FailureKind.UPGRADE_REQUIRED: "Exit and run `worktrace init`, then retry.",
+    FailureKind.UNSUPPORTED_NEWER: "Upgrade WorkTrace before opening this database.",
+    FailureKind.GENERATION_CHANGED: "Candidate suggestions changed. Return and refresh candidates.",
+    FailureKind.DATABASE: "WorkTrace could not read the database. Run `worktrace doctor`.",
+    FailureKind.UNEXPECTED: "WorkTrace could not complete this read. Press r to retry.",
+}
+
+
+def _append_dynamic(output: Text, value: object) -> None:
+    output.append_text(literal_dynamic_text(value))
+
+
+def _append_field(output: Text, label: str, value: object) -> None:
+    output.append(f"{label}: ")
+    _append_dynamic(output, "Unknown" if value is None or value == "" else value)
+    output.append("\n")
+
+
+def _append_values(output: Text, label: str, value: object) -> None:
+    output.append(f"{label}: ")
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        values = list(value)
+        if not values:
+            output.append("None\n")
+            return
+        output.append("\n")
+        for item in values:
+            output.append("  • ")
+            _append_dynamic(output, item)
+            output.append("\n")
+        return
+    _append_dynamic(output, "None" if value is None else value)
+    output.append("\n")
+
+
+def _append_structure(output: Text, value: object, *, indent: int = 0) -> None:
+    prefix = " " * indent
+    if isinstance(value, Mapping):
+        for key, child in value.items():
+            output.append(prefix)
+            _append_dynamic(output, str(key).replace("_", " ").title())
+            if isinstance(child, (Mapping, list, tuple)) and child:
+                output.append(":\n")
+                _append_structure(output, child, indent=indent + 2)
+            else:
+                output.append(": ")
+                _append_dynamic(output, "None" if child in (None, "", [], {}) else child)
+                output.append("\n")
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        if not value:
+            output.append(prefix + "None\n")
+            return
+        for child in value:
+            output.append(prefix + "• ")
+            if isinstance(child, (Mapping, list, tuple)):
+                output.append("\n")
+                _append_structure(output, child, indent=indent + 2)
+            else:
+                _append_dynamic(output, child)
+                output.append("\n")
+        return
+    output.append(prefix)
+    _append_dynamic(output, value)
+    output.append("\n")
+
+
+def _status_label(status: object) -> str:
+    value = str(status or "unknown")
+    return _STATUS_SYMBOLS.get(value, f"? {value.replace('_', ' ').title()}")
+
+
+class ContributionScreen(WorkTraceScreen):
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("1", "show_tab('summary')", "Summary"),
+        Binding("2", "show_tab('evidence')", "Evidence"),
+        Binding("3", "show_tab('participation')", "Participation"),
+        Binding("4", "show_tab('delivery')", "Delivery"),
+        Binding("5", "show_tab('questions')", "Questions"),
+        Binding("j", "cursor_down", "Next"),
+        Binding("k", "cursor_up", "Previous"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("a", "app.switch_application", "Switch app"),
+        Binding("y", "app.copy_selected_id", "Copy ID"),
+        Binding("q,escape", "back", "Back"),
+    ]
+
+    def __init__(
+        self,
+        app_id: str,
+        candidate_id: str,
+        *,
+        return_to_existing: bool,
+    ) -> None:
+        super().__init__()
+        self.app_id = app_id
+        self.candidate_id = candidate_id
+        self.return_to_existing = return_to_existing
+        self._review_request_id = 0
+        self._excerpt_request_id = 0
+        self._review: ContributionReview | None = None
+        self._evidence_rows: list[dict[str, object]] = []
+        self._questions: list[tuple[str, dict[str, object]]] = []
+        self._gaps_by_question: dict[str, dict[str, object]] = {}
+
+    def compose(self) -> ComposeResult:
+        yield Static("Loading contribution review…", id="contribution-title", classes="page-title")
+        yield Static("Loading read-only packet…", id="contribution-message", markup=False)
+        with TabbedContent(initial="summary", id="review-tabs"):
+            with (
+                TabPane("Summary", id="summary"),
+                VerticalScroll(id="summary-scroll", classes="review-scroll"),
+            ):
+                yield Static(id="summary-content", markup=False)
+            with TabPane("Evidence", id="evidence"):
+                yield DataTable(id="evidence-table", cursor_type="cell", zebra_stripes=True)
+                yield Static(id="evidence-detail", classes="notice", markup=False)
+            with (
+                TabPane("Participation", id="participation"),
+                VerticalScroll(id="participation-scroll", classes="review-scroll"),
+            ):
+                yield Static(id="participation-content", markup=False)
+            with (
+                TabPane("Delivery", id="delivery"),
+                VerticalScroll(id="delivery-scroll", classes="review-scroll"),
+            ):
+                yield Static(id="delivery-content", markup=False)
+            with TabPane("Questions", id="questions"):
+                yield DataTable(id="questions-table", cursor_type="row", zebra_stripes=True)
+                with VerticalScroll(id="question-scroll", classes="review-scroll"):
+                    yield Static(id="question-detail", markup=False)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        evidence = self.query_one("#evidence-table", DataTable)
+        evidence.add_columns("State", "Source", "Kind", "Title", "Evidence ID", "Object ID")
+        questions = self.query_one("#questions-table", DataTable)
+        questions.add_columns("State", "Section", "Question")
+        self._load_review()
+
+    def refresh_data(self) -> None:
+        self.action_refresh()
+
+    def action_refresh(self) -> None:
+        self._excerpt_request_id += 1
+        self.query_one("#contribution-message", Static).update("Refreshing read-only packet…")
+        self._load_review()
+
+    def action_back(self) -> None:
+        self._review_request_id += 1
+        self._excerpt_request_id += 1
+        if self.return_to_existing:
+            self.app.pop_screen()
+        else:
+            cast("WorkTraceApp", self.app).open_application(self.app_id)
+
+    def action_show_tab(self, tab_id: str) -> None:
+        self.query_one("#review-tabs", TabbedContent).active = tab_id
+        if tab_id == "evidence":
+            self.query_one("#evidence-table", DataTable).focus()
+        elif tab_id == "questions":
+            self.query_one("#questions-table", DataTable).focus()
+        elif tab_id in {"summary", "participation", "delivery"}:
+            self.query_one(f"#{tab_id}-scroll", VerticalScroll).focus()
+
+    def action_cursor_down(self) -> None:
+        focused = self.focused
+        if isinstance(focused, DataTable):
+            focused.action_cursor_down()
+        elif isinstance(focused, VerticalScroll):
+            focused.action_scroll_down()
+
+    def action_cursor_up(self) -> None:
+        focused = self.focused
+        if isinstance(focused, DataTable):
+            focused.action_cursor_up()
+        elif isinstance(focused, VerticalScroll):
+            focused.action_scroll_up()
+
+    def selected_stable_id(self) -> tuple[str, frozenset[str]] | None:
+        review = self._review
+        if review is None:
+            return None
+        active = self.query_one("#review-tabs", TabbedContent).active
+        if active == "evidence":
+            table = self.query_one("#evidence-table", DataTable)
+            if not 0 <= table.cursor_row < len(self._evidence_rows):
+                return None
+            row = self._evidence_rows[table.cursor_row]
+            if table.cursor_column == 5:
+                object_id = row.get("object_id")
+                return (
+                    (object_id, _OBJECT_PREFIXES)
+                    if isinstance(object_id, str) and object_id
+                    else None
+                )
+            evidence_id = row.get("evidence_id")
+            if isinstance(evidence_id, str) and evidence_id:
+                return evidence_id, _EVIDENCE_PREFIXES
+            object_id = row.get("object_id")
+            return (
+                (object_id, _OBJECT_PREFIXES) if isinstance(object_id, str) and object_id else None
+            )
+        if active == "questions":
+            table = self.query_one("#questions-table", DataTable)
+            if 0 <= table.cursor_row < len(self._questions):
+                question = self._questions[table.cursor_row][1]
+                evidence_ids = question.get("supporting_evidence_ids", [])
+                if isinstance(evidence_ids, list) and evidence_ids:
+                    first = evidence_ids[0]
+                    if isinstance(first, str):
+                        return first, _EVIDENCE_PREFIXES
+        return review.resolved_contribution_id, _CONTRIBUTION_PREFIXES
+
+    @work(thread=True, exclusive=True, group="contribution-review", exit_on_error=False)
+    def load_review(self, request_id: int) -> None:
+        try:
+            review = cast("WorkTraceApp", self.app).workspace.contribution_review(
+                self.app_id,
+                self.candidate_id,
+            )
+        except Exception as error:
+            self.post_message(ReadFailed("contribution_review", request_id, failure_kind(error)))
+        else:
+            self.post_message(ContributionReviewLoaded(request_id, review))
+
+    @work(thread=True, exclusive=True, group="evidence-excerpt", exit_on_error=False)
+    def load_excerpt(self, request_id: int, evidence_id: str) -> None:
+        try:
+            excerpt = cast("WorkTraceApp", self.app).workspace.evidence_excerpt(
+                self.app_id,
+                evidence_id,
+                max_chars=4_000,
+            )
+        except Exception as error:
+            self.post_message(ReadFailed("evidence_excerpt", request_id, failure_kind(error)))
+        else:
+            self.post_message(EvidenceExcerptLoaded(request_id, excerpt))
+
+    def _load_review(self) -> None:
+        self._review_request_id += 1
+        self.load_review(self._review_request_id)
+
+    def _load_excerpt(self, evidence_id: str) -> None:
+        self._excerpt_request_id += 1
+        self.query_one("#contribution-message", Static).update("Loading bounded evidence excerpt…")
+        self.load_excerpt(self._excerpt_request_id, evidence_id)
+
+    def on_contribution_review_loaded(self, message: ContributionReviewLoaded) -> None:
+        if message.request_id != self._review_request_id:
+            return
+        self._review = message.review
+        self._render_review(message.review)
+
+    def on_evidence_excerpt_loaded(self, message: EvidenceExcerptLoaded) -> None:
+        if message.request_id != self._excerpt_request_id:
+            return
+        self.query_one("#contribution-message", Static).update("Read-only review loaded.")
+        self.app.push_screen(EvidenceModal(message.excerpt))
+
+    def on_read_failed(self, message: ReadFailed) -> None:
+        if message.operation == "contribution_review":
+            if message.request_id != self._review_request_id:
+                return
+        elif message.operation == "evidence_excerpt":
+            if message.request_id != self._excerpt_request_id:
+                return
+        else:
+            return
+        self.query_one("#contribution-message", Static).update(_FAILURE_TEXT[message.kind])
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        if event.data_table.id == "evidence-table":
+            self._open_evidence_row(event.cursor_row)
+        elif event.data_table.id == "questions-table":
+            self._render_question_detail(event.cursor_row)
+            self.query_one("#question-scroll", VerticalScroll).focus()
+
+    def on_data_table_cell_selected(self, event: DataTable.CellSelected) -> None:
+        if event.data_table.id == "evidence-table":
+            self._open_evidence_row(event.coordinate.row)
+
+    def _open_evidence_row(self, row_index: int) -> None:
+        if 0 <= row_index < len(self._evidence_rows):
+            evidence_id = self._evidence_rows[row_index].get("evidence_id")
+            if isinstance(evidence_id, str) and evidence_id:
+                self._load_excerpt(evidence_id)
+            else:
+                self.app.notify(
+                    "No current evidence excerpt is available for this member.", markup=False
+                )
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        if event.data_table.id == "evidence-table":
+            self._render_evidence_detail(event.cursor_row)
+        elif event.data_table.id == "questions-table":
+            self._render_question_detail(event.cursor_row)
+
+    def on_data_table_cell_highlighted(self, event: DataTable.CellHighlighted) -> None:
+        if event.data_table.id == "evidence-table":
+            self._render_evidence_detail(event.coordinate.row)
+
+    def _render_review(self, review: ContributionReview) -> None:
+        contribution = review.packet.get("contribution")
+        contribution_data = contribution if isinstance(contribution, dict) else {}
+        title = contribution_data.get("title") or "Untitled contribution"
+        title_text = Text()
+        _append_dynamic(title_text, title)
+        self.query_one("#contribution-title", Static).update(title_text)
+        self.query_one("#contribution-message", Static).update("Read-only review loaded.")
+        self._render_summary(review, contribution_data)
+        self._render_evidence(review)
+        self._render_participation(review)
+        self._render_delivery(review)
+        self._render_questions(review)
+
+    def _render_summary(
+        self,
+        review: ContributionReview,
+        contribution: dict[str, object],
+    ) -> None:
+        output = Text()
+        _append_field(output, "Candidate ID", review.candidate_id)
+        _append_field(output, "Contribution ID", review.resolved_contribution_id)
+        _append_field(output, "Application", review.app_id)
+        _append_field(output, "Status", review.status)
+        _append_field(output, "Type", contribution.get("type"))
+        _append_field(output, "Title authority", contribution.get("title_authority"))
+        _append_field(output, "Title status", contribution.get("title_status"))
+        _append_field(output, "Period from", contribution.get("date_from"))
+        _append_field(output, "Period to", contribution.get("date_to"))
+        _append_field(output, "As of", review.packet.get("as_of"))
+        evidence_summary = review.packet.get("evidence_summary")
+        summary = evidence_summary if isinstance(evidence_summary, dict) else {}
+        _append_values(output, "Sources", sorted(self._member_sources(summary)))
+        _append_values(output, "Modules", summary.get("modules", []))
+        members = summary.get("members", [])
+        _append_field(output, "Current members", len(members) if isinstance(members, list) else 0)
+        unsupported = summary.get("unsupported_member_ids", [])
+        _append_field(
+            output,
+            "Current evidence",
+            "Incomplete" if isinstance(unsupported, list) and unsupported else "Complete",
+        )
+        _append_values(output, "Unsupported member IDs", unsupported)
+        output.append("\nContradictions\n")
+        _append_structure(output, review.packet.get("contradictions", []), indent=2)
+        output.append("\nLimitations\n")
+        _append_structure(output, review.packet.get("limitations", []), indent=2)
+        self.query_one("#summary-content", Static).update(output)
+
+    @staticmethod
+    def _member_sources(summary: dict[str, object]) -> set[str]:
+        members = summary.get("members", [])
+        if not isinstance(members, list):
+            return set()
+        return {
+            str(member["source"])
+            for member in members
+            if isinstance(member, dict) and member.get("source")
+        }
+
+    def _render_evidence(self, review: ContributionReview) -> None:
+        summary = review.packet.get("evidence_summary")
+        summary_data = summary if isinstance(summary, dict) else {}
+        raw_members = summary_data.get("members", [])
+        members = (
+            [item for item in raw_members if isinstance(item, dict)]
+            if isinstance(raw_members, list)
+            else []
+        )
+        self._evidence_rows = [dict(item) for item in members]
+        self._evidence_rows.sort(
+            key=lambda item: (str(item.get("source", "")), str(item.get("evidence_id", "")))
+        )
+        for unsupported in review.unsupported_members:
+            self._evidence_rows.append(
+                {
+                    "state": "unsupported current",
+                    "source": unsupported.source,
+                    "kind": unsupported.kind,
+                    "title": "No authoritative current observation",
+                    "evidence_id": None,
+                    "object_id": unsupported.object_id,
+                    "external_id": unsupported.external_id,
+                }
+            )
+        table = self.query_one("#evidence-table", DataTable)
+        table.clear()
+        for index, row in enumerate(self._evidence_rows):
+            state = row.get("state") or (
+                "context only" if row.get("context_only") is True else "material current"
+            )
+            table.add_row(
+                literal_dynamic_text(state),
+                literal_dynamic_text(row.get("source", "unknown")),
+                literal_dynamic_text(row.get("kind", "unknown")),
+                literal_dynamic_text(row.get("title") or "No title"),
+                literal_dynamic_text(row.get("evidence_id") or "None"),
+                literal_dynamic_text(row.get("object_id") or "None"),
+                key=f"evidence-row-{index}",
+            )
+        if self._evidence_rows:
+            self._render_evidence_detail(0)
+        else:
+            self.query_one("#evidence-detail", Static).update(
+                "No current or unsupported evidence members are recorded."
+            )
+
+    def _render_evidence_detail(self, index: int) -> None:
+        if not 0 <= index < len(self._evidence_rows):
+            return
+        output = Text()
+        _append_structure(output, self._evidence_rows[index])
+        self.query_one("#evidence-detail", Static).update(output)
+
+    def _render_participation(self, review: ContributionReview) -> None:
+        output = Text("Observed participation facts\n\n")
+        _append_structure(output, review.packet.get("participation", {}))
+        output.append("\nOwnership remains unresolved unless explicitly human-attested.\n")
+        self.query_one("#participation-content", Static).update(output)
+
+    def _render_delivery(self, review: ContributionReview) -> None:
+        output = Text("Seven independent delivery states\n\n")
+        raw_ladder = review.packet.get("release_ladder")
+        ladder = raw_ladder if isinstance(raw_ladder, dict) else {}
+        for rung, raw_detail in ladder.items():
+            detail = raw_detail if isinstance(raw_detail, dict) else {}
+            _append_dynamic(output, str(rung).replace("_", " ").title())
+            output.append(" — ")
+            output.append(_status_label(detail.get("status")))
+            output.append("\n")
+            _append_field(output, "  Statement", detail.get("statement"))
+            _append_values(
+                output, "  Supporting evidence", detail.get("supporting_evidence_ids", [])
+            )
+            _append_values(output, "  Limitations", detail.get("limitations", []))
+            output.append("\n")
+        self.query_one("#delivery-content", Static).update(output)
+
+    def _render_questions(self, review: ContributionReview) -> None:
+        self._questions = []
+        sections = review.packet.get("sections")
+        if isinstance(sections, dict):
+            for section, raw_questions in sections.items():
+                if not isinstance(raw_questions, list):
+                    continue
+                for raw_question in raw_questions:
+                    if isinstance(raw_question, dict):
+                        self._questions.append((str(section), raw_question))
+        self._gaps_by_question = {}
+        raw_gaps = review.gaps.get("unknown_questions", [])
+        if isinstance(raw_gaps, list):
+            for raw_gap in raw_gaps:
+                if isinstance(raw_gap, dict) and isinstance(raw_gap.get("question_id"), str):
+                    self._gaps_by_question[str(raw_gap["question_id"])] = raw_gap
+        table = self.query_one("#questions-table", DataTable)
+        table.clear()
+        for index, (section, question) in enumerate(self._questions):
+            table.add_row(
+                literal_dynamic_text(_status_label(question.get("status"))),
+                literal_dynamic_text(section.replace("_", " ").title()),
+                literal_dynamic_text(question.get("question", "Unknown question")),
+                key=f"question-row-{index}",
+            )
+        if self._questions:
+            self._render_question_detail(0)
+        else:
+            self.query_one("#question-detail", Static).update("No Phase 4 questions were returned.")
+
+    def _render_question_detail(self, index: int) -> None:
+        if not 0 <= index < len(self._questions):
+            return
+        section, question = self._questions[index]
+        output = Text()
+        _append_field(output, "Section", section)
+        _append_field(output, "Question ID", question.get("question_id"))
+        _append_field(output, "Question", question.get("question"))
+        _append_field(output, "Status", _status_label(question.get("status")))
+        _append_field(output, "Answer", question.get("answer_draft"))
+        _append_values(output, "Supporting evidence", question.get("supporting_evidence_ids", []))
+        _append_values(
+            output, "Contradicting evidence", question.get("contradicting_evidence_ids", [])
+        )
+        _append_values(output, "Limitations", question.get("limitations", []))
+        _append_values(output, "Missing information", question.get("missing_information", []))
+        question_id = question.get("question_id")
+        if isinstance(question_id, str) and question_id in self._gaps_by_question:
+            output.append("\nPacket-derived gap\n")
+            _append_structure(output, self._gaps_by_question[question_id], indent=2)
+        self.query_one("#question-detail", Static).update(output)

--- a/src/worktrace/tui/terminal_text.py
+++ b/src/worktrace/tui/terminal_text.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from rich.text import Text
+
+_BIDI_NAMES = {
+    "\u061c": "ALM",
+    "\u200e": "LRM",
+    "\u200f": "RLM",
+    "\u202a": "LRE",
+    "\u202b": "RLE",
+    "\u202c": "PDF",
+    "\u202d": "LRO",
+    "\u202e": "RLO",
+    "\u2066": "LRI",
+    "\u2067": "RLI",
+    "\u2068": "FSI",
+    "\u2069": "PDI",
+}
+_TRUNCATION_MARKER = "<TRUNCATED_FOR_TERMINAL>"
+
+
+@dataclass(frozen=True, slots=True)
+class TerminalSafeText:
+    text: str
+    encoded_control_count: int
+    truncated: bool
+
+
+def terminal_safe_text(
+    value: str,
+    *,
+    max_output_chars: int = 20_000,
+) -> TerminalSafeText:
+    if max_output_chars < 0:
+        raise ValueError("max_output_chars must be non-negative")
+
+    output: list[str] = []
+    output_length = 0
+    encoded_controls = 0
+
+    for character in value:
+        codepoint = ord(character)
+        if character == "\n":
+            replacement = "\n"
+        elif character == "\t":
+            replacement = "    "
+            encoded_controls += 1
+        elif character in _BIDI_NAMES:
+            replacement = f"<{_BIDI_NAMES[character]}>"
+            encoded_controls += 1
+        elif codepoint == 0x1B:
+            replacement = "<ESC>"
+            encoded_controls += 1
+        elif codepoint == 0x7F:
+            replacement = "<DEL>"
+            encoded_controls += 1
+        elif codepoint == 0x2028:
+            replacement = "<LS>"
+            encoded_controls += 1
+        elif codepoint == 0x2029:
+            replacement = "<PS>"
+            encoded_controls += 1
+        elif codepoint < 0x20 or 0x80 <= codepoint <= 0x9F or 0xD800 <= codepoint <= 0xDFFF:
+            replacement = f"<U+{codepoint:04X}>"
+            encoded_controls += 1
+        else:
+            replacement = character
+
+        if output_length + len(replacement) > max_output_chars:
+            remaining = max_output_chars - output_length
+            if remaining:
+                output.append(_TRUNCATION_MARKER[:remaining])
+            return TerminalSafeText(
+                text="".join(output),
+                encoded_control_count=encoded_controls,
+                truncated=True,
+            )
+        output.append(replacement)
+        output_length += len(replacement)
+
+    return TerminalSafeText(
+        text="".join(output),
+        encoded_control_count=encoded_controls,
+        truncated=False,
+    )
+
+
+def literal_dynamic_text(value: object, *, max_output_chars: int = 20_000) -> Text:
+    encoded = terminal_safe_text(str(value), max_output_chars=max_output_chars)
+    return Text(encoded.text)

--- a/src/worktrace/tui/worktrace.tcss
+++ b/src/worktrace/tui/worktrace.tcss
@@ -73,9 +73,21 @@ TabbedContent {
 }
 
 #help-dialog, #terminal-dialog {
-    width: 72;
-    height: auto;
+    width: 90%;
+    max-width: 72;
     max-height: 90%;
+}
+
+#help-dialog {
+    height: 90%;
+}
+
+#help-dialog:focus {
+    border: solid $accent;
+}
+
+#help-content, #terminal-dialog {
+    height: auto;
 }
 
 .compact .optional-column {

--- a/src/worktrace/tui/worktrace.tcss
+++ b/src/worktrace/tui/worktrace.tcss
@@ -1,0 +1,83 @@
+Screen {
+    background: $surface;
+    color: $text;
+}
+
+Footer {
+    background: $panel;
+}
+
+.page-title {
+    height: 1;
+    text-style: bold;
+    padding: 0 1;
+}
+
+.notice {
+    height: auto;
+    padding: 0 1;
+    color: $text-muted;
+}
+
+.error {
+    height: auto;
+    padding: 1 2;
+    border: solid $error;
+}
+
+.loading {
+    height: 1fr;
+    content-align: center middle;
+}
+
+DataTable {
+    height: 1fr;
+}
+
+DataTable:focus {
+    border: solid $accent;
+}
+
+TabbedContent {
+    height: 1fr;
+}
+
+.review-scroll, .excerpt-scroll {
+    height: 1fr;
+    padding: 0 1;
+}
+
+.review-scroll:focus, .excerpt-scroll:focus {
+    border: solid $accent;
+}
+
+#source-status-scroll {
+    height: 7;
+    max-height: 7;
+}
+
+#source-status-scroll:focus {
+    border: solid $accent;
+}
+
+#source-status {
+    height: auto;
+}
+
+#evidence-dialog, #help-dialog, #terminal-dialog {
+    width: 90%;
+    height: 90%;
+    border: solid $accent;
+    background: $surface;
+    padding: 1 2;
+}
+
+#help-dialog, #terminal-dialog {
+    width: 72;
+    height: auto;
+    max-height: 90%;
+}
+
+.compact .optional-column {
+    display: none;
+}

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""WorkTrace test support package."""

--- a/tests/test_read_workspace.py
+++ b/tests/test_read_workspace.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import worktrace.read_workspace as read_workspace_module
+from tests.test_packets_golden import _packet_state
+from worktrace.errors import ScopeViolation
+from worktrace.read_workspace import (
+    DatabaseBusy,
+    DatabaseUpgradeRequired,
+    DatabaseVersionUnsupported,
+    ReadOnlyWorkspace,
+)
+
+
+def _workspace(tmp_path: Path) -> tuple[ReadOnlyWorkspace, str]:
+    connection, _, config, candidate_id = _packet_state(tmp_path)
+    connection.close()
+    return ReadOnlyWorkspace(config), candidate_id
+
+
+def test_read_only_workspace_completes_one_coherent_review(tmp_path: Path) -> None:
+    workspace, candidate_id = _workspace(tmp_path)
+
+    applications = workspace.applications()
+    page = workspace.candidate_page("sample_store")
+    status = workspace.source_status("sample_store")
+    review = workspace.contribution_review("sample_store", candidate_id)
+    members = review.packet["evidence_summary"]
+    assert isinstance(members, dict)
+    raw_members = members["members"]
+    assert isinstance(raw_members, list)
+    evidence_id = str(raw_members[0]["evidence_id"])
+    excerpt = workspace.evidence_excerpt("sample_store", evidence_id, max_chars=1_200)
+
+    assert [application.app_id for application in applications] == ["sample_store"]
+    assert [item.candidate_id for item in page.items] == [candidate_id]
+    assert set(status) == {"git", "gitlab", "jira", "manual"}
+    assert review.app_id == "sample_store"
+    assert review.packet["schema_version"] == 2
+    assert review.gaps["contribution_id"] == review.resolved_contribution_id
+    assert excerpt["evidence_id"] == evidence_id
+
+
+def test_workspace_builds_packet_once_and_derives_gaps_from_same_object(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, candidate_id = _workspace(tmp_path)
+    original_build = read_workspace_module.PacketBuilder.build_packet
+    original_gaps = read_workspace_module.build_gap_report
+    packet_ids: list[int] = []
+    gap_packet_ids: list[int] = []
+
+    def build_packet(builder: Any, identifier: str) -> dict[str, object]:
+        packet = original_build(builder, identifier)
+        packet_ids.append(id(packet))
+        return packet
+
+    def build_gaps(packet: dict[str, object]) -> dict[str, object]:
+        gap_packet_ids.append(id(packet))
+        return original_gaps(packet)
+
+    monkeypatch.setattr(read_workspace_module.PacketBuilder, "build_packet", build_packet)
+    monkeypatch.setattr(read_workspace_module, "build_gap_report", build_gaps)
+
+    workspace.contribution_review("sample_store", candidate_id)
+
+    assert len(packet_ids) == 1
+    assert gap_packet_ids == packet_ids
+
+
+def test_workspace_connection_is_worker_created_query_only_500ms_and_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, _ = _workspace(tmp_path)
+    original = read_workspace_module.connect_read_only
+    events: list[tuple[str, int, int]] = []
+
+    class TrackingConnection:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self.connection = connection
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self.connection, name)
+
+        def close(self) -> None:
+            events.append(("close", threading.get_ident(), 500))
+            self.connection.close()
+
+    def tracking_connect(path: Path, *, busy_timeout_ms: int) -> Any:
+        events.append(("open", threading.get_ident(), busy_timeout_ms))
+        connection = original(path, busy_timeout_ms=busy_timeout_ms)
+        assert int(connection.execute("PRAGMA query_only").fetchone()[0]) == 1
+        connection.execute("PRAGMA query_only = OFF")
+        with pytest.raises(sqlite3.OperationalError):
+            connection.execute("INSERT INTO apps(id, name) VALUES ('bad', 'Bad')")
+        connection.execute("PRAGMA query_only = ON")
+        return TrackingConnection(connection)
+
+    monkeypatch.setattr(read_workspace_module, "connect_read_only", tracking_connect)
+    main_thread = threading.get_ident()
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        assert executor.submit(workspace.applications).result()[0].app_id == "sample_store"
+
+    assert events[0][0] == "open"
+    assert events[-1][0] == "close"
+    assert events[0][1] == events[-1][1]
+    assert events[0][1] != main_thread
+    assert events[0][2] == 500
+
+
+def test_workspace_rejects_cross_application_candidate_and_evidence(tmp_path: Path) -> None:
+    from tests.tui_support import add_second_application
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    config = add_second_application(connection, config, tmp_path)
+    connection.close()
+    workspace = ReadOnlyWorkspace(config)
+
+    with pytest.raises(ScopeViolation):
+        workspace.contribution_review("sample_store", "candidate:other")
+    with pytest.raises(ScopeViolation):
+        workspace.evidence_excerpt("sample_store", "obs:other", max_chars=1_200)
+
+
+def test_workspace_reports_older_and_newer_database_versions(tmp_path: Path) -> None:
+    from worktrace.db.migrations import migrations
+
+    workspace, _ = _workspace(tmp_path)
+    database_path = workspace.database_path
+    supported = migrations()[-1].version
+    writer = sqlite3.connect(database_path)
+    try:
+        writer.execute(f"PRAGMA user_version = {supported - 1}")
+        writer.commit()
+        with pytest.raises(DatabaseUpgradeRequired):
+            workspace.applications()
+
+        writer.execute(f"PRAGMA user_version = {supported + 1}")
+        writer.commit()
+        with pytest.raises(DatabaseVersionUnsupported):
+            workspace.applications()
+    finally:
+        writer.close()
+
+
+def test_workspace_bounds_lock_contention_to_busy_error(tmp_path: Path) -> None:
+    workspace, _ = _workspace(tmp_path)
+    blocker = sqlite3.connect(workspace.database_path, timeout=0.1, isolation_level=None)
+    try:
+        blocker.execute("BEGIN EXCLUSIVE")
+        with pytest.raises(DatabaseBusy):
+            workspace.applications()
+    finally:
+        blocker.execute("ROLLBACK")
+        blocker.close()

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -58,6 +58,18 @@ async def _pause_until(
     raise AssertionError("Textual state did not settle")
 
 
+async def _drag_selection_attempt(
+    pilot: object,
+    widget: Static,
+    *,
+    start: tuple[int, int],
+    end: tuple[int, int],
+) -> None:
+    assert await pilot.mouse_down(widget, offset=start)  # type: ignore[attr-defined]
+    assert await pilot.mouse_up(widget, offset=end)  # type: ignore[attr-defined]
+    await pilot.pause()  # type: ignore[attr-defined]
+
+
 def _copy_binding_actions(screen: Screen[object]) -> list[str]:
     return [
         binding.action
@@ -197,6 +209,66 @@ async def test_compact_help_scrolls_to_final_commands_and_q_closes(tmp_path: Pat
         assert help_scroll.scroll_y == help_scroll.max_scroll_y
         await pilot.press("q")
         assert app.screen is candidate_screen
+
+
+@pytest.mark.asyncio
+async def test_modal_mouse_selection_cannot_copy_but_explicit_evidence_id_can(
+    tmp_path: Path,
+) -> None:
+    app, _ = _app(tmp_path)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidate_screen = app.screen
+        assert isinstance(candidate_screen, CandidateScreen)
+        candidate_table = candidate_screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: candidate_table.row_count == 1)
+
+        await pilot.press("?")
+        await _pause_until(pilot, lambda: isinstance(app.screen, HelpModal))
+        help_modal = app.screen
+        assert isinstance(help_modal, HelpModal)
+        help_content = help_modal.query_one("#help-content", Static)
+        await _drag_selection_attempt(
+            pilot,
+            help_content,
+            start=(1, 1),
+            end=(20, 4),
+        )
+        await pilot.press("ctrl+c", "super+c")
+        assert app.copied == []
+        assert help_modal.selections == {}
+        assert help_modal.get_selected_text() is None
+        await pilot.press("q")
+        assert app.screen is candidate_screen
+
+        await pilot.press("enter")
+        await _pause_until(
+            pilot,
+            lambda: isinstance(app.screen, ContributionScreen) and app.screen._review is not None,
+        )
+        await pilot.press("2", "enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceModal))
+        evidence_modal = app.screen
+        assert isinstance(evidence_modal, EvidenceModal)
+        evidence_body = evidence_modal.query_one("#evidence-body", Static)
+        await _drag_selection_attempt(
+            pilot,
+            evidence_body,
+            start=(1, 0),
+            end=(20, 0),
+        )
+        await pilot.press("ctrl+c", "super+c")
+        assert app.copied == []
+        assert evidence_modal.selections == {}
+        assert evidence_modal.get_selected_text() is None
+
+        selected = evidence_modal.selected_stable_id()
+        assert selected is not None
+        expected_evidence_id = selected[0]
+        assert expected_evidence_id.startswith("obs:")
+        await pilot.press("y")
+        assert app.copied == [expected_evidence_id]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import socket
+import sqlite3
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from rich.text import Text
+from textual.screen import Screen
+from textual.widgets import DataTable, Static, TabbedContent
+
+from tests.test_packets_golden import _packet_state
+from worktrace.read_workspace import ReadOnlyWorkspace
+from worktrace.tui.app import SmallTerminalScreen, WorkTraceApp
+from worktrace.tui.modals.evidence import EvidenceModal
+from worktrace.tui.screens.applications import ApplicationScreen
+from worktrace.tui.screens.candidates import CandidateScreen
+from worktrace.tui.screens.contribution import ContributionScreen
+
+
+class RecordingWorkTraceApp(WorkTraceApp):
+    def __init__(self, workspace: ReadOnlyWorkspace, **kwargs: object) -> None:
+        super().__init__(workspace, **kwargs)  # type: ignore[arg-type]
+        self.copied: list[str] = []
+        self.notifications: list[str] = []
+
+    def copy_to_clipboard(self, text: str) -> None:
+        self.copied.append(text)
+
+    def notify(self, message: str, **kwargs: object) -> None:
+        self.notifications.append(message)
+        super().notify(message, **kwargs)  # type: ignore[arg-type]
+
+
+def _app(tmp_path: Path, **kwargs: object) -> tuple[RecordingWorkTraceApp, str]:
+    connection, _, config, candidate_id = _packet_state(tmp_path)
+    connection.close()
+    return RecordingWorkTraceApp(ReadOnlyWorkspace(config), **kwargs), candidate_id
+
+
+async def _pause_until(
+    pilot: object,
+    predicate: object,
+    *,
+    attempts: int = 80,
+) -> None:
+    for _ in range(attempts):
+        if predicate():  # type: ignore[operator]
+            await pilot.pause()  # type: ignore[attr-defined]
+            return
+        await pilot.pause()  # type: ignore[attr-defined]
+    raise AssertionError("Textual state did not settle")
+
+
+def _copy_binding_actions(screen: Screen[object]) -> list[str]:
+    return [
+        binding.action
+        for bindings in screen._bindings.key_to_bindings.values()
+        for binding in bindings
+        if binding.key in {"ctrl+c", "super+c"}
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(80, 24), (120, 40)])
+async def test_keyboard_contribution_review_journey(tmp_path: Path, size: tuple[int, int]) -> None:
+    app, candidate_id = _app(tmp_path)
+
+    async with app.run_test(size=size) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidate_screen = app.screen
+        assert isinstance(candidate_screen, CandidateScreen)
+        table = candidate_screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: table.row_count == 1)
+        await pilot.press("enter")
+        await _pause_until(
+            pilot,
+            lambda: isinstance(app.screen, ContributionScreen) and app.screen._review is not None,
+        )
+        contribution = app.screen
+        assert isinstance(contribution, ContributionScreen)
+        assert contribution.candidate_id == candidate_id
+        assert contribution._review is not None
+        packet_questions = [
+            str(question["question_id"])
+            for questions in contribution._review.packet["sections"].values()
+            for question in questions
+        ]
+        assert [str(question[1]["question_id"]) for question in contribution._questions] == (
+            packet_questions
+        )
+        assert len(packet_questions) == 30
+
+        for key, tab_id in zip(
+            "12345", ("summary", "evidence", "participation", "delivery", "questions"), strict=True
+        ):
+            await pilot.press(key)
+            assert contribution.query_one("#review-tabs", TabbedContent).active == tab_id
+
+        await pilot.press("2")
+        assert contribution.query_one("#evidence-table", DataTable).has_focus
+        await pilot.press("enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceModal))
+        modal = app.screen
+        assert isinstance(modal, EvidenceModal)
+        body = modal.query_one("#evidence-body", Static).render()
+        assert body.plain == "Synthetic and sanitized evidence."
+        assert body.spans == []
+        await pilot.press("ctrl+c")
+        await pilot.press("super+c")
+        assert app.copied == []
+        await pilot.press("y")
+        assert len(app.copied) == 1
+        assert app.copied[0].startswith("obs:")
+        await pilot.press("escape")
+        assert isinstance(app.screen, ContributionScreen)
+        await pilot.press("escape")
+        assert isinstance(app.screen, CandidateScreen)
+
+
+@pytest.mark.asyncio
+async def test_multiple_apps_and_scoped_deep_link(tmp_path: Path) -> None:
+    from tests.tui_support import add_second_application
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    config = add_second_application(connection, config, tmp_path)
+    connection.close()
+    app = RecordingWorkTraceApp(
+        ReadOnlyWorkspace(config),
+        initial_app_id="sample_store",
+        initial_candidate_id="candidate:other",
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, ContributionScreen))
+        screen = app.screen
+        assert isinstance(screen, ContributionScreen)
+        await _pause_until(
+            pilot,
+            lambda: (
+                "outside the selected application"
+                in str(screen.query_one("#contribution-message", Static).render())
+            ),
+        )
+        assert screen._review is None
+
+    app = RecordingWorkTraceApp(ReadOnlyWorkspace(config))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, ApplicationScreen))
+
+
+@pytest.mark.asyncio
+async def test_compact_terminal_reduces_candidate_columns(tmp_path: Path) -> None:
+    app, _ = _app(tmp_path)
+
+    async with app.run_test(size=(70, 18)) as pilot:
+        assert isinstance(app.screen, SmallTerminalScreen)
+        await pilot.press("c")
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        table = app.screen.query_one("#candidate-table", DataTable)
+        assert len(table.columns) == 4
+        assert app.compact_mode is True
+
+
+@pytest.mark.asyncio
+async def test_palette_is_fixed_and_screens_disable_selected_text_copy(tmp_path: Path) -> None:
+    app, _ = _app(tmp_path)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        titles = [command.title for command in app.get_system_commands(app.screen)]
+        assert titles == ["Quit", "Keyboard help", "Switch application", "Refresh"]
+        assert "Screenshot" not in titles
+        assert app.ALLOW_SELECT is False
+        assert app.screen.ALLOW_SELECT is False
+        assert _copy_binding_actions(app.screen) == []
+
+
+@pytest.mark.asyncio
+async def test_stale_candidate_page_result_is_ignored(tmp_path: Path) -> None:
+    from worktrace.read_models.candidates import CandidatePage
+    from worktrace.tui.messages import CandidatePageLoaded
+
+    app, _ = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        await _pause_until(
+            pilot,
+            lambda: screen.query_one("#candidate-table", DataTable).row_count == 1,
+        )
+        original_ids = tuple(item.candidate_id for item in screen._items)
+        screen.on_candidate_page_loaded(
+            CandidatePageLoaded(
+                screen._page_request_id - 1,
+                CandidatePage(generation_token=None, items=(), next_cursor=None),
+            )
+        )
+        assert tuple(item.candidate_id for item in screen._items) == original_ids
+
+
+@pytest.mark.asyncio
+async def test_candidate_next_previous_and_generation_restart(tmp_path: Path) -> None:
+    from tests.tui_support import add_visible_candidate_page
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    add_visible_candidate_page(connection)
+    connection.close()
+    app = RecordingWorkTraceApp(
+        ReadOnlyWorkspace(config),
+        initial_app_id="sample_store",
+    )
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        table = screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: screen._page is not None)
+        assert table.row_count == 25
+        assert screen._page is not None and screen._page.next_cursor is not None
+
+        await pilot.press("n")
+        await _pause_until(pilot, lambda: table.row_count == 6)
+        assert len(screen._cursor_stack) == 2
+        await pilot.press("p")
+        await _pause_until(pilot, lambda: table.row_count == 25)
+        assert len(screen._cursor_stack) == 1
+
+        writer = sqlite3.connect(app.workspace.database_path)
+        try:
+            writer.execute(
+                "UPDATE candidate_groups SET generated_at='2026-08-31T00:00:00+00:00' "
+                "WHERE app_id='sample_store'"
+            )
+            writer.commit()
+        finally:
+            writer.close()
+        await pilot.press("n")
+        await _pause_until(
+            pilot,
+            lambda: any("suggestions changed" in message for message in app.notifications),
+        )
+        assert screen._cursor_stack == [None]
+
+
+@pytest.mark.asyncio
+async def test_database_busy_and_empty_candidate_states_are_actionable(tmp_path: Path) -> None:
+    app, _ = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        await _pause_until(pilot, lambda: screen._page is not None)
+
+        original_candidate_page = app.workspace.candidate_page
+
+        def busy(*args: object, **kwargs: object) -> object:
+            from worktrace.read_workspace import DatabaseBusy
+
+            raise DatabaseBusy("secret raw database detail")
+
+        app.workspace.candidate_page = busy  # type: ignore[method-assign]
+        await pilot.press("r")
+        await _pause_until(
+            pilot,
+            lambda: "data is busy" in str(screen.query_one("#candidate-message", Static).render()),
+        )
+        assert "secret raw database detail" not in str(
+            screen.query_one("#candidate-message", Static).render()
+        )
+        app.workspace.candidate_page = original_candidate_page  # type: ignore[method-assign]
+
+    empty_root = tmp_path / "empty"
+    empty_root.mkdir()
+    connection, _, config, _ = _packet_state(empty_root)
+    connection.execute("DELETE FROM candidate_members")
+    connection.execute("DELETE FROM candidate_groups")
+    connection.commit()
+    connection.close()
+    empty_app = RecordingWorkTraceApp(ReadOnlyWorkspace(config))
+    async with empty_app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(empty_app.screen, CandidateScreen))
+        screen = empty_app.screen
+        assert isinstance(screen, CandidateScreen)
+        await _pause_until(
+            pilot,
+            lambda: (
+                "No current contribution candidates"
+                in str(screen.query_one("#candidate-message", Static).render())
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_dynamic_provider_text_is_literal_in_real_ui_sinks(tmp_path: Path) -> None:
+    danger = "[bold][@click=app.quit]Danger[/]\x1b]52;c;YQ==\x07"
+    connection, _, config, _ = _packet_state(tmp_path)
+    connection.execute("UPDATE observations SET title=?, body_text=?", (danger, danger))
+    connection.execute(
+        "UPDATE sync_runs SET error_summary=? WHERE id='run:jira_partial'",
+        (danger,),
+    )
+    connection.execute("UPDATE candidate_groups SET suggested_title=?", (danger,))
+    connection.commit()
+    connection.close()
+    app = RecordingWorkTraceApp(ReadOnlyWorkspace(config))
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidate = app.screen
+        assert isinstance(candidate, CandidateScreen)
+        table = candidate.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: table.row_count == 1)
+        title_cell = table.get_row_at(0)[1]
+        assert isinstance(title_cell, Text)
+        assert "[bold][@click=app.quit]Danger[/]<ESC>]52" in title_cell.plain
+        assert title_cell.spans == []
+        status_render = candidate.query_one("#source-status", Static).render()
+        assert "[bold][@click=app.quit]Danger[/]<ESC>]52" in status_render.plain
+        assert status_render.spans == []
+
+        await pilot.press("enter")
+        await _pause_until(
+            pilot,
+            lambda: isinstance(app.screen, ContributionScreen) and app.screen._review is not None,
+        )
+        contribution = app.screen
+        assert isinstance(contribution, ContributionScreen)
+        title_render = contribution.query_one("#contribution-title", Static).render()
+        assert "[bold][@click=app.quit]Danger[/]<ESC>]52" in title_render.plain
+        assert title_render.spans == []
+        await pilot.press("2", "enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceModal))
+        body = app.screen.query_one("#evidence-body", Static).render()
+        assert "[bold][@click=app.quit]Danger[/]<ESC>]52" in body.plain
+        assert body.spans == []
+
+
+def _directory_fingerprint(path: Path) -> dict[str, str]:
+    return {
+        str(file.relative_to(path)): hashlib.sha256(file.read_bytes()).hexdigest()
+        for file in sorted(path.rglob("*"))
+        if file.is_file()
+    }
+
+
+@pytest.mark.asyncio
+async def test_tui_journey_cannot_reach_providers_network_or_managed_writes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import httpx
+
+    import worktrace.config as config_module
+    import worktrace.local_security as local_security_module
+    from worktrace.adapters.git_local import LocalGitAdapter
+    from worktrace.adapters.gitlab import GitLabAdapter
+    from worktrace.adapters.jira import JiraAdapter
+
+    app, _ = _app(tmp_path)
+    before = _directory_fingerprint(tmp_path)
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        raise AssertionError("forbidden capability reached")
+
+    monkeypatch.setattr(config_module, "jira_credentials", forbidden)
+    monkeypatch.setattr(config_module, "gitlab_credentials", forbidden)
+    monkeypatch.setattr(local_security_module, "email_hmac_key", forbidden)
+    monkeypatch.setattr(LocalGitAdapter, "__init__", forbidden)
+    monkeypatch.setattr(JiraAdapter, "__init__", forbidden)
+    monkeypatch.setattr(GitLabAdapter, "__init__", forbidden)
+    monkeypatch.setattr(httpx.Client, "__init__", forbidden)
+    monkeypatch.setattr(socket.socket, "connect", forbidden)
+    monkeypatch.setattr(subprocess, "run", forbidden)
+    monkeypatch.setattr(Path, "write_text", forbidden)
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        table = app.screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: table.row_count == 1)
+        await pilot.press("enter")
+        await _pause_until(
+            pilot,
+            lambda: isinstance(app.screen, ContributionScreen) and app.screen._review is not None,
+        )
+
+    assert _directory_fingerprint(tmp_path) == before
+
+
+@pytest.mark.asyncio
+async def test_stale_review_and_excerpt_results_are_ignored(tmp_path: Path) -> None:
+    from worktrace.tui.messages import ContributionReviewLoaded, EvidenceExcerptLoaded
+
+    app, _ = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        table = app.screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: table.row_count == 1)
+        await pilot.press("enter")
+        await _pause_until(
+            pilot,
+            lambda: isinstance(app.screen, ContributionScreen) and app.screen._review is not None,
+        )
+        screen = app.screen
+        assert isinstance(screen, ContributionScreen)
+        assert screen._review is not None
+        current = screen._review
+        screen.on_contribution_review_loaded(
+            ContributionReviewLoaded(
+                screen._review_request_id - 1,
+                replace(current, status="stale result"),
+            )
+        )
+        assert screen._review is current
+        stale_excerpt_request_id = screen._excerpt_request_id
+        screen.action_refresh()
+        screen.on_evidence_excerpt_loaded(
+            EvidenceExcerptLoaded(
+                stale_excerpt_request_id,
+                {"evidence_id": "obs:stale", "app_id": "sample_store"},
+            )
+        )
+        assert app.screen is screen
+        await _pause_until(
+            pilot,
+            lambda: (
+                "Read-only review loaded"
+                in str(screen.query_one("#contribution-message", Static).render())
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_rapid_screen_replacement_has_no_deferred_widget_callbacks(tmp_path: Path) -> None:
+    from textual.widgets import Header
+
+    app, _ = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        for _ in range(4):
+            app.show_applications()
+            app.open_application("sample_store")
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        await pilot.pause()
+        assert app.screen.query_one("#candidate-table", DataTable) is not None
+        assert list(app.query(Header)) == []
+
+
+def test_no_color_is_honored_in_a_fresh_process() -> None:
+    script = """
+import asyncio
+from worktrace.tui.app import WorkTraceApp
+
+class EmptyWorkspace:
+    def applications(self):
+        return ()
+
+async def main():
+    app = WorkTraceApp(EmptyWorkspace())
+    async with app.run_test(size=(80, 24)) as pilot:
+        for _ in range(4):
+            await pilot.pause()
+        assert 'nocolor' in app.pseudo_classes
+
+asyncio.run(main())
+"""
+    environment = dict(os.environ)
+    environment["NO_COLOR"] = "1"
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -11,12 +11,13 @@ from pathlib import Path
 
 import pytest
 from rich.text import Text
+from textual.containers import VerticalScroll
 from textual.screen import Screen
 from textual.widgets import DataTable, Static, TabbedContent
 
 from tests.test_packets_golden import _packet_state
 from worktrace.read_workspace import ReadOnlyWorkspace
-from worktrace.tui.app import SmallTerminalScreen, WorkTraceApp
+from worktrace.tui.app import HelpModal, SmallTerminalScreen, WorkTraceApp
 from worktrace.tui.modals.evidence import EvidenceModal
 from worktrace.tui.screens.applications import ApplicationScreen
 from worktrace.tui.screens.candidates import CandidateScreen
@@ -160,11 +161,42 @@ async def test_compact_terminal_reduces_candidate_columns(tmp_path: Path) -> Non
 
     async with app.run_test(size=(70, 18)) as pilot:
         assert isinstance(app.screen, SmallTerminalScreen)
+        terminal_dialog = app.screen.query_one("#terminal-dialog", Static)
+        assert terminal_dialog.size.width <= 70
+        assert terminal_dialog.size.height <= 18
         await pilot.press("c")
         await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
         table = app.screen.query_one("#candidate-table", DataTable)
         assert len(table.columns) == 4
         assert app.compact_mode is True
+
+
+@pytest.mark.asyncio
+async def test_compact_help_scrolls_to_final_commands_and_q_closes(tmp_path: Path) -> None:
+    app, _ = _app(tmp_path)
+
+    async with app.run_test(size=(70, 18)) as pilot:
+        assert isinstance(app.screen, SmallTerminalScreen)
+        await pilot.press("c")
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidate_screen = app.screen
+        await pilot.press("?")
+        await _pause_until(pilot, lambda: isinstance(app.screen, HelpModal))
+        help_modal = app.screen
+        assert isinstance(help_modal, HelpModal)
+        help_scroll = help_modal.query_one("#help-dialog", VerticalScroll)
+        help_content = help_modal.query_one("#help-content", Static)
+        assert help_scroll.has_focus
+        assert help_scroll.size.width <= 70
+        assert help_scroll.size.height <= 18
+        assert help_scroll.max_scroll_y > 0
+        assert "1-5     Contribution tabs" in help_content.render().plain
+
+        await pilot.press("end")
+        await pilot.pause()
+        assert help_scroll.scroll_y == help_scroll.max_scroll_y
+        await pilot.press("q")
+        assert app.screen is candidate_screen
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui_cli.py
+++ b/tests/test_tui_cli.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import builtins
+import io
+import os
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+import worktrace.cli as cli
+from tests.test_cli import _write_config
+from worktrace.cli import _TUI_ENVIRONMENT_VARIABLES, app, launch_ui
+from worktrace.db.connection import connect
+from worktrace.db.migrations import migrate
+
+
+class _TTY(io.StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+def _initialized_config(tmp_path: Path) -> Path:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    config_path = _write_config(tmp_path, repository)
+    database_path = tmp_path / "data" / "worktrace.sqlite3"
+    database_path.parent.mkdir()
+    connection = connect(database_path)
+    try:
+        migrate(connection, database_path)
+    finally:
+        connection.close()
+    return config_path
+
+
+def test_ui_rejects_non_tty_without_importing_textual() -> None:
+    script = """
+import sys
+from typer.testing import CliRunner
+from worktrace.cli import app
+assert 'textual' not in sys.modules
+result = CliRunner().invoke(app, ['ui'])
+assert result.exit_code == 2, result.output
+assert 'requires an interactive terminal' in result.output
+assert 'textual' not in sys.modules
+assert 'worktrace.tui.app' not in sys.modules
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+
+
+def test_candidate_option_requires_app_before_launch() -> None:
+    result = CliRunner().invoke(app, ["ui", "--candidate", "candidate:phase4"])
+
+    assert result.exit_code == 2
+    assert "--candidate requires --app" in result.output
+
+
+def test_ui_scrubs_environment_before_importing_tui(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_path = _initialized_config(tmp_path)
+    for name in _TUI_ENVIRONMENT_VARIABLES:
+        monkeypatch.setenv(name, "must-not-survive")
+    monkeypatch.setattr(cli.sys, "stdin", _TTY())
+    monkeypatch.setattr(cli.sys, "stdout", _TTY())
+    imported: list[str] = []
+    fake_module = types.ModuleType("worktrace.tui.app")
+
+    def fake_run(*args: object, **kwargs: object) -> None:
+        imported.append("run")
+
+    fake_module.run_worktrace_ui = fake_run  # type: ignore[attr-defined]
+    original_import = builtins.__import__
+
+    def guarded_import(
+        name: str,
+        globals: dict[str, object] | None = None,
+        locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        if name == "worktrace.tui.app":
+            assert all(name not in os.environ for name in _TUI_ENVIRONMENT_VARIABLES)
+            return fake_module
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    launch_ui(app_id="sample_store", candidate_id=None, config=config_path)
+
+    assert imported == ["run"]
+    assert all(name not in os.environ for name in _TUI_ENVIRONMENT_VARIABLES)

--- a/tests/test_tui_packaging.py
+++ b/tests/test_tui_packaging.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from importlib.resources import files
+
+
+def test_tui_stylesheet_is_packaged_as_a_resource() -> None:
+    stylesheet = files("worktrace.tui").joinpath("worktrace.tcss")
+
+    assert stylesheet.is_file()

--- a/tests/test_tui_terminal_text.py
+++ b/tests/test_tui_terminal_text.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from worktrace.tui.terminal_text import literal_dynamic_text, terminal_safe_text
+
+
+def test_terminal_safe_text_encodes_full_control_and_bidi_corpus() -> None:
+    controls = "".join(chr(value) for value in range(0x20) if value not in {0x09, 0x0A})
+    c1 = "".join(chr(value) for value in range(0x80, 0xA0))
+    bidi = "\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069"
+    source = (
+        "ordinary Ω\n\ttab"
+        + controls
+        + "\x1b[31m"
+        + "\x1b]8;;https://example.test\x07link\x1b]8;;\x1b\\"
+        + "\x1b]52;c;Y29weQ==\x07"
+        + "\x1bPpayload\x1b\\"
+        + c1
+        + "\x7f\u2028\u2029"
+        + bidi
+        + "\ud800\udfff"
+        + "[bold][@click=app.quit]literal[/]"
+    )
+
+    encoded = terminal_safe_text(source, max_output_chars=20_000)
+
+    assert "ordinary Ω\n    tab" in encoded.text
+    assert "<ESC>[31m" in encoded.text
+    assert "<RLO>" in encoded.text
+    assert "<U+D800><U+DFFF>" in encoded.text
+    assert "[bold][@click=app.quit]literal[/]" in encoded.text
+    assert encoded.encoded_control_count > 70
+    assert encoded.truncated is False
+    assert all(character == "\n" or ord(character) >= 0x20 for character in encoded.text)
+    assert not any(0x7F <= ord(character) <= 0x9F for character in encoded.text)
+
+
+def test_terminal_safe_text_bounds_replacement_expansion() -> None:
+    assert terminal_safe_text("unsafe\x1b", max_output_chars=0).text == ""
+    for bound in (1, 3, 5, 10, 24):
+        encoded = terminal_safe_text("\x1b" * 100, max_output_chars=bound)
+        assert len(encoded.text) <= bound
+        assert encoded.truncated is True
+        assert "\x1b" not in encoded.text
+
+
+def test_literal_dynamic_text_has_no_markup_spans_or_links() -> None:
+    rendered = literal_dynamic_text("[bold][@click=app.quit]literal[/][/]")
+
+    assert rendered.plain == "[bold][@click=app.quit]literal[/][/]"
+    assert rendered.spans == []

--- a/tests/tui_support.py
+++ b/tests/tui_support.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import replace
+from pathlib import Path
+
+from worktrace.config import AppConfig, WorkTraceConfig
+
+
+def add_second_application(
+    connection: sqlite3.Connection,
+    config: WorkTraceConfig,
+    root: Path,
+) -> WorkTraceConfig:
+    other = AppConfig(
+        id="other_app",
+        name="Other App",
+        market="YY",
+        business_type="fixture",
+        jira_project_keys=(),
+        gitlab_project_ids=(),
+        repo_paths=(root / "other-repo",),
+        jira_key_patterns=(),
+        production_environments=(),
+        release_tag_patterns=(),
+        ignored_paths=(),
+    )
+    connection.execute(
+        "INSERT INTO apps(id, name, market, business_type) VALUES (?, ?, ?, ?)",
+        (other.id, other.name, other.market, other.business_type),
+    )
+    connection.execute(
+        """
+        INSERT INTO sync_runs(
+            id, app_id, source, source_instance, status, started_at, completed_at,
+            adapter_version, scope_json, completeness
+        ) VALUES (
+            'run:other', 'other_app', 'manual', 'local', 'complete',
+            '2026-08-30T12:00:00+00:00', '2026-08-30T12:00:00+00:00',
+            'fixture', '{}', 'complete_for_scope'
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO source_objects(
+            id, app_id, source, source_instance, kind, external_id,
+            first_seen_run_id, last_seen_run_id
+        ) VALUES (
+            'obj:other', 'other_app', 'manual', 'local', 'manual_evidence', 'other',
+            'run:other', 'run:other'
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO observations(
+            id, source_object_id, sync_run_id, source_updated_at, fetched_at,
+            payload_hash, title, body_text, data_json, completeness,
+            adapter_version, normalization_version, redaction_version
+        ) VALUES (
+            'obs:other', 'obj:other', 'run:other', '2026-08-30T12:00:00+00:00',
+            '2026-08-30T12:00:00+00:00', 'hash-other', 'Other title', 'Other body', '{}',
+            'complete', 'fixture', '1', '1'
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO candidate_groups(
+            id, app_id, seed_object_id, generator_version, suggested_title,
+            suggested_type, generated_at
+        ) VALUES (
+            'candidate:other', 'other_app', 'obj:other', 'fixture-v1', 'Other title',
+            'feature', '2026-08-30T12:00:00+00:00'
+        )
+        """
+    )
+    connection.execute(
+        "INSERT INTO candidate_members VALUES ('candidate:other', 'obj:other', 'fixture', 0)"
+    )
+    connection.commit()
+    return replace(config, apps=(*config.apps, other))
+
+
+def add_visible_candidate_page(connection: sqlite3.Connection, *, count: int = 30) -> None:
+    generation = connection.execute(
+        "SELECT generated_at, generator_version FROM candidate_groups LIMIT 1"
+    ).fetchone()
+    assert generation is not None
+    connection.executemany(
+        """
+        INSERT INTO source_objects(
+            id, app_id, source, source_instance, kind, external_id,
+            first_seen_run_id, last_seen_run_id
+        ) VALUES (?, 'sample_store', 'manual', 'local', 'manual_evidence', ?,
+                  'run:manual', 'run:manual')
+        """,
+        [(f"obj:paged-{index:02d}", f"paged-{index:02d}") for index in range(count)],
+    )
+    connection.executemany(
+        """
+        INSERT INTO observations(
+            id, source_object_id, sync_run_id, source_updated_at, fetched_at,
+            payload_hash, title, body_text, data_json, completeness,
+            adapter_version, normalization_version, redaction_version
+        ) VALUES (?, ?, 'run:manual', '2026-08-26T12:00:00+00:00',
+                  '2026-08-26T12:00:00+00:00', ?, ?, 'Synthetic page evidence.', '{}',
+                  'complete', 'fixture', '1', '1')
+        """,
+        [
+            (
+                f"obs:paged-{index:02d}",
+                f"obj:paged-{index:02d}",
+                f"hash-paged-{index:02d}",
+                f"Paged candidate {index:02d}",
+            )
+            for index in range(count)
+        ],
+    )
+    connection.executemany(
+        """
+        INSERT INTO candidate_groups(
+            id, app_id, seed_object_id, generator_version, suggested_title,
+            suggested_type, generated_at
+        ) VALUES (?, 'sample_store', ?, ?, ?, 'feature', ?)
+        """,
+        [
+            (
+                f"candidate:paged-{index:02d}",
+                f"obj:paged-{index:02d}",
+                str(generation["generator_version"]),
+                f"Paged candidate {index:02d}",
+                str(generation["generated_at"]),
+            )
+            for index in range(count)
+        ],
+    )
+    connection.executemany(
+        """
+        INSERT INTO candidate_members(
+            candidate_id, source_object_id, membership_reason, context_only
+        ) VALUES (?, ?, 'fixture', 0)
+        """,
+        [(f"candidate:paged-{index:02d}", f"obj:paged-{index:02d}") for index in range(count)],
+    )
+    connection.commit()

--- a/uv.lock
+++ b/uv.lock
@@ -531,6 +531,15 @@ wheels = [
 ]
 
 [[package]]
+name = "linkify-it-py"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/98/7a1a5f31fd5c7ba93e963b168e244b8e3dd705b3d2a718e3c3307583bf57/linkify_it_py-2.2.0.tar.gz", hash = "sha256:907acd2d17ac1fbb9ddb62c8957ccbd6158cac602231a15c3b0cd1e215f03cee", size = 32939, upload-time = "2026-08-29T07:07:08.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/d4/1152d1c7ab42d8b908be64fd200ddc870dc9d4925e951198702084aa1a7d/linkify_it_py-2.2.0-py3-none-any.whl", hash = "sha256:3adc40eb5af300b2605fcfdb968c24e1d780a90f1f2221af7c15e5111e94d443", size = 21971, upload-time = "2026-08-29T07:07:07.164Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -540,6 +549,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -578,6 +592,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -669,6 +695,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/06/cf1564dcc2e2261c8c8c6c05628dc8b418943bdae2a4e58640ceb2f770fa/platformdirs-4.11.5.tar.gz", hash = "sha256:e8b31f4f8bcbbedef91a6b57a706255e4f148d2a4e01648382a0a47342539173", size = 34823, upload-time = "2026-08-27T21:36:37.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl", hash = "sha256:89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b", size = 23900, upload-time = "2026-08-27T21:36:36.227Z" },
 ]
 
 [[package]]
@@ -1055,6 +1090,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
 name = "truststore"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1119,6 +1171,7 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "mcp" },
+    { name = "textual" },
     { name = "typer" },
 ]
 
@@ -1136,6 +1189,7 @@ dev = [
 requires-dist = [
     { name = "httpx", specifier = ">=0.28,<1" },
     { name = "mcp", specifier = ">=2,<3" },
+    { name = "textual", specifier = ">=8.2.8,<9" },
     { name = "typer", specifier = ">=0.16,<1" },
 ]
 


### PR DESCRIPTION
## Summary

- **Adds the complete `worktrace ui` review journey** — engineers can select an application, inspect honest source-attempt status, browse bounded candidate pages, review Summary/Evidence/Participation/Delivery/Questions, and open a bounded evidence excerpt without reading raw JSON.
- **Keeps the interface structurally read-only** — one narrow `ReadOnlyWorkspace` opens short-lived SQLite `mode=ro`, query-only, 500 ms connections inside Textual workers; the TUI constructs no provider, network, decision, migration, maintenance, export, or configuration capability.
- **Makes terminal presentation an explicit security boundary** — all dynamic text is control/bidi encoded and rendered as literal Rich `Text`; selection-copy and default screenshot commands are removed, while explicit clipboard actions accept only validated stable WorkTrace IDs.
- **Preserves evidence semantics and automation contracts** — candidate paging reuses the generation-bound Issue #10 query, contribution review builds one canonical Phase 4 v2 packet and derives gaps from that same packet, evidence and source-object IDs remain distinct, and all six MCP tools plus existing CLI JSON behavior are unchanged.
- **Ships the complete installed product, not a shell** — Textual 8.2.8 is locked, TCSS is packaged in the wheel, README/limitations describe the actual boundary, and synthetic behavioral/security tests cover 80x24, 120x40, below-size compact mode, stale workers, deep-link scope, and capability denial.

## Product workflow

```text
worktrace ui
  → select application when needed
  → inspect latest source-attempt status
  → browse a bounded candidate page
  → review Summary / Evidence / Participation / Delivery / Questions
  → inspect one literal bounded evidence excerpt
```

The UI never claims ownership, productivity, promotion value, or delivery-state implication. Unknown, partial, human-attested, contradicted, stale, unavailable, and unsupported-current states remain visible.

## Authority and disclosure boundary

- TTY validation and `--candidate`/`--app` validation occur before Textual launch.
- Provider credential/HMAC variables and Textual driver/log/input/screenshot variables are removed before the TUI import.
- Every workspace operation creates and closes its own read-only connection; no connection remains while the user is idle or crosses threads.
- The command palette is a fixed allowlist and never calls Textual's default system-command provider.
- All screens and modals disable selection-copy; only designated validated IDs reach `copy_to_clipboard`.
- Provider URLs remain non-clickable and no application action copies bodies, packets, titles, errors, or URLs.
- These controls reduce accidental disclosure; they do not prevent OS screenshots, terminal-emulator selection, photography, or terminal logging by the authorized local user.

## Verification

- `uv run pytest` — 265 passed
- `uv run coverage run -m pytest` — 265 passed
- `uv run coverage report` — 85% branch coverage
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run mypy src` — 69 source files
- `uv build` — sdist and wheel built
- isolated installed-wheel smoke:
  - `worktrace ui --help`
  - non-TTY `worktrace ui` exits 2 before launch
  - `ReadOnlyWorkspace`, `WorkTraceApp`, and terminal encoder import
  - packaged `worktrace/tui/worktrace.tcss` resolves through `importlib.resources`
- `git diff --check`

The runtime defects found during independent team verification—initial screen replacement, evidence selection events, tab focus, compact dead state, clipped source health, stale excerpt workers, and Textual Header mount races—are covered by deterministic regressions.

## Deliberate limits

Synthetic SQLite, headless Textual, and isolated-wheel tests do not establish live Jira/GitLab behavior, proprietary-ledger parity, every terminal emulator, or full screen-reader accessibility. No live provider access is part of this read-only release.

## Glossary

| Term | Definition |
|---|---|
| ReadOnlyWorkspace | The narrow TUI data boundary that creates one short-lived query-only SQLite connection per operation. |
| Generation-bound cursor | A candidate cursor tied to one deterministic rebuild so stale navigation fails explicitly. |
| Literal renderable | A Rich `Text` value created without markup interpretation after terminal-control encoding. |
| Stable ID | A validated WorkTrace identity such as a candidate, contribution, observation, or source-object ID. |
| Phase 4 packet | The canonical 30-question evidence projection used for contribution review and gap derivation. |
| Compact mode | The below-recommended-size drill-down layout that removes optional columns without removing required information or actions. |

Closes #11
Refs #6
Refs AgDR-0005

