### PR TITLE
fix(#19): serialize candidate paging and normalize TUI screen stack

### DIFF
--- a/src/worktrace/tui/app.py
+++ b/src/worktrace/tui/app.py
@@ -14,6 +14,7 @@ from textual.widgets import Footer, Static
 from worktrace.mcp_server.schemas import stable_id
 from worktrace.read_workspace import ApplicationSummary, ReadOnlyWorkspace
 from worktrace.tui.messages import ApplicationsLoaded, FailureKind, ReadFailed, failure_kind
+from worktrace.tui.modals.evidence import EvidenceModal
 from worktrace.tui.screens.applications import ApplicationScreen
 from worktrace.tui.screens.base import WorkTraceModal, WorkTraceScreen
 from worktrace.tui.screens.candidates import CandidateScreen
@@ -22,6 +23,12 @@ from worktrace.tui.screens.contribution import ContributionScreen
 # Below this width the candidate browser uses the four-column compact table; the
 # six-column full layout is reserved for the documented full terminal size.
 _FULL_LAYOUT_WIDTH = 120
+
+
+def _uses_compact_layout(width: int, height: int) -> bool:
+    """Return the fixed launch-time layout choice for a usable terminal."""
+    return width < _FULL_LAYOUT_WIDTH or height < 24
+
 
 _HELP_TEXT = """WorkTrace read-only review
 
@@ -174,19 +181,41 @@ class WorkTraceApp(App[None], inherit_bindings=False):
         if self.size.width < 80 or self.size.height < 24:
             self.push_screen(SmallTerminalScreen(), self._after_terminal_check)
         else:
-            self.compact_mode = self.size.width < _FULL_LAYOUT_WIDTH
+            self.compact_mode = _uses_compact_layout(self.size.width, self.size.height)
             self.action_restart()
 
     def _after_terminal_check(self, proceed: bool | None) -> None:
         if proceed:
-            self.compact_mode = self.size.width < _FULL_LAYOUT_WIDTH
+            self.compact_mode = _uses_compact_layout(self.size.width, self.size.height)
             self.action_restart()
 
     def get_system_commands(self, screen: Screen[object]) -> Iterable[SystemCommand]:
+        if isinstance(screen, HelpModal):
+            yield SystemCommand("Close", "Close keyboard help", screen.dismiss)
+            yield SystemCommand("Quit", "Quit WorkTrace", self.action_quit)
+            return
+        if isinstance(screen, EvidenceModal):
+            yield SystemCommand("Close", "Close evidence excerpt", screen.dismiss)
+            yield SystemCommand(
+                "Copy evidence ID",
+                "Copy the validated WorkTrace evidence ID",
+                self.action_copy_selected_id,
+            )
+            yield SystemCommand("Quit", "Quit WorkTrace", self.action_quit)
+            return
+        if isinstance(screen, SmallTerminalScreen):
+            yield SystemCommand(
+                "Continue compact",
+                "Continue using the compact layout",
+                screen.action_continue_compact,
+            )
+            yield SystemCommand("Recheck terminal", "Recheck terminal size", screen.action_recheck)
+            yield SystemCommand("Quit", "Quit WorkTrace", self.action_quit)
+            return
         yield SystemCommand("Quit", "Quit WorkTrace", self.action_quit)
         if isinstance(screen, ModalScreen):
-            # Only quitting is safe to offer while a modal screen is active;
-            # navigation and refresh commands would restructure screens beneath it.
+            # Unknown modal screens remain constrained to quitting rather than
+            # restructuring screens beneath the modal.
             return
         yield SystemCommand("Keyboard help", "Show safe keyboard commands", self.action_show_help)
         yield SystemCommand(

--- a/src/worktrace/tui/app.py
+++ b/src/worktrace/tui/app.py
@@ -17,6 +17,11 @@ from worktrace.tui.messages import ApplicationsLoaded, FailureKind, ReadFailed, 
 from worktrace.tui.screens.applications import ApplicationScreen
 from worktrace.tui.screens.base import WorkTraceModal, WorkTraceScreen
 from worktrace.tui.screens.candidates import CandidateScreen
+from worktrace.tui.screens.contribution import ContributionScreen
+
+# Below this width the candidate browser uses the four-column compact table; the
+# six-column full layout is reserved for the documented full terminal size.
+_FULL_LAYOUT_WIDTH = 120
 
 _HELP_TEXT = """WorkTrace read-only review
 
@@ -169,15 +174,20 @@ class WorkTraceApp(App[None], inherit_bindings=False):
         if self.size.width < 80 or self.size.height < 24:
             self.push_screen(SmallTerminalScreen(), self._after_terminal_check)
         else:
+            self.compact_mode = self.size.width < _FULL_LAYOUT_WIDTH
             self.action_restart()
 
     def _after_terminal_check(self, proceed: bool | None) -> None:
         if proceed:
-            self.compact_mode = self.size.width < 80 or self.size.height < 24
+            self.compact_mode = self.size.width < _FULL_LAYOUT_WIDTH
             self.action_restart()
 
     def get_system_commands(self, screen: Screen[object]) -> Iterable[SystemCommand]:
         yield SystemCommand("Quit", "Quit WorkTrace", self.action_quit)
+        if isinstance(screen, ModalScreen):
+            # Only quitting is safe to offer while a modal screen is active;
+            # navigation and refresh commands would restructure screens beneath it.
+            return
         yield SystemCommand("Keyboard help", "Show safe keyboard commands", self.action_show_help)
         yield SystemCommand(
             "Switch application",
@@ -185,7 +195,7 @@ class WorkTraceApp(App[None], inherit_bindings=False):
             self.action_switch_application,
         )
         yield SystemCommand("Refresh", "Refresh the current read-only view", self.action_refresh)
-        if isinstance(screen, (CandidateScreen,)) is False and self.current_app_id is not None:
+        if isinstance(screen, ContributionScreen) and self.current_app_id is not None:
             yield SystemCommand(
                 "Return to candidates",
                 "Return to the selected application's candidate page",
@@ -202,10 +212,15 @@ class WorkTraceApp(App[None], inherit_bindings=False):
         self.load_applications(request_id)
 
     def _show_screen(self, screen: Screen[None]) -> None:
-        if self.screen.id == "_default":
-            self.push_screen(screen)
-        else:
-            self.switch_screen(screen)
+        """Reset the stack to exactly one visible base screen.
+
+        Popping back to the default screen before pushing removes hidden nested
+        screens left by earlier navigation, so application switching and global
+        restarts can never stack a new screen above a stale one.
+        """
+        while len(self.screen_stack) > 1:
+            self.pop_screen()
+        self.push_screen(screen)
 
     def action_show_help(self) -> None:
         self.push_screen(HelpModal())
@@ -221,8 +236,26 @@ class WorkTraceApp(App[None], inherit_bindings=False):
             self.action_restart()
 
     def action_return_to_candidates(self) -> None:
-        if self.current_app_id is not None:
-            self.open_application(self.current_app_id)
+        if self.current_app_id is None:
+            return
+        if self._pop_to_candidate(self.current_app_id):
+            return
+        self.open_application(self.current_app_id)
+
+    def _pop_to_candidate(self, app_id: str) -> bool:
+        """Reveal an existing CandidateScreen for app_id, preserving its state.
+
+        Returns True when the running CandidateScreen was revealed; everything
+        above it (contribution review, modals) is popped so the stack depth and
+        the candidate row, cursor history, and page position are restored.
+        """
+        for index in range(len(self.screen_stack) - 1, -1, -1):
+            screen = self.screen_stack[index]
+            if isinstance(screen, CandidateScreen) and screen.application.app_id == app_id:
+                while len(self.screen_stack) - 1 > index:
+                    self.pop_screen()
+                return True
+        return False
 
     def action_copy_selected_id(self) -> None:
         selected = getattr(self.screen, "selected_stable_id", lambda: None)()
@@ -317,8 +350,6 @@ class WorkTraceApp(App[None], inherit_bindings=False):
         *,
         return_to_existing: bool,
     ) -> None:
-        from worktrace.tui.screens.contribution import ContributionScreen
-
         self.current_app_id = app_id
         screen = ContributionScreen(
             app_id,

--- a/src/worktrace/tui/screens/candidates.py
+++ b/src/worktrace/tui/screens/candidates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
 
 from rich.text import Text
 from textual import work
@@ -23,6 +23,11 @@ from worktrace.tui.terminal_text import literal_dynamic_text
 
 if TYPE_CHECKING:
     from worktrace.tui.app import WorkTraceApp
+
+# A page load is one navigation action at a time. "next"/"previous" commit the
+# cursor history only when their page loads successfully; "restart" lands on
+# page one (initial mount, refresh, and generation invalidation).
+_PageDirection = Literal["next", "previous", "restart"]
 
 
 _FAILURE_TEXT = {
@@ -116,7 +121,11 @@ class CandidateScreen(WorkTraceScreen):
         self.application = application
         self._source_request_id = 0
         self._page_request_id = 0
-        self._cursor_stack: list[CandidateCursor | None] = [None]
+        # Cursor history for the page currently displayed. It changes only when
+        # a page load succeeds; a pending navigation never mutates it.
+        self._committed_history: list[CandidateCursor | None] = [None]
+        self._pending_direction: _PageDirection | None = None
+        self._pending_cursor: CandidateCursor | None = None
         self._page: CandidatePage | None = None
         self._items: tuple[CandidateListItem, ...] = ()
 
@@ -145,17 +154,18 @@ class CandidateScreen(WorkTraceScreen):
             table.add_columns("State", "Contribution", "Authority", "Period", "Sources", "Roles")
         table.focus()
         self._load_source_status()
-        self._load_current_page()
+        self._begin_page_load(None, "restart")
 
     def refresh_data(self) -> None:
         self.action_refresh()
 
     def action_refresh(self) -> None:
-        self._cursor_stack = [None]
-        self._page = None
+        if self._page_load_in_flight():
+            self.app.notify("A candidate page is still loading.", markup=False)
+            return
         self.query_one("#candidate-message", Static).update("Refreshing read-only data…")
         self._load_source_status()
-        self._load_current_page()
+        self._begin_page_load(None, "restart")
 
     def action_cursor_down(self) -> None:
         focused = self.focused
@@ -172,18 +182,25 @@ class CandidateScreen(WorkTraceScreen):
             self.query_one("#candidate-table", DataTable).action_cursor_up()
 
     def action_next_page(self) -> None:
-        if self._page is None or self._page.next_cursor is None:
+        if self._page_load_in_flight():
+            self.app.notify("A candidate page is still loading.", markup=False)
+            return
+        if self._page is None:
+            self.app.notify("No candidate page is loaded. Press r to retry.", markup=False)
+            return
+        if self._page.next_cursor is None:
             self.app.notify("No later candidate page is available.", markup=False)
             return
-        self._cursor_stack.append(self._page.next_cursor)
-        self._load_current_page()
+        self._begin_page_load(self._page.next_cursor, "next")
 
     def action_previous_page(self) -> None:
-        if len(self._cursor_stack) == 1:
+        if self._page_load_in_flight():
+            self.app.notify("A candidate page is still loading.", markup=False)
+            return
+        if len(self._committed_history) == 1:
             self.app.notify("Already on the first candidate page.", markup=False)
             return
-        self._cursor_stack.pop()
-        self._load_current_page()
+        self._begin_page_load(self._committed_history[-2], "previous")
 
     def selected_stable_id(self) -> tuple[str, frozenset[str]] | None:
         table = self.query_one("#candidate-table", DataTable)
@@ -202,11 +219,16 @@ class CandidateScreen(WorkTraceScreen):
                 return_to_existing=True,
             )
 
-    def _load_current_page(self) -> None:
+    def _page_load_in_flight(self) -> bool:
+        return self._pending_direction is not None
+
+    def _begin_page_load(self, cursor: CandidateCursor | None, direction: _PageDirection) -> None:
         self._page_request_id += 1
         request_id = self._page_request_id
+        self._pending_direction = direction
+        self._pending_cursor = cursor
         self.query_one("#candidate-message", Static).update("Loading candidate page…")
-        self.load_candidate_page(request_id, self._cursor_stack[-1])
+        self.load_candidate_page(request_id, cursor)
 
     def _load_source_status(self) -> None:
         self._source_request_id += 1
@@ -245,6 +267,17 @@ class CandidateScreen(WorkTraceScreen):
     def on_candidate_page_loaded(self, message: CandidatePageLoaded) -> None:
         if message.request_id != self._page_request_id:
             return
+        direction = self._pending_direction
+        pending_cursor = self._pending_cursor
+        self._pending_direction = None
+        self._pending_cursor = None
+        if direction == "next":
+            self._committed_history.append(pending_cursor)
+        elif direction == "previous":
+            if len(self._committed_history) > 1:
+                self._committed_history.pop()
+        elif direction == "restart":
+            self._committed_history = [None]
         self._page = message.page
         self._items = message.page.items
         table = self.query_one("#candidate-table", DataTable)
@@ -280,7 +313,7 @@ class CandidateScreen(WorkTraceScreen):
                     "`worktrace rebuild candidates APP_ID` from the CLI."
                 )
         else:
-            state = f"Page {len(self._cursor_stack)} · {len(self._items)} candidates"
+            state = f"Page {len(self._committed_history)} · {len(self._items)} candidates"
             if message.page.next_cursor is not None and len(self._items) < 25:
                 state += " · hidden or unavailable candidates were skipped; press n to continue"
         self.query_one("#candidate-message", Static).update(state)
@@ -293,9 +326,16 @@ class CandidateScreen(WorkTraceScreen):
             return
         if message.operation != "candidate_page" or message.request_id != self._page_request_id:
             return
+        self._pending_direction = None
+        self._pending_cursor = None
         if message.kind is FailureKind.GENERATION_CHANGED:
-            self._cursor_stack = [None]
+            # Restart exactly once at page one. The restart request itself uses
+            # no cursor, so it cannot raise another generation change, and n/p/r
+            # stay inert while it is in flight.
+            self._committed_history = [None]
             self.app.notify(_FAILURE_TEXT[message.kind], markup=False)
-            self._load_current_page()
+            self._begin_page_load(None, "restart")
             return
+        # Ordinary failure: the committed history, displayed rows, and page
+        # label remain those of the last successful page.
         self.query_one("#candidate-message", Static).update(_FAILURE_TEXT[message.kind])

--- a/src/worktrace/tui/screens/candidates.py
+++ b/src/worktrace/tui/screens/candidates.py
@@ -230,6 +230,17 @@ class CandidateScreen(WorkTraceScreen):
         self.query_one("#candidate-message", Static).update("Loading candidate page…")
         self.load_candidate_page(request_id, cursor)
 
+    def _clear_loaded_page(self) -> None:
+        """Remove stale rows before a generation restart begins.
+
+        A generation-bound cursor can no longer describe the displayed rows.
+        If the automatic first-page restart then fails, no stale candidate may
+        remain selectable, openable, or copyable.
+        """
+        self._page = None
+        self._items = ()
+        self.query_one("#candidate-table", DataTable).clear()
+
     def _load_source_status(self) -> None:
         self._source_request_id += 1
         self.load_source_status(self._source_request_id)
@@ -333,6 +344,7 @@ class CandidateScreen(WorkTraceScreen):
             # no cursor, so it cannot raise another generation change, and n/p/r
             # stay inert while it is in flight.
             self._committed_history = [None]
+            self._clear_loaded_page()
             self.app.notify(_FAILURE_TEXT[message.kind], markup=False)
             self._begin_page_load(None, "restart")
             return

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -331,10 +331,10 @@ async def test_candidate_next_previous_and_generation_restart(tmp_path: Path) ->
 
         await pilot.press("n")
         await _pause_until(pilot, lambda: table.row_count == 6)
-        assert len(screen._cursor_stack) == 2
+        assert len(screen._committed_history) == 2
         await pilot.press("p")
         await _pause_until(pilot, lambda: table.row_count == 25)
-        assert len(screen._cursor_stack) == 1
+        assert len(screen._committed_history) == 1
 
         writer = sqlite3.connect(app.workspace.database_path)
         try:
@@ -350,7 +350,280 @@ async def test_candidate_next_previous_and_generation_restart(tmp_path: Path) ->
             pilot,
             lambda: any("suggestions changed" in message for message in app.notifications),
         )
-        assert screen._cursor_stack == [None]
+        assert screen._committed_history == [None]
+
+
+@pytest.mark.asyncio
+async def test_rapid_page_keys_never_mutate_committed_history(tmp_path: Path) -> None:
+    import threading
+
+    from tests.tui_support import add_visible_candidate_page
+    from worktrace.read_workspace import DatabaseBusy
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    add_visible_candidate_page(connection)
+    connection.close()
+    app = RecordingWorkTraceApp(ReadOnlyWorkspace(config), initial_app_id="sample_store")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        table = screen.query_one("#candidate-table", DataTable)
+        message = screen.query_one("#candidate-message", Static)
+        await _pause_until(pilot, lambda: screen._page is not None)
+        assert table.row_count == 25
+
+        original_page = app.workspace.candidate_page
+        gate = threading.Event()
+        calls: list[str] = []
+
+        def gated_page(*args: object, **kwargs: object) -> object:
+            calls.append("call")
+            assert gate.wait(timeout=10)
+            return original_page(*args, **kwargs)
+
+        app.workspace.candidate_page = gated_page  # type: ignore[method-assign]
+        try:
+            await pilot.press("n")
+            await _pause_until(pilot, lambda: screen._pending_direction == "next")
+            await pilot.press("n", "p", "r")
+            still_loading = [m for m in app.notifications if "still loading" in m]
+            assert len(still_loading) == 3
+            assert len(calls) == 1
+            assert screen._committed_history == [None]
+            assert "Page 2" not in str(message.render())
+            assert table.row_count == 25
+
+            gate.set()
+            await _pause_until(pilot, lambda: screen._pending_direction is None)
+            assert len(screen._committed_history) == 2
+            assert table.row_count == 6
+            assert "Page 2" in str(message.render())
+
+            failure_gate = threading.Event()
+
+            def busy_page(*args: object, **kwargs: object) -> object:
+                assert failure_gate.wait(timeout=10)
+                raise DatabaseBusy("secret raw database detail")
+
+            app.workspace.candidate_page = busy_page  # type: ignore[method-assign]
+            await pilot.press("p")
+            await _pause_until(pilot, lambda: screen._pending_direction == "previous")
+            failure_gate.set()
+            await _pause_until(pilot, lambda: "data is busy" in str(message.render()))
+            assert len(screen._committed_history) == 2
+            assert table.row_count == 6
+            assert "secret raw database detail" not in str(message.render())
+        finally:
+            app.workspace.candidate_page = original_page  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_generation_invalidation_restarts_exactly_once_at_page_one(
+    tmp_path: Path,
+) -> None:
+    import threading
+
+    from tests.tui_support import add_visible_candidate_page
+    from worktrace.read_models.candidates import CandidateGenerationChanged
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    add_visible_candidate_page(connection)
+    connection.close()
+    app = RecordingWorkTraceApp(ReadOnlyWorkspace(config), initial_app_id="sample_store")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        table = screen.query_one("#candidate-table", DataTable)
+        message = screen.query_one("#candidate-message", Static)
+        await _pause_until(pilot, lambda: screen._page is not None)
+        await pilot.press("n")
+        await _pause_until(pilot, lambda: len(screen._committed_history) == 2)
+
+        original_page = app.workspace.candidate_page
+        restart_gate = threading.Event()
+        calls: list[str] = []
+
+        def stale_then_restart(*args: object, **kwargs: object) -> object:
+            calls.append("call")
+            if len(calls) == 1:
+                raise CandidateGenerationChanged("generation moved")
+            assert restart_gate.wait(timeout=10)
+            return original_page(*args, **kwargs)
+
+        app.workspace.candidate_page = stale_then_restart  # type: ignore[method-assign]
+        try:
+            await pilot.press("p")
+            await _pause_until(
+                pilot,
+                lambda: any("suggestions changed" in m for m in app.notifications),
+            )
+            assert screen._committed_history == [None]
+            await _pause_until(
+                pilot,
+                lambda: len(calls) == 2 and screen._pending_direction == "restart",
+            )
+            await pilot.press("n", "p", "r")
+            assert len(calls) == 2
+            restart_gate.set()
+            await _pause_until(pilot, lambda: screen._pending_direction is None)
+            assert screen._committed_history == [None]
+            assert table.row_count == 25
+            assert "Page 1" in str(message.render())
+            assert "Page 2" not in str(message.render())
+            assert sum("suggestions changed" in m for m in app.notifications) == 1
+        finally:
+            app.workspace.candidate_page = original_page  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_global_return_restores_the_same_candidate_screen(tmp_path: Path) -> None:
+    from tests.tui_support import add_visible_candidate_page
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    add_visible_candidate_page(connection)
+    connection.close()
+    app = RecordingWorkTraceApp(ReadOnlyWorkspace(config), initial_app_id="sample_store")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        table = screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: screen._page is not None)
+        await pilot.press("n")
+        await _pause_until(pilot, lambda: len(screen._committed_history) == 2)
+        await pilot.press("j", "j", "j")
+        assert table.cursor_row == 3
+        depth_before = len(app.screen_stack)
+
+        await pilot.press("enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, ContributionScreen))
+        assert len(app.screen_stack) == depth_before + 1
+
+        app.action_return_to_candidates()
+        await _pause_until(pilot, lambda: app.screen is screen)
+        assert app.screen is screen
+        assert len(app.screen_stack) == depth_before
+        assert table.cursor_row == 3
+        assert len(screen._committed_history) == 2
+        assert screen._pending_direction is None
+
+        app.action_return_to_candidates()
+        await pilot.pause()
+        assert app.screen is screen
+        assert len(app.screen_stack) == depth_before
+
+
+@pytest.mark.asyncio
+async def test_application_switching_leaves_no_hidden_nested_screens(tmp_path: Path) -> None:
+    from tests.tui_support import add_second_application
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    config = add_second_application(connection, config, tmp_path)
+    connection.close()
+    app = RecordingWorkTraceApp(ReadOnlyWorkspace(config))
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, ApplicationScreen))
+        await pilot.press("enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        first_candidate_screen = app.screen
+        assert isinstance(first_candidate_screen, CandidateScreen)
+        await _pause_until(pilot, lambda: first_candidate_screen._page is not None)
+        await pilot.press("enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, ContributionScreen))
+
+        await pilot.press("a")
+        await _pause_until(pilot, lambda: isinstance(app.screen, ApplicationScreen))
+        assert len(app.screen_stack) == 2
+        assert not any(
+            isinstance(entry, (CandidateScreen, ContributionScreen)) for entry in app.screen_stack
+        )
+
+        await pilot.press("j", "enter")
+        await _pause_until(
+            pilot,
+            lambda: (
+                isinstance(app.screen, CandidateScreen) and app.screen is not first_candidate_screen
+            ),
+        )
+        assert len(app.screen_stack) == 2
+
+
+@pytest.mark.asyncio
+async def test_modal_command_palettes_expose_only_safe_actions(tmp_path: Path) -> None:
+    app, _ = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidate_screen = app.screen
+        assert isinstance(candidate_screen, CandidateScreen)
+        table = candidate_screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: table.row_count == 1)
+        assert [command.title for command in app.get_system_commands(candidate_screen)] == [
+            "Quit",
+            "Keyboard help",
+            "Switch application",
+            "Refresh",
+        ]
+
+        await pilot.press("?")
+        await _pause_until(pilot, lambda: isinstance(app.screen, HelpModal))
+        help_modal = app.screen
+        assert isinstance(help_modal, HelpModal)
+        assert [command.title for command in app.get_system_commands(help_modal)] == ["Quit"]
+        await pilot.press("q")
+        assert app.screen is candidate_screen
+
+        await pilot.press("enter")
+        await _pause_until(
+            pilot,
+            lambda: isinstance(app.screen, ContributionScreen) and app.screen._review is not None,
+        )
+        contribution = app.screen
+        assert isinstance(contribution, ContributionScreen)
+        assert [command.title for command in app.get_system_commands(contribution)] == [
+            "Quit",
+            "Keyboard help",
+            "Switch application",
+            "Refresh",
+            "Return to candidates",
+        ]
+        await pilot.press("2", "enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceModal))
+        evidence_modal = app.screen
+        assert isinstance(evidence_modal, EvidenceModal)
+        assert [command.title for command in app.get_system_commands(evidence_modal)] == ["Quit"]
+
+    small_root = tmp_path / "small"
+    small_root.mkdir()
+    connection, _, small_config, _ = _packet_state(small_root)
+    connection.close()
+    small_app = RecordingWorkTraceApp(ReadOnlyWorkspace(small_config))
+    async with small_app.run_test(size=(70, 18)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(small_app.screen, SmallTerminalScreen))
+        assert [command.title for command in small_app.get_system_commands(small_app.screen)] == [
+            "Quit"
+        ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("size", "expected_columns"),
+    [((80, 24), 4), ((120, 40), 6)],
+)
+async def test_candidate_columns_match_terminal_layout(
+    tmp_path: Path,
+    size: tuple[int, int],
+    expected_columns: int,
+) -> None:
+    app, _ = _app(tmp_path)
+    async with app.run_test(size=size) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        table = screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: table.row_count == 1)
+        assert len(table.columns) == expected_columns
 
 
 @pytest.mark.asyncio

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -478,6 +478,70 @@ async def test_generation_invalidation_restarts_exactly_once_at_page_one(
 
 
 @pytest.mark.asyncio
+async def test_generation_invalidation_clears_stale_rows_when_restart_fails(
+    tmp_path: Path,
+) -> None:
+    import threading
+
+    from tests.tui_support import add_visible_candidate_page
+    from worktrace.read_models.candidates import CandidateGenerationChanged
+    from worktrace.read_workspace import DatabaseBusy
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    add_visible_candidate_page(connection)
+    connection.close()
+    app = RecordingWorkTraceApp(ReadOnlyWorkspace(config), initial_app_id="sample_store")
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        table = screen.query_one("#candidate-table", DataTable)
+        message = screen.query_one("#candidate-message", Static)
+        await _pause_until(pilot, lambda: screen._page is not None)
+        await pilot.press("n")
+        await _pause_until(pilot, lambda: len(screen._committed_history) == 2)
+
+        original_page = app.workspace.candidate_page
+        restart_gate = threading.Event()
+        calls: list[str] = []
+
+        def stale_then_busy(*args: object, **kwargs: object) -> object:
+            calls.append("call")
+            if len(calls) == 1:
+                raise CandidateGenerationChanged("generation moved")
+            assert restart_gate.wait(timeout=10)
+            raise DatabaseBusy("secret raw database detail")
+
+        app.workspace.candidate_page = stale_then_busy  # type: ignore[method-assign]
+        try:
+            await pilot.press("p")
+            await _pause_until(pilot, lambda: len(calls) == 2)
+            assert screen._committed_history == [None]
+            assert screen._page is None
+            assert screen._items == ()
+            assert table.row_count == 0
+            assert screen.selected_stable_id() is None
+
+            await pilot.press("enter", "y")
+            assert app.copied == []
+
+            restart_gate.set()
+            await _pause_until(pilot, lambda: "data is busy" in str(message.render()))
+            assert screen._committed_history == [None]
+            assert screen._page is None
+            assert screen._items == ()
+            assert table.row_count == 0
+
+            app.workspace.candidate_page = original_page  # type: ignore[method-assign]
+            await pilot.press("r")
+            await _pause_until(pilot, lambda: screen._page is not None)
+            assert screen._committed_history == [None]
+            assert table.row_count == 25
+        finally:
+            app.workspace.candidate_page = original_page  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
 async def test_global_return_restores_the_same_candidate_screen(tmp_path: Path) -> None:
     from tests.tui_support import add_visible_candidate_page
 
@@ -570,8 +634,10 @@ async def test_modal_command_palettes_expose_only_safe_actions(tmp_path: Path) -
         await _pause_until(pilot, lambda: isinstance(app.screen, HelpModal))
         help_modal = app.screen
         assert isinstance(help_modal, HelpModal)
-        assert [command.title for command in app.get_system_commands(help_modal)] == ["Quit"]
-        await pilot.press("q")
+        help_commands = list(app.get_system_commands(help_modal))
+        assert [command.title for command in help_commands] == ["Close", "Quit"]
+        help_commands[0].callback()
+        await _pause_until(pilot, lambda: app.screen is candidate_screen)
         assert app.screen is candidate_screen
 
         await pilot.press("enter")
@@ -592,7 +658,16 @@ async def test_modal_command_palettes_expose_only_safe_actions(tmp_path: Path) -
         await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceModal))
         evidence_modal = app.screen
         assert isinstance(evidence_modal, EvidenceModal)
-        assert [command.title for command in app.get_system_commands(evidence_modal)] == ["Quit"]
+        evidence_commands = list(app.get_system_commands(evidence_modal))
+        assert [command.title for command in evidence_commands] == [
+            "Close",
+            "Copy evidence ID",
+            "Quit",
+        ]
+        evidence_commands[1].callback()
+        assert app.copied == [evidence_modal.selected_stable_id()[0]]  # type: ignore[index]
+        evidence_commands[0].callback()
+        await _pause_until(pilot, lambda: isinstance(app.screen, ContributionScreen))
 
     small_root = tmp_path / "small"
     small_root.mkdir()
@@ -601,15 +676,22 @@ async def test_modal_command_palettes_expose_only_safe_actions(tmp_path: Path) -
     small_app = RecordingWorkTraceApp(ReadOnlyWorkspace(small_config))
     async with small_app.run_test(size=(70, 18)) as pilot:
         await _pause_until(pilot, lambda: isinstance(small_app.screen, SmallTerminalScreen))
-        assert [command.title for command in small_app.get_system_commands(small_app.screen)] == [
-            "Quit"
+        terminal_commands = list(small_app.get_system_commands(small_app.screen))
+        assert [command.title for command in terminal_commands] == [
+            "Continue compact",
+            "Recheck terminal",
+            "Quit",
         ]
+        terminal_commands[1].callback()
+        assert isinstance(small_app.screen, SmallTerminalScreen)
+        terminal_commands[0].callback()
+        await _pause_until(pilot, lambda: isinstance(small_app.screen, CandidateScreen))
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("size", "expected_columns"),
-    [((80, 24), 4), ((120, 40), 6)],
+    [((80, 24), 4), ((100, 40), 4), ((120, 40), 6)],
 )
 async def test_candidate_columns_match_terminal_layout(
     tmp_path: Path,
@@ -624,6 +706,21 @@ async def test_candidate_columns_match_terminal_layout(
         table = screen.query_one("#candidate-table", DataTable)
         await _pause_until(pilot, lambda: table.row_count == 1)
         assert len(table.columns) == expected_columns
+
+
+@pytest.mark.asyncio
+async def test_small_terminal_continue_uses_compact_layout(tmp_path: Path) -> None:
+    app, _ = _app(tmp_path)
+    async with app.run_test(size=(120, 20)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, SmallTerminalScreen))
+        await pilot.press("c")
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        screen = app.screen
+        assert isinstance(screen, CandidateScreen)
+        table = screen.query_one("#candidate-table", DataTable)
+        await _pause_until(pilot, lambda: table.row_count == 1)
+        assert app.compact_mode is True
+        assert len(table.columns) == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Candidate paging separates committed cursor history from pending navigation: `n`/`p`/`r` are inert (with an actionable notification) while a page request is in flight, and history commits only when the matching request succeeds. This prevents rapid `n`/`n` and `n`/`p` from advancing the page label ahead of the page on screen.
- Generation invalidation restarts exactly once at page one and clears the prior page before the restart begins. If that automatic restart fails, no stale candidate row, page state, or stable ID remains selectable, openable, or copyable; `r` retries from page one.
- The global Return command reveals the running `CandidateScreen` (preserving its instance, selected row, cursor history, and stack depth) instead of switching in a new screen above the old hidden one; `_show_screen` normalizes the stack to exactly one base screen, so application switching and restarts cannot leave hidden nested screens beneath the visible one.
- Modal palettes now contain only their fixed safe actions: Help exposes Close/Quit; Evidence exposes Close/validated evidence-ID copy/Quit; the small-terminal warning exposes Continue compact/Recheck/Quit. They never expose refresh, application switching, return navigation, or Screenshot.
- The candidate browser uses the four-column compact table below 120 columns or below 24 rows. This gives 80×24, 100×40, and a continued 120×20 session the compact layout; 120×40 remains six-column full layout.

Validation: `uv run pytest`, `uv run coverage run -m pytest`, `uv run coverage report`, `uv run ruff format --check .`, `uv run ruff check .`, `uv run mypy src`, and `uv build` all pass (277 tests, total coverage 85% ≥ 81% gate). New deterministic Textual interaction tests cover stale-generation restart failure, the exact layout boundaries, and each modal palette callback.

## Glossary

| Term | Definition |
|------|------------|
| Committed cursor history | Navigation state corresponding to the page currently displayed; changes only on a matching successful page load. |
| Pending navigation | A requested page transition not yet accepted by the UI. |
| Generation invalidation | The candidate rebuild generation changed under an open cursor, requiring a restart from page one. |
| Screen-stack normalization | Popping back to the default screen before pushing, so exactly one base screen remains visible. |

Refs #19