### PR TITLE
fix(#18): keep contribution review on one snapshot

### DIFF
--- a/src/worktrace/read_workspace.py
+++ b/src/worktrace/read_workspace.py
@@ -116,6 +116,20 @@ class ReadOnlyWorkspace:
             if connection is not None:
                 connection.close()
 
+    @contextmanager
+    def _read_snapshot(self) -> Iterator[sqlite3.Connection]:
+        with self._connection() as connection:
+            connection.execute("BEGIN")
+            try:
+                yield connection
+            except BaseException:
+                if connection.in_transaction:
+                    connection.execute("ROLLBACK")
+                raise
+            else:
+                if connection.in_transaction:
+                    connection.execute("COMMIT")
+
     def applications(self) -> tuple[ApplicationSummary, ...]:
         with self._connection():
             return tuple(
@@ -161,7 +175,7 @@ class ReadOnlyWorkspace:
 
     def contribution_review(self, app_id: str, candidate_id: str) -> ContributionReview:
         self._config.app(app_id)
-        with self._connection() as connection:
+        with self._read_snapshot() as connection:
             projected = project_candidate(connection, candidate_id)
             if projected.app_id != app_id:
                 raise ScopeViolation("candidate belongs to another application")
@@ -202,15 +216,15 @@ class ReadOnlyWorkspace:
                     )
                     for row in rows
                 )
-            return ContributionReview(
-                app_id=app_id,
-                candidate_id=candidate_id,
-                resolved_contribution_id=contribution_id,
-                status=projected.status,
-                packet=packet,
-                gaps=build_gap_report(packet),
-                unsupported_members=unsupported,
-            )
+        return ContributionReview(
+            app_id=app_id,
+            candidate_id=candidate_id,
+            resolved_contribution_id=contribution_id,
+            status=projected.status,
+            packet=packet,
+            gaps=build_gap_report(packet),
+            unsupported_members=unsupported,
+        )
 
     def evidence_excerpt(
         self,

--- a/tests/test_read_workspace.py
+++ b/tests/test_read_workspace.py
@@ -10,6 +10,8 @@ import pytest
 
 import worktrace.read_workspace as read_workspace_module
 from tests.test_packets_golden import _packet_state
+from worktrace.candidates.decisions import append_decision
+from worktrace.db.connection import connect
 from worktrace.errors import ScopeViolation
 from worktrace.read_workspace import (
     DatabaseBusy,
@@ -74,6 +76,132 @@ def test_workspace_builds_packet_once_and_derives_gaps_from_same_object(
 
     assert len(packet_ids) == 1
     assert gap_packet_ids == packet_ids
+
+
+def test_contribution_review_uses_one_snapshot_during_concurrent_decision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, candidate_id = _workspace(tmp_path)
+    journal = sqlite3.connect(workspace.database_path, autocommit=True)
+    try:
+        assert str(journal.execute("PRAGMA journal_mode = WAL").fetchone()[0]) == "wal"
+    finally:
+        journal.close()
+
+    baseline = workspace.contribution_review("sample_store", candidate_id)
+    summary = baseline.packet["evidence_summary"]
+    assert isinstance(summary, dict)
+    members = summary["members"]
+    assert isinstance(members, list)
+    member_ids = [
+        str(member["object_id"])
+        for member in members
+        if isinstance(member, dict) and member.get("object_id")
+    ]
+    baseline_contribution = baseline.packet["contribution"]
+    assert isinstance(baseline_contribution, dict)
+    baseline_signature = (
+        baseline.status,
+        baseline_contribution.get("title"),
+        baseline_contribution.get("title_authority"),
+        baseline_contribution.get("title_status"),
+    )
+
+    projection_ready = threading.Event()
+    writer_committed = threading.Event()
+    original_project_candidate = read_workspace_module.project_candidate
+    paused = False
+
+    def project_then_pause(*args: Any, **kwargs: Any) -> Any:
+        nonlocal paused
+        projected = original_project_candidate(*args, **kwargs)
+        if not paused:
+            paused = True
+            projection_ready.set()
+            assert writer_committed.wait(timeout=5)
+        return projected
+
+    monkeypatch.setattr(read_workspace_module, "project_candidate", project_then_pause)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(workspace.contribution_review, "sample_store", candidate_id)
+        assert projection_ready.wait(timeout=5)
+        writer = connect(workspace.database_path)
+        try:
+            append_decision(
+                writer,
+                "confirm_candidate",
+                candidate_id,
+                {
+                    "contribution_id": "contribution:concurrent-confirmation",
+                    "app_id": "sample_store",
+                    "title": "Concurrent human-reviewed title",
+                    "members": member_ids,
+                },
+            )
+        finally:
+            writer.close()
+            writer_committed.set()
+        interleaved = future.result(timeout=5)
+
+    interleaved_contribution = interleaved.packet["contribution"]
+    assert isinstance(interleaved_contribution, dict)
+    assert (
+        interleaved.status,
+        interleaved_contribution.get("title"),
+        interleaved_contribution.get("title_authority"),
+        interleaved_contribution.get("title_status"),
+    ) == baseline_signature
+
+    settled = workspace.contribution_review("sample_store", candidate_id)
+    settled_contribution = settled.packet["contribution"]
+    assert isinstance(settled_contribution, dict)
+    assert settled.status == "confirmed"
+    assert settled_contribution["title"] == "Concurrent human-reviewed title"
+
+
+def test_contribution_review_rolls_back_snapshot_before_closing_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, candidate_id = _workspace(tmp_path)
+    original_connect = read_workspace_module.connect_read_only
+    events: list[str | tuple[str, bool]] = []
+
+    class TrackingConnection:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self.connection = connection
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self.connection, name)
+
+        def execute(self, sql: str, *args: object) -> sqlite3.Cursor:
+            command = sql.strip().split(maxsplit=1)[0].upper()
+            if command in {"BEGIN", "COMMIT", "ROLLBACK"}:
+                events.append(command)
+            return self.connection.execute(sql, *args)
+
+        def close(self) -> None:
+            events.append(("CLOSE", self.connection.in_transaction))
+            self.connection.close()
+
+    def tracking_connect(path: Path, *, busy_timeout_ms: int) -> Any:
+        return TrackingConnection(original_connect(path, busy_timeout_ms=busy_timeout_ms))
+
+    def fail_packet(*args: object, **kwargs: object) -> dict[str, object]:
+        raise RuntimeError("synthetic packet failure")
+
+    monkeypatch.setattr(read_workspace_module, "connect_read_only", tracking_connect)
+    monkeypatch.setattr(read_workspace_module.PacketBuilder, "build_packet", fail_packet)
+
+    with pytest.raises(RuntimeError, match="synthetic packet failure"):
+        workspace.contribution_review("sample_store", candidate_id)
+
+    assert events.count("BEGIN") == 1
+    assert events.count("ROLLBACK") == 1
+    assert "COMMIT" not in events
+    assert events[-1] == ("CLOSE", False)
 
 
 def test_workspace_connection_is_worker_created_query_only_500ms_and_closed(
@@ -153,13 +281,13 @@ def test_workspace_reports_older_and_newer_database_versions(tmp_path: Path) -> 
         writer.close()
 
 
-def test_workspace_bounds_lock_contention_to_busy_error(tmp_path: Path) -> None:
-    workspace, _ = _workspace(tmp_path)
+def test_contribution_review_bounds_lock_contention_to_busy_error(tmp_path: Path) -> None:
+    workspace, candidate_id = _workspace(tmp_path)
     blocker = sqlite3.connect(workspace.database_path, timeout=0.1, isolation_level=None)
     try:
         blocker.execute("BEGIN EXCLUSIVE")
         with pytest.raises(DatabaseBusy):
-            workspace.applications()
+            workspace.contribution_review("sample_store", candidate_id)
     finally:
         blocker.execute("ROLLBACK")
         blocker.close()


### PR DESCRIPTION
## Summary
- Wraps one contribution review in an explicit SQLite read transaction so its candidate status, packet, and unsupported-member metadata describe the same committed state.
- Derives gaps from the already-built packet after the read transaction, shortening snapshot lifetime without changing the public DTO or packet semantics.
- Adds deterministic concurrency, rollback, and lock-contention regressions so the original mixed-state failure cannot silently return.

## Scope
This PR changes only ReadOnlyWorkspace snapshot composition and its focused tests. Runtime WAL policy, SQLite autocommit configuration, PacketBuilder, candidate paging, CLI behavior, and all six MCP contracts remain unchanged.

## Verification
- [x] uv run pytest - 267 passed
- [x] uv run coverage run -m pytest - 267 passed
- [x] uv run coverage report - 85% branch coverage
- [x] uv run ruff format --check .
- [x] uv run ruff check .
- [x] uv run mypy src
- [x] uv build
- [x] isolated installed-wheel worktrace version smoke
- [x] deterministic temporary WAL-backed interleaved-writer regression
- [x] rollback-before-close and 500 ms DatabaseBusy regression

## Risk and rollback
The transaction is read-only, short-lived, and scoped only to contribution_review(). Reverting this commit restores the previous behavior without a schema or data migration.

## QA
- Verify a concurrent decision yields a wholly old review while the next refresh yields the wholly new review.
- Verify normal contribution review and evidence navigation remain unchanged.
- Verify lock contention returns the existing sanitized busy message.

## Glossary
| Term | Definition |
|------|------------|
| Read snapshot | One SQLite state shared by all related SELECT operations in a review. |
| Interleaved writer | A separate valid CLI connection that commits while the TUI read is in progress. |
| Packet | The canonical evidence-backed Phase 4 contribution projection. |

Refs #18
Parent: #17
Related: #3
