### PR TITLE
fix(#26): reconcile exact identity and preserve legacy evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,43 @@ uv run worktrace gaps candidate:stable-id
 Use `worktrace --help` and each subcommand's `--help` for all commands. Human corrections are
 append-only events; `undo` writes a compensating event rather than deleting history.
 
+## Identity upgrade and repair
+
+Git self identity uses configured email aliases, never display names. Author, committer and
+co-author remain distinct roles. Existing ledgers must reconcile older actor flags before those
+flags can support personal attribution. Confirmed contributions and human decisions are preserved;
+affected history is marked for re-review.
+
+Stop other WorkTrace writers/readers before upgrading. Keep the database and its matching
+`email-hmac.key` together as a private recovery pair. `worktrace init` now makes a coherent SQLite
+backup before forward migrations and refuses to recreate a missing key for an existing database.
+It does not silently repair historical identities. Never run an older binary on the upgraded schema.
+
+```console
+uv run worktrace init
+uv run worktrace repair-identities APP_ID --dry-run
+uv run worktrace repair-identities APP_ID --apply --expected-proposal PROPOSAL_TOKEN
+uv run worktrace rebuild all APP_ID
+uv run worktrace status APP_ID
+```
+
+Review the proposed promotions, demotions, unresolved actors and affected confirmed contributions
+before applying. The proposal token returned by the dry run can guard against changed state.
+Imports refuse changed or unreconciled identity policy; staged pages cannot reclassify existing
+actors. A rebuild clears derived-state invalidation, but does not clear human re-review warnings.
+
+Legacy ledgers do not contain a key verifier. Their first repair requires an independently known
+stored actor ID and its matching configured email alias (zero-based index): add
+`--proof-actor-id ACTOR_ID --proof-alias-index INDEX` to both preview and apply. Identify the actor
+from trusted stored evidence; do not guess from a matching display name. A missing or wrong key,
+unverifiable pair, or unexpected impact on another application blocks apply. Restore the trusted
+database/key pair when continuity cannot be established; never treat zero matches as proof.
+
+Repair is offline by default. For legacy Jira/GitLab identities, explicitly add `--verify-providers`
+to verify configured accounts using their existing credentials. This reads identity endpoints only,
+does not import evidence, and never falls back to display names. Unverified provider flags remain
+pending. Corrected full-range source imports are still needed for the later discovery fixes.
+
 ## Human review UI
 
 Launch the keyboard-first, read-only evidence workstation in an interactive terminal:

--- a/migrations/004_identity_policy.sql
+++ b/migrations/004_identity_policy.sql
@@ -1,0 +1,29 @@
+ALTER TABLE actors ADD COLUMN identity_policy_version INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE apps ADD COLUMN read_revision INTEGER NOT NULL DEFAULT 0;
+
+CREATE TABLE app_identity_policy (
+    app_id TEXT PRIMARY KEY REFERENCES apps(id),
+    version INTEGER NOT NULL,
+    fingerprint TEXT NOT NULL,
+    rebuild_required INTEGER NOT NULL DEFAULT 0 CHECK (rebuild_required IN (0, 1))
+);
+
+CREATE TABLE identity_key_binding (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    ledger_id TEXT NOT NULL,
+    verifier TEXT NOT NULL
+);
+
+CREATE TABLE identity_repair_audit (
+    id TEXT PRIMARY KEY,
+    app_id TEXT NOT NULL REFERENCES apps(id),
+    created_at TEXT NOT NULL,
+    report_json TEXT NOT NULL
+);
+
+CREATE TABLE identity_rereview (
+    app_id TEXT NOT NULL REFERENCES apps(id),
+    target_id TEXT NOT NULL,
+    repair_id TEXT NOT NULL REFERENCES identity_repair_audit(id),
+    PRIMARY KEY (app_id, target_id, repair_id)
+);

--- a/src/worktrace/adapters/gitlab.py
+++ b/src/worktrace/adapters/gitlab.py
@@ -168,7 +168,18 @@ class GitLabAdapter:
                     cursor_prefix=environment,
                 )
 
+    def resolved_self_ids(self, configured_email_hashes: set[str]) -> set[str]:
+        """Resolve the run identity before persistence using the authenticated user."""
+        self._verify_identity()
+        assert self._verified_user_id is not None
+        identities = {self._verified_user_id, *configured_email_hashes}
+        if self._verified_email:
+            identities.add(self._redactor.hash_email(self._verified_email))
+        return identities
+
     def _verify_identity(self) -> None:
+        if self._verified_user_id is not None:
+            return
         response = request_with_retry(
             self._client,
             "GET",
@@ -185,6 +196,8 @@ class GitLabAdapter:
         username = _text(document.get("username"))
         if user_id is None or username is None:
             raise PermanentSourceError("GitLab identity omitted stable fields")
+        if not user_id.isascii() or not user_id.isdecimal() or int(user_id) < 1:
+            raise PermanentSourceError("GitLab identity returned an invalid numeric user ID")
         if self._config.user_id is not None and user_id != str(self._config.user_id):
             raise ScopeViolation("GitLab authenticated user does not match configured user_id")
         if (

--- a/src/worktrace/adapters/jira.py
+++ b/src/worktrace/adapters/jira.py
@@ -113,6 +113,7 @@ class JiraAdapter:
         self._discovered_keys = discovered_keys
         self._client = client
         self._redactor = Redactor(config.email_key)
+        self._identity_verified = False
         self._window_start = datetime.combine(config.date_from, time.min, tzinfo=UTC)
         self._window_end = datetime.combine(
             config.date_to + timedelta(days=1),
@@ -174,7 +175,16 @@ class JiraAdapter:
             yield from self._changelog_pages(issue_id, issue_key, observed_at)
         yield from self._hierarchy_pages(tuple(unique_issues.values()), observed_at)
 
+    def resolved_self_id(self) -> str:
+        """Verify and return the configured account before accepting its actor policy."""
+        if self._config.account_id is None:
+            raise ConfigurationError("Jira self identity requires a configured account_id")
+        self._verify_identity()
+        return self._config.account_id
+
     def _verify_identity(self) -> None:
+        if self._identity_verified:
+            return
         if self._config.account_id is None:
             return
         response = request_with_retry(
@@ -186,6 +196,7 @@ class JiraAdapter:
         document = self._response_mapping(response, "identity")
         if _text(document.get("accountId")) != self._config.account_id:
             raise ScopeViolation("Jira authenticated identity does not match configured account")
+        self._identity_verified = True
 
     def _discovery_queries(self) -> tuple[tuple[str, bool], ...]:
         quoted_projects = ", ".join(f'"{key}"' for key in self._projects)

--- a/src/worktrace/candidates/builder.py
+++ b/src/worktrace/candidates/builder.py
@@ -52,7 +52,7 @@ def _self_roles(
         FROM authoritative_current_participations p
         JOIN actors a ON a.id=p.actor_id
         JOIN source_objects so ON so.id=p.source_object_id
-        WHERE so.app_id=? AND a.is_self=1
+        WHERE so.app_id=? AND a.is_self=1 AND a.identity_policy_version=1
         """,
         (app_id,),
     )

--- a/src/worktrace/cli.py
+++ b/src/worktrace/cli.py
@@ -34,10 +34,18 @@ from worktrace.db.authority import (
 from worktrace.db.connection import connect
 from worktrace.db.migrations import backup_database, migrate
 from worktrace.db.queries import search_evidence, source_status
+from worktrace.db.readiness import DatabaseReadinessStatus, database_readiness
 from worktrace.db.repository import EvidenceRepository, stable_id
 from worktrace.doctor import run_doctor
 from worktrace.domain.models import JsonValue
 from worktrace.errors import ConfigurationError, WorkTraceError
+from worktrace.identity import (
+    finish_identity_rebuild,
+    identity_policy_status,
+    initialize_identity,
+    prepare_identity_import,
+    repair_identities,
+)
 from worktrace.importers.orchestrator import ImportResult, import_snapshot
 from worktrace.linking.builder import rebuild_references
 from worktrace.linking.extractors import extract_jira_keys
@@ -247,9 +255,17 @@ def _open(
     config_path: Path | None = None,
 ) -> tuple[WorkTraceConfig, sqlite3.Connection, EvidenceRepository]:
     config = load_config(config_path)
+    if not config.database_path.is_file():
+        raise WorkTraceError("database is missing; run worktrace init")
     connection = connect(config.database_path)
-    redactor = Redactor(email_hmac_key(config.data_directory, create=False))
-    return config, connection, EvidenceRepository(connection, redactor)
+    try:
+        if database_readiness(connection).status is not DatabaseReadinessStatus.READY:
+            raise WorkTraceError("unsupported database schema; run the matching worktrace init")
+        redactor = Redactor(email_hmac_key(config.data_directory, create=False))
+        return config, connection, EvidenceRepository(connection, redactor)
+    except BaseException:
+        connection.close()
+        raise
 
 
 @app.callback()
@@ -319,16 +335,48 @@ def initialize(config: ConfigOption = None) -> None:
     """Create or upgrade the private local ledger idempotently."""
     configuration = load_config(config)
     ensure_private_directory(configuration.data_directory)
-    email_hmac_key(configuration.data_directory, create=True)
+    existing = (
+        configuration.database_path.exists() and configuration.database_path.stat().st_size > 0
+    )
+    key = email_hmac_key(configuration.data_directory, create=not existing)
     connection = connect(configuration.database_path)
     try:
+        binding_table = connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='identity_key_binding'"
+        ).fetchone()
+        if binding_table and connection.execute("SELECT 1 FROM identity_key_binding").fetchone():
+            with connection:
+                initialize_identity(connection, configuration, key)
         applied = migrate(connection, configuration.database_path)
         repository = EvidenceRepository(connection)
         repository.ensure_apps(configuration)
+        populated = any(
+            connection.execute(f"SELECT 1 FROM {table} LIMIT 1").fetchone()
+            for table in (
+                "actors",
+                "source_objects",
+                "observations",
+                "human_decisions",
+                "sync_runs",
+            )
+        )
+        if not populated:
+            with connection:
+                initialize_identity(connection, configuration, key)
+        identity = {
+            item.id: identity_policy_status(connection, configuration, item.id)
+            for item in configuration.apps
+        }
     finally:
         connection.close()
     configuration.database_path.chmod(0o600)
-    _emit({"database": str(configuration.database_path), "migrations_applied": applied})
+    _emit(
+        {
+            "database": str(configuration.database_path),
+            "migrations_applied": applied,
+            "identity": identity,
+        }
+    )
 
 
 @app.command()
@@ -368,6 +416,113 @@ def _git_self_ids(configuration: WorkTraceConfig, key: bytes) -> set[str]:
     return {redactor.hash_email(email) for email in configuration.identity.git_author_emails}
 
 
+def _verified_repair_identities(
+    configuration: WorkTraceConfig, app_id: str, key: bytes
+) -> tuple[dict[str, str], frozenset[str]]:
+    """Run only for the explicit --verify-providers repair option."""
+    selected = configuration.app(app_id)
+    verified: dict[str, str] = {}
+    verified_emails: frozenset[str] = frozenset()
+    if selected.jira_project_keys:
+        credentials = jira_credentials()
+        if credentials is None or configuration.identity.jira_account_id is None:
+            raise WorkTraceError("Jira credentials and account ID are required for verification")
+        with httpx.Client(
+            base_url=credentials.base_url,
+            auth=(credentials.email, credentials.token),
+            timeout=30,
+        ) as client:
+            adapter = JiraAdapter(
+                JiraConfig(
+                    base_url=credentials.base_url,
+                    source_instance=_source_instance(app_id, "jira", credentials.base_url),
+                    app_id=app_id,
+                    project_keys=selected.jira_project_keys,
+                    account_id=configuration.identity.jira_account_id,
+                    date_from=configuration.employment_from,
+                    date_to=configuration.employment_to,
+                    email_key=key,
+                ),
+                client,
+            )
+            verified["jira"] = adapter.resolved_self_id()
+    if selected.gitlab_project_ids:
+        credentials_gitlab = gitlab_credentials()
+        if credentials_gitlab is None:
+            raise WorkTraceError("GitLab credentials are required for verification")
+        with httpx.Client(
+            base_url=credentials_gitlab.base_url,
+            headers={"PRIVATE-TOKEN": credentials_gitlab.token, "Accept": "application/json"},
+            timeout=30,
+        ) as client:
+            gitlab_adapter = GitLabAdapter(
+                GitLabConfig(
+                    base_url=credentials_gitlab.base_url,
+                    source_instance=_source_instance(
+                        app_id, "gitlab", selected.gitlab_project_ids[0]
+                    ),
+                    app_id=app_id,
+                    project_id=selected.gitlab_project_ids[0],
+                    user_id=configuration.identity.gitlab_user_id,
+                    username=configuration.identity.gitlab_username,
+                    date_from=configuration.employment_from,
+                    date_to=configuration.employment_to,
+                    email_key=key,
+                ),
+                client,
+            )
+            ids = gitlab_adapter.resolved_self_ids(_git_self_ids(configuration, key))
+            verified["gitlab"] = next(value for value in ids if value.isdecimal())
+            verified_emails = frozenset(
+                value for value in ids if value.startswith("email_hmac_sha256:")
+            )
+    return verified, verified_emails
+
+
+@app.command("repair-identities")
+def repair_identity_command(
+    app_id: str,
+    apply: Annotated[bool, typer.Option("--apply")] = False,
+    dry_run: Annotated[bool, typer.Option("--dry-run")] = False,
+    proof_actor_id: Annotated[str | None, typer.Option("--proof-actor-id")] = None,
+    proof_alias_index: Annotated[int | None, typer.Option("--proof-alias-index", min=0)] = None,
+    expected_proposal: Annotated[str | None, typer.Option("--expected-proposal")] = None,
+    verify_providers: Annotated[
+        bool,
+        typer.Option("--verify-providers", help="Explicitly verify provider identities online."),
+    ] = False,
+    config: ConfigOption = None,
+) -> None:
+    """Preview identity reconciliation; apply only explicitly approved changes."""
+    if apply and dry_run:
+        raise WorkTraceError("choose --apply or --dry-run, not both")
+    configuration, connection, _ = _open(config)
+    try:
+        configuration.app(app_id)
+        key = email_hmac_key(configuration.data_directory, create=False)
+        verified, verified_emails = (
+            _verified_repair_identities(configuration, app_id, key)
+            if verify_providers
+            else ({}, frozenset())
+        )
+        with connection:
+            result = repair_identities(
+                connection,
+                configuration,
+                key,
+                app_id,
+                apply=apply,
+                proof_actor_id=proof_actor_id,
+                proof_alias_index=proof_alias_index,
+                expected_proposal=expected_proposal,
+                verified_self_ids=verified,
+                verified_gitlab_email_hashes=verified_emails,
+            )
+        _emit(result)
+    finally:
+        connection.close()
+
+
 @dataclass(frozen=True, slots=True)
 class _CommitSeedSelection:
     values: tuple[str, ...]
@@ -400,7 +555,8 @@ def _relevant_git_commit_shas(
             JOIN actors a ON a.id=p.actor_id
             JOIN source_objects so ON so.id=p.source_object_id
             WHERE so.app_id=? AND so.source='git' AND so.kind='git_commit'
-              AND a.is_self=1 AND p.role IN ('git_author', 'git_coauthor')
+              AND a.is_self=1 AND a.identity_policy_version=1
+              AND p.role IN ('git_author', 'git_coauthor')
               AND p.observation_id IN ({placeholders})
             """,
             [app_id, *current_observation_ids],
@@ -513,6 +669,8 @@ def import_git(
         scoped_repo = configured_app.assert_repo_scope(repo)
         source_instance = _source_instance(app_id, "git", scoped_repo)
         key = email_hmac_key(configuration.data_directory, create=False)
+        with connection:
+            prepare_identity_import(connection, configuration, key, app_id)
         adapter = LocalGitAdapter(
             LocalGitConfig(
                 repository_path=scoped_repo,
@@ -534,9 +692,6 @@ def import_git(
             date_from=start,
             date_to=end,
             self_actor_ids=_git_self_ids(configuration, key),
-            self_display_names={
-                name.casefold() for name in configuration.identity.git_author_names
-            },
             scope_details={"selection_reasons": ["configured repository read-only snapshot"]},
         )
         _emit(
@@ -568,6 +723,8 @@ def import_jira(
             raise WorkTraceError("Jira credentials are not configured")
         key = email_hmac_key(configuration.data_directory, create=False)
         source_instance = _source_instance(app_id, "jira", credentials.base_url)
+        with connection:
+            prepare_identity_import(connection, configuration, key, app_id)
         discovered_keys = _discovered_jira_keys(repository, configured_app)
         with httpx.Client(
             base_url=credentials.base_url,
@@ -654,6 +811,8 @@ def import_gitlab(
             raise WorkTraceError("GitLab identity is required for user-scoped discovery")
         key = email_hmac_key(configuration.data_directory, create=False)
         commit_seeds = _relevant_git_commit_shas(repository, app_id)
+        with connection:
+            prepare_identity_import(connection, configuration, key, app_id)
         with httpx.Client(
             base_url=credentials.base_url,
             headers={"PRIVATE-TOKEN": credentials.token, "Accept": "application/json"},
@@ -677,11 +836,7 @@ def import_gitlab(
                 ),
                 client,
             )
-            own_ids = set()
-            if configuration.identity.gitlab_user_id is not None:
-                own_ids.add(str(configuration.identity.gitlab_user_id))
-            if configuration.identity.gitlab_username:
-                own_ids.add(configuration.identity.gitlab_username)
+            own_ids = adapter.resolved_self_ids(_git_self_ids(configuration, key))
             result = import_snapshot(
                 configured_app,
                 adapter,
@@ -731,6 +886,13 @@ def import_all(
     start, end = _window(configuration, date_from, date_to)
     configured_app = configuration.app(app_id)
     _assert_no_scope_contraction(repository, app_id, start, end)
+    try:
+        key = email_hmac_key(configuration.data_directory, create=False)
+        with connection:
+            prepare_identity_import(connection, configuration, key, app_id)
+    except BaseException:
+        connection.close()
+        raise
     session_id = repository.create_import_session(configured_app, start, end)
     results: list[dict[str, object]] = []
     try:
@@ -758,9 +920,6 @@ def import_all(
                 date_from=start,
                 date_to=end,
                 self_actor_ids=_git_self_ids(configuration, key),
-                self_display_names={
-                    name.casefold() for name in configuration.identity.git_author_names
-                },
                 import_session_id=session_id,
                 finish_session=False,
                 scope_details={"selection_reasons": ["configured repository read-only snapshot"]},
@@ -828,33 +987,27 @@ def import_all(
                 headers={"PRIVATE-TOKEN": gitlab_auth.token, "Accept": "application/json"},
                 timeout=30,
             ) as client:
-                own_ids = {
-                    str(value)
-                    for value in (
-                        configuration.identity.gitlab_user_id,
-                        configuration.identity.gitlab_username,
-                    )
-                    if value is not None
-                }
+                gitlab_adapter = GitLabAdapter(
+                    GitLabConfig(
+                        base_url=gitlab_auth.base_url,
+                        source_instance=source_instance,
+                        app_id=app_id,
+                        project_id=project_id,
+                        email_key=key,
+                        date_from=start,
+                        date_to=end,
+                        jira_project_keys=configured_app.jira_project_keys,
+                        user_id=configuration.identity.gitlab_user_id,
+                        username=configuration.identity.gitlab_username,
+                        production_environments=configured_app.production_environments,
+                        relevant_commit_shas=commit_seeds.values,
+                    ),
+                    client,
+                )
+                own_ids = gitlab_adapter.resolved_self_ids(_git_self_ids(configuration, key))
                 result = import_snapshot(
                     configured_app,
-                    GitLabAdapter(
-                        GitLabConfig(
-                            base_url=gitlab_auth.base_url,
-                            source_instance=source_instance,
-                            app_id=app_id,
-                            project_id=project_id,
-                            email_key=key,
-                            date_from=start,
-                            date_to=end,
-                            jira_project_keys=configured_app.jira_project_keys,
-                            user_id=configuration.identity.gitlab_user_id,
-                            username=configuration.identity.gitlab_username,
-                            production_environments=configured_app.production_environments,
-                            relevant_commit_shas=commit_seeds.values,
-                        ),
-                        client,
-                    ),
+                    gitlab_adapter,
                     repository,
                     source="gitlab",
                     source_instance=source_instance,
@@ -982,6 +1135,8 @@ def import_all(
 
         reference_count = rebuild_references(configured_app, repository)
         candidate_count = rebuild_candidates(app_id, repository)
+        with connection:
+            finish_identity_rebuild(connection, configuration, app_id)
         complete = all(result.get("status") == "complete" for result in results)
         overall = "complete" if complete else "partial"
         repository.finish_import_session(
@@ -1026,7 +1181,13 @@ def status(app_id: str, config: ConfigOption = None) -> None:
     configuration, connection, _ = _open(config)
     try:
         configuration.app(app_id)
-        _emit({"app_id": app_id, "sources": source_status(connection, app_id)})
+        _emit(
+            {
+                "app_id": app_id,
+                "sources": source_status(connection, app_id),
+                "identity": identity_policy_status(connection, configuration, app_id),
+            }
+        )
     finally:
         connection.close()
 
@@ -1245,11 +1406,16 @@ def _rebuild(
     configuration, connection, repository = _open(config_path)
     try:
         configured_app = configuration.app(app_id)
+        if not identity_policy_status(connection, configuration, app_id)["valid"]:
+            raise WorkTraceError("identity policy requires repair before rebuilding")
         result: dict[str, int] = {}
         if refs:
             result["references"] = rebuild_references(configured_app, repository)
         if candidates:
             result["candidates"] = rebuild_candidates(app_id, repository)
+        if refs and candidates:
+            with connection:
+                finish_identity_rebuild(connection, configuration, app_id)
         return result
     finally:
         connection.close()
@@ -1275,7 +1441,17 @@ def export_command(app_id: str, destination: Path, config: ConfigOption = None) 
     configuration, connection, _ = _open(config)
     try:
         configuration.app(app_id)
-        _emit({"objects": export_app(connection, app_id, destination), "path": str(destination)})
+        _emit(
+            {
+                "objects": export_app(
+                    connection,
+                    app_id,
+                    destination,
+                    identity_state=identity_policy_status(connection, configuration, app_id),
+                ),
+                "path": str(destination),
+            }
+        )
     finally:
         connection.close()
 

--- a/src/worktrace/db/authority.py
+++ b/src/worktrace/db/authority.py
@@ -274,7 +274,9 @@ def authoritative_participations_for_current_observations(
         SELECT participation.id, participation.source_object_id,
             participation.observation_id, participation.role,
             participation.effective_from, participation.effective_to,
-            actor.id AS actor_id, actor.display_name, actor.is_self,
+            actor.id AS actor_id, actor.display_name,
+            CASE WHEN actor.identity_policy_version=1 OR actor.source='manual'
+                 THEN actor.is_self ELSE 0 END AS is_self,
             object.source, object.kind, object.external_id
         FROM participations participation
         JOIN observations observation

--- a/src/worktrace/db/migrations.py
+++ b/src/worktrace/db/migrations.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import os
 import re
-import shutil
 import sqlite3
+import time
+from contextlib import closing
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -11,6 +12,8 @@ from pathlib import Path
 from worktrace.errors import DatabaseError
 
 MIGRATION_RE = re.compile(r"^(?P<version>[0-9]{3})_[a-z0-9_]+\.sql$")
+BACKUP_TIMEOUT_SECONDS = 5.0
+MIGRATION_BUSY_TIMEOUT_MS = 5_000
 
 
 @dataclass(frozen=True)
@@ -50,16 +53,40 @@ def user_version(connection: sqlite3.Connection) -> int:
 
 
 def backup_database(path: Path, destination: Path | None = None) -> Path | None:
+    """Back up committed SQLite state, including WAL, without replacing a file."""
     if not path.exists() or path.stat().st_size == 0:
         return None
     if destination is None:
-        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+        stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S%fZ")
         destination = path.with_suffix(f".sqlite3.{stamp}.backup")
     destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     descriptor = os.open(destination, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    os.close(descriptor)
+    deadline = time.monotonic() + BACKUP_TIMEOUT_SECONDS
+
+    def check_deadline(status: int, remaining: int, total: int) -> None:
+        if status != sqlite3.SQLITE_DONE and time.monotonic() >= deadline:
+            raise DatabaseError("database backup timed out; stop other writers and retry")
+
     try:
-        with path.open("rb") as source, os.fdopen(descriptor, "wb") as target:
-            shutil.copyfileobj(source, target)
+        # A separate connection observes committed state and avoids backing up a
+        # caller's autocommit=False transaction, which can retry forever on BUSY.
+        with (
+            closing(
+                sqlite3.connect(
+                    f"{path.resolve().as_uri()}?mode=ro",
+                    uri=True,
+                    autocommit=True,
+                    timeout=0,
+                )
+            ) as source,
+            closing(sqlite3.connect(destination, autocommit=True, timeout=0)) as target,
+        ):
+            source.execute("PRAGMA query_only = ON")
+            source.backup(target, pages=128, progress=check_deadline, sleep=0.01)
+    except sqlite3.Error as exc:
+        destination.unlink(missing_ok=True)
+        raise DatabaseError("database backup failed; original database was not changed") from exc
     except Exception:
         destination.unlink(missing_ok=True)
         raise
@@ -67,18 +94,32 @@ def backup_database(path: Path, destination: Path | None = None) -> Path | None:
 
 
 def migrate(connection: sqlite3.Connection, database_path: Path) -> list[int]:
-    current = user_version(connection)
-    pending = [migration for migration in migrations() if migration.version > current]
-    if not pending:
-        return []
-    backup_database(database_path)
+    available = migrations()
+    supported = available[-1].version if available else 0
     applied: list[int] = []
+    owns_transaction = False
     previous_autocommit = connection.autocommit
-    connection.autocommit = True
+    previous_timeout = int(connection.execute("PRAGMA busy_timeout").fetchone()[0])
+    connection.execute(f"PRAGMA busy_timeout = {MIGRATION_BUSY_TIMEOUT_MS}")
     try:
+        current = user_version(connection)
+        if current > supported:
+            raise DatabaseError("database schema is newer than this WorkTrace version supports")
+        if current == supported:
+            return []
+        connection.autocommit = True
+        # Reserve the writer before backup, retaining the reservation until all
+        # migrations commit. The backup reads the pre-migration committed state.
+        connection.execute("BEGIN IMMEDIATE")
+        owns_transaction = True
+        current = user_version(connection)
+        if current > supported:
+            raise DatabaseError("database schema is newer than this WorkTrace version supports")
+        pending = [migration for migration in available if migration.version > current]
+        if pending:
+            backup_database(database_path)
         for migration in pending:
             try:
-                connection.execute("BEGIN IMMEDIATE")
                 statement = ""
                 for line in migration.sql.splitlines(keepends=True):
                     statement += line
@@ -88,12 +129,21 @@ def migrate(connection: sqlite3.Connection, database_path: Path) -> list[int]:
                 if statement.strip():
                     raise sqlite3.OperationalError("incomplete SQL statement")
                 connection.execute(f"PRAGMA user_version = {migration.version}")
-                connection.execute("COMMIT")
             except sqlite3.Error as exc:
-                if connection.in_transaction:
-                    connection.execute("ROLLBACK")
                 raise DatabaseError(f"migration {migration.path.name} failed") from exc
             applied.append(migration.version)
+        connection.execute("COMMIT")
+        owns_transaction = False
+    except sqlite3.Error as exc:
+        if owns_transaction and connection.in_transaction:
+            connection.execute("ROLLBACK")
+        raise DatabaseError("database migration could not acquire or retain its lock") from exc
+    except Exception:
+        if owns_transaction and connection.in_transaction:
+            connection.execute("ROLLBACK")
+        raise
     finally:
-        connection.autocommit = previous_autocommit
+        if connection.autocommit != previous_autocommit:
+            connection.autocommit = previous_autocommit
+        connection.execute(f"PRAGMA busy_timeout = {previous_timeout}")
     return applied

--- a/src/worktrace/db/repository.py
+++ b/src/worktrace/db/repository.py
@@ -63,8 +63,14 @@ class EvidenceRepository:
         self.redactor = redactor
 
     def ensure_apps(self, config: WorkTraceConfig) -> None:
+        from worktrace.identity import IDENTITY_POLICY_VERSION, identity_fingerprint
+
         with self.connection:
             for app in config.apps:
+                is_new = (
+                    self.connection.execute("SELECT 1 FROM apps WHERE id=?", (app.id,)).fetchone()
+                    is None
+                )
                 self.connection.execute(
                     """
                     INSERT INTO apps(id, name, market, business_type)
@@ -76,6 +82,12 @@ class EvidenceRepository:
                     """,
                     (app.id, app.name, app.market, app.business_type),
                 )
+                if is_new:
+                    self.connection.execute(
+                        "INSERT INTO app_identity_policy(app_id, version, fingerprint) "
+                        "VALUES (?, ?, ?)",
+                        (app.id, IDENTITY_POLICY_VERSION, identity_fingerprint(config)),
+                    )
 
     def create_import_session(self, app: AppConfig, date_from: date, date_to: date) -> str:
         session_id = f"import:{uuid.uuid4()}"
@@ -296,15 +308,31 @@ class EvidenceRepository:
         ):
             raise DatabaseError("redaction is required before actor persistence")
         actor_id = stable_id("actor", actor.source, actor.source_instance, external_actor_id)
+        existing = self.connection.execute(
+            "SELECT is_self, email_hash, identity_policy_version FROM actors "
+            "WHERE source=? AND source_instance=? AND external_actor_id=?",
+            (actor.source, actor.source_instance, external_actor_id),
+        ).fetchone()
+        if existing is not None and (
+            int(existing["identity_policy_version"]) != 1
+            or bool(existing["is_self"]) != actor.is_self
+            or (
+                existing["email_hash"] is not None
+                and email_hash is not None
+                and existing["email_hash"] != email_hash
+            )
+        ):
+            raise DatabaseError(
+                "identity_reconciliation_required: source pages cannot change accepted identity"
+            )
         self.connection.execute(
             """
             INSERT INTO actors(
-                id, source, source_instance, external_actor_id, display_name, email_hash, is_self
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                id, source, source_instance, external_actor_id, display_name, email_hash, is_self,
+                identity_policy_version
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, 1)
             ON CONFLICT(source, source_instance, external_actor_id) DO UPDATE SET
-                display_name=excluded.display_name,
-                email_hash=COALESCE(excluded.email_hash, actors.email_hash),
-                is_self=excluded.is_self
+                display_name=excluded.display_name
             """,
             (
                 actor_id,

--- a/src/worktrace/identity.py
+++ b/src/worktrace/identity.py
@@ -1,0 +1,450 @@
+"""CLI identity-policy transitions and offline read readiness.
+
+Writes join the caller's transaction through a savepoint. Public CLI callers own
+the commit; no helper can commit unrelated evidence or a staged source page.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sqlite3
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from typing import Any
+
+from worktrace.candidates.decisions import (
+    decision_lineages,
+    decision_scope_map,
+    decision_stream,
+    snapshot_member_ids,
+)
+from worktrace.config import WorkTraceConfig
+from worktrace.errors import ConfigurationError, ScopeViolation
+from worktrace.normalize.redaction import Redactor
+
+IDENTITY_POLICY_VERSION = 1
+
+
+def identity_fingerprint(config: WorkTraceConfig) -> str:
+    """Fingerprint only classification inputs; names cannot change identity."""
+    identity = config.identity
+    value = {
+        "version": IDENTITY_POLICY_VERSION,
+        "emails": sorted({email.strip().casefold() for email in identity.git_author_emails}),
+        "jira_account_id": identity.jira_account_id,
+        "gitlab_user_id": identity.gitlab_user_id,
+        "gitlab_username": identity.gitlab_username if identity.gitlab_user_id is None else None,
+    }
+    return hashlib.sha256(json.dumps(value, sort_keys=True).encode()).hexdigest()
+
+
+@contextmanager
+def _transition(connection: sqlite3.Connection) -> Iterator[None]:
+    name = "identity_" + uuid.uuid4().hex
+    connection.execute(f"SAVEPOINT {name}")
+    try:
+        yield
+    except BaseException:
+        connection.execute(f"ROLLBACK TO {name}")
+        connection.execute(f"RELEASE {name}")
+        raise
+    else:
+        connection.execute(f"RELEASE {name}")
+
+
+def _populated(connection: sqlite3.Connection) -> bool:
+    return any(
+        connection.execute(f"SELECT 1 FROM {table} LIMIT 1").fetchone() is not None
+        for table in ("actors", "source_objects", "observations", "human_decisions", "sync_runs")
+    )
+
+
+def _verifier(key: bytes, ledger_id: str) -> str:
+    if not key:
+        raise ConfigurationError("identity key is missing; restore the matching key")
+    return hmac.new(
+        key, f"worktrace:identity-key:v1:{ledger_id}".encode(), hashlib.sha256
+    ).hexdigest()
+
+
+def _key_matches(connection: sqlite3.Connection, key: bytes) -> bool:
+    if not key:
+        raise ConfigurationError("identity key is missing; restore the matching key")
+    row = connection.execute("SELECT ledger_id, verifier FROM identity_key_binding").fetchone()
+    if row is None:
+        return False
+    if not hmac.compare_digest(_verifier(key, str(row[0])), str(row[1])):
+        raise ConfigurationError(
+            "identity key does not match this ledger; restore the matching key"
+        )
+    return True
+
+
+def _bind_key(connection: sqlite3.Connection, key: bytes) -> None:
+    ledger_id = str(uuid.uuid4())
+    connection.execute(
+        "INSERT INTO identity_key_binding VALUES (1, ?, ?)",
+        (ledger_id, _verifier(key, ledger_id)),
+    )
+
+
+def _accept_policy(connection: sqlite3.Connection, config: WorkTraceConfig, app_id: str) -> None:
+    connection.execute(
+        "INSERT INTO app_identity_policy(app_id, version, fingerprint) VALUES (?, ?, ?) "
+        "ON CONFLICT(app_id) DO UPDATE SET version=excluded.version, "
+        "fingerprint=excluded.fingerprint",
+        (app_id, IDENTITY_POLICY_VERSION, identity_fingerprint(config)),
+    )
+
+
+def initialize_identity(
+    connection: sqlite3.Connection, config: WorkTraceConfig, key: bytes
+) -> None:
+    """Enroll an empty ledger, never replace a populated ledger's unknown key."""
+    with _transition(connection):
+        connection.execute("UPDATE apps SET read_revision=read_revision")
+        if _key_matches(connection, key):
+            return
+        if _populated(connection):
+            raise ConfigurationError(
+                "legacy identity key continuity requires explicit repair proof"
+            )
+        _bind_key(connection, key)
+        for app in config.apps:
+            if (
+                connection.execute(
+                    "SELECT 1 FROM app_identity_policy WHERE app_id=?", (app.id,)
+                ).fetchone()
+                is None
+            ):
+                _accept_policy(connection, config, app.id)
+
+
+def mark_read_state_changed(connection: sqlite3.Connection, app_id: str) -> None:
+    """Invalidate app reads in the caller's visible-state transaction."""
+    connection.execute("UPDATE apps SET read_revision=read_revision+1 WHERE id=?", (app_id,))
+
+
+def identity_policy_status(
+    connection: sqlite3.Connection, config: WorkTraceConfig, app_id: str
+) -> dict[str, Any]:
+    config.app(app_id)
+    policy = connection.execute(
+        "SELECT * FROM app_identity_policy WHERE app_id=?", (app_id,)
+    ).fetchone()
+    warnings: list[str] = []
+    valid = (
+        policy is not None
+        and int(policy["version"]) == IDENTITY_POLICY_VERSION
+        and policy["fingerprint"] == identity_fingerprint(config)
+    )
+    if not valid:
+        warnings.append("identity_policy_unaccepted: personal attribution requires identity repair")
+    legacy = connection.execute(
+        "SELECT 1 FROM actors a JOIN participations p ON p.actor_id=a.id "
+        "JOIN source_objects s ON s.id=p.source_object_id "
+        "WHERE s.app_id=? AND a.source!='manual' AND a.identity_policy_version<>? LIMIT 1",
+        (app_id, IDENTITY_POLICY_VERSION),
+    ).fetchone()
+    if legacy is not None:
+        valid = False
+        warnings.append("identity_policy_legacy: unverified actor flags cannot support self claims")
+    rebuild = bool(policy is not None and policy["rebuild_required"])
+    if rebuild:
+        warnings.append("identity_rebuild_required: rebuild references and candidates")
+    targets = [
+        str(row[0])
+        for row in connection.execute(
+            "SELECT DISTINCT target_id FROM identity_rereview WHERE app_id=? ORDER BY target_id",
+            (app_id,),
+        )
+    ]
+    if targets:
+        warnings.append(
+            "identity_requires_rereview: confirmed history was affected by identity repair"
+        )
+    return {
+        "valid": valid,
+        "version": IDENTITY_POLICY_VERSION,
+        "fingerprint": identity_fingerprint(config),
+        "rebuild_required": rebuild,
+        "requires_rereview": targets,
+        "warnings": warnings,
+    }
+
+
+def prepare_identity_import(
+    connection: sqlite3.Connection, config: WorkTraceConfig, key: bytes, app_id: str
+) -> None:
+    """Resolve accepted policy and key before any source run or provider page."""
+    config.app(app_id)
+    with _transition(connection):
+        connection.execute("UPDATE apps SET read_revision=read_revision WHERE id=?", (app_id,))
+        if not _key_matches(connection, key):
+            initialize_identity(connection, config, key)
+        status = identity_policy_status(connection, config, app_id)
+        if not status["valid"]:
+            raise ConfigurationError("identity policy requires repair before importing")
+
+
+def _check_legacy_proof(
+    connection: sqlite3.Connection,
+    config: WorkTraceConfig,
+    key: bytes,
+    proof_actor_id: str | None,
+    proof_alias_index: int | None,
+) -> None:
+    aliases = config.identity.git_author_emails
+    if (
+        proof_actor_id is None
+        or proof_alias_index is None
+        or not 0 <= proof_alias_index < len(aliases)
+    ):
+        raise ConfigurationError(
+            "legacy enrollment needs a known actor ID and configured alias index"
+        )
+    row = connection.execute(
+        "SELECT email_hash FROM actors WHERE id=? AND source IN ('git','gitlab')",
+        (proof_actor_id,),
+    ).fetchone()
+    if (
+        row is None
+        or row[0] is None
+        or not hmac.compare_digest(
+            str(row[0]), Redactor(key).hash_email(aliases[proof_alias_index])
+        )
+    ):
+        raise ConfigurationError("legacy identity proof does not match; restore the matching key")
+
+
+def _affected_targets(connection: sqlite3.Connection, app_id: str, objects: set[str]) -> list[str]:
+    targets: set[str] = set()
+    for lineage in decision_lineages(connection, active_only=False):
+        if lineage.app_id != app_id:
+            continue
+        mentioned: set[str] = set()
+        for decision in lineage.decisions:
+            mentioned.update(snapshot_member_ids(decision.payload))
+            member = decision.payload.get("source_object_id")
+            if isinstance(member, str):
+                mentioned.add(member)
+        if mentioned & objects:
+            targets.update(lineage.candidate_ids | lineage.contribution_ids)
+    # Earlier confirm records may predate immutable creation snapshots.
+    scopes = decision_scope_map(connection)
+    for decision in decision_stream(connection):
+        if scopes.get(decision.id) != app_id or decision.action not in {
+            "confirm",
+            "confirm_candidate",
+        }:
+            continue
+        members = snapshot_member_ids(decision.payload)
+        members.update(
+            str(row[0])
+            for row in connection.execute(
+                "SELECT source_object_id FROM candidate_members WHERE candidate_id=?",
+                (decision.target_id,),
+            )
+        )
+        if members & objects:
+            targets.add(decision.target_id)
+    return sorted(targets)
+
+
+def _proposal(
+    connection: sqlite3.Connection,
+    config: WorkTraceConfig,
+    key: bytes,
+    app_id: str,
+    verified_self_ids: dict[str, str],
+    verified_gitlab_email_hashes: frozenset[str],
+) -> dict[str, Any]:
+    hashes = {Redactor(key).hash_email(email) for email in config.identity.git_author_emails}
+    actors = list(
+        connection.execute(
+            "SELECT DISTINCT a.* FROM actors a JOIN participations p ON p.actor_id=a.id "
+            "JOIN source_objects s ON s.id=p.source_object_id WHERE s.app_id=? ORDER BY a.id",
+            (app_id,),
+        )
+    )
+    changes: list[dict[str, Any]] = []
+    unresolved: list[str] = []
+    blocked_providers: list[str] = []
+    affected_apps: set[str] = {app_id}
+    objects: set[str] = set()
+    policy = connection.execute(
+        "SELECT * FROM app_identity_policy WHERE app_id=?", (app_id,)
+    ).fetchone()
+    policy_changed = (
+        policy is None
+        or int(policy["version"]) != IDENTITY_POLICY_VERSION
+        or policy["fingerprint"] != identity_fingerprint(config)
+    )
+    for actor in actors:
+        source = str(actor["source"])
+        if source == "manual":
+            continue
+        email_identity = source == "git" or (
+            source == "gitlab" and actor["external_actor_id"] == actor["email_hash"]
+        )
+        if not email_identity:
+            # Config alone does not prove which account authenticated to a provider.
+            if source in verified_self_ids:
+                desired = actor["external_actor_id"] == verified_self_ids[source]
+            elif policy_changed or int(actor["identity_policy_version"]) != IDENTITY_POLICY_VERSION:
+                unresolved.append(str(actor["id"]))
+                blocked_providers.append(str(actor["id"]))
+                continue
+            else:
+                continue
+        else:
+            allowed = hashes | (verified_gitlab_email_hashes if source == "gitlab" else set())
+            desired = actor["email_hash"] is not None and actor["email_hash"] in allowed
+            if (
+                source == "gitlab"
+                and not desired
+                and bool(actor["is_self"])
+                and int(actor["identity_policy_version"]) == IDENTITY_POLICY_VERSION
+                and source not in verified_self_ids
+            ):
+                # A previously verified provider email may not be a configured Git alias.
+                unresolved.append(str(actor["id"]))
+                blocked_providers.append(str(actor["id"]))
+                continue
+            if actor["email_hash"] is None:
+                unresolved.append(str(actor["id"]))
+        if (
+            bool(actor["is_self"]) == desired
+            and int(actor["identity_policy_version"]) == IDENTITY_POLICY_VERSION
+        ):
+            continue
+        changes.append(
+            {"actor_id": str(actor["id"]), "before": bool(actor["is_self"]), "after": desired}
+        )
+        for reach in connection.execute(
+            "SELECT DISTINCT s.id, s.app_id FROM participations p "
+            "JOIN source_objects s ON s.id=p.source_object_id WHERE p.actor_id=?",
+            (actor["id"],),
+        ):
+            objects.add(str(reach[0]))
+            affected_apps.add(str(reach[1]))
+    confirmed_by_app = {
+        affected_app: _affected_targets(connection, affected_app, objects)
+        for affected_app in sorted(affected_apps)
+    }
+    report: dict[str, Any] = {
+        "app_id": app_id,
+        "policy_version": IDENTITY_POLICY_VERSION,
+        "fingerprint": identity_fingerprint(config),
+        "changes": changes,
+        "promotions": sum(not item["before"] and item["after"] for item in changes),
+        "demotions": sum(item["before"] and not item["after"] for item in changes),
+        "unresolved_actor_ids": unresolved,
+        "provider_verification_required": blocked_providers,
+        "verified_sources": sorted(verified_self_ids),
+        "affected_apps": sorted(affected_apps),
+        "confirmed_targets": sorted(
+            {target for targets in confirmed_by_app.values() for target in targets}
+        ),
+        "confirmed_targets_by_app": confirmed_by_app,
+        "cross_app_scope_required": affected_apps != {app_id},
+    }
+    report["previous_policy"] = dict(policy) if policy is not None else None
+    report["proposal_token"] = hashlib.sha256(
+        json.dumps(report, sort_keys=True).encode()
+    ).hexdigest()
+    return report
+
+
+def repair_identities(
+    connection: sqlite3.Connection,
+    config: WorkTraceConfig,
+    key: bytes,
+    app_id: str,
+    *,
+    apply: bool = False,
+    proof_actor_id: str | None = None,
+    proof_alias_index: int | None = None,
+    expected_proposal: str | None = None,
+    verified_self_ids: dict[str, str] | None = None,
+    verified_gitlab_email_hashes: frozenset[str] = frozenset(),
+) -> dict[str, Any]:
+    """Report exact-identity reconciliation, or apply within the caller's commit."""
+    config.app(app_id)
+    verified = verified_self_ids or {}
+    if any(source not in {"jira", "gitlab"} for source in verified):
+        raise ConfigurationError("unsupported verified identity source")
+    if "jira" in verified and verified["jira"] != config.identity.jira_account_id:
+        raise ConfigurationError("verified Jira identity differs from configured account")
+    if "gitlab" in verified:
+        numeric = verified["gitlab"]
+        configured = config.identity.gitlab_user_id
+        if (
+            not numeric.isascii()
+            or not numeric.isdecimal()
+            or int(numeric) < 1
+            or (configured is not None and str(configured) != numeric)
+            or (configured is None and not config.identity.gitlab_username)
+        ):
+            raise ConfigurationError("verified GitLab identity differs from configured account")
+    if verified_gitlab_email_hashes and "gitlab" not in verified:
+        raise ConfigurationError("verified GitLab email requires verified account identity")
+    with _transition(connection):
+        if apply:
+            # Reserve the writer before reading a proposal; stale WAL snapshots fail safely.
+            connection.execute("UPDATE apps SET read_revision=read_revision WHERE id=?", (app_id,))
+        bound = _key_matches(connection, key)
+        if not bound:
+            _check_legacy_proof(connection, config, key, proof_actor_id, proof_alias_index)
+        report = _proposal(connection, config, key, app_id, verified, verified_gitlab_email_hashes)
+        if expected_proposal is not None and expected_proposal != report["proposal_token"]:
+            raise ConfigurationError("identity proposal changed; repeat the dry run")
+        report["applied"] = False
+        if not apply:
+            return report
+        if report["cross_app_scope_required"]:
+            raise ScopeViolation(
+                "identity repair reaches other apps; expanded scope requires review"
+            )
+        if not bound:
+            _bind_key(connection, key)
+        for change in report["changes"]:
+            connection.execute(
+                "UPDATE actors SET is_self=?, identity_policy_version=? WHERE id=?",
+                (int(change["after"]), IDENTITY_POLICY_VERSION, change["actor_id"]),
+            )
+        _accept_policy(connection, config, app_id)
+        if report["provider_verification_required"]:
+            connection.execute("UPDATE app_identity_policy SET version=0 WHERE app_id=?", (app_id,))
+        connection.execute(
+            "UPDATE app_identity_policy SET rebuild_required=1 WHERE app_id=?", (app_id,)
+        )
+        mark_read_state_changed(connection, app_id)
+        report["applied"] = True
+        repair_id = "identity-repair:" + str(uuid.uuid4())
+        connection.execute(
+            "INSERT INTO identity_repair_audit VALUES (?, ?, ?, ?)",
+            (repair_id, app_id, datetime.now(UTC).isoformat(), json.dumps(report, sort_keys=True)),
+        )
+        for target in report["confirmed_targets"]:
+            connection.execute(
+                "INSERT INTO identity_rereview VALUES (?, ?, ?)", (app_id, target, repair_id)
+            )
+        report["repair_id"] = repair_id
+        return report
+
+
+def finish_identity_rebuild(
+    connection: sqlite3.Connection, config: WorkTraceConfig, app_id: str
+) -> None:
+    """Only clear derived-state invalidation after both canonical rebuilds succeed."""
+    if not identity_policy_status(connection, config, app_id)["valid"]:
+        raise ConfigurationError("identity policy requires repair before rebuilding")
+    connection.execute(
+        "UPDATE app_identity_policy SET rebuild_required=0 WHERE app_id=?", (app_id,)
+    )
+    mark_read_state_changed(connection, app_id)

--- a/src/worktrace/importers/orchestrator.py
+++ b/src/worktrace/importers/orchestrator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import date, datetime
 
-from worktrace.adapters.base import NormalizedRecord, SnapshotAdapter
+from worktrace.adapters.base import ActorIdentity, NormalizedRecord, SnapshotAdapter
 from worktrace.config import AppConfig
 from worktrace.db.repository import EvidenceRepository
 from worktrace.domain.enums import Completeness
@@ -56,6 +56,25 @@ def _kind(source: str, object_type: str) -> str:
     return aliases.get((source, object_type), f"{source}_{object_type}")
 
 
+def _is_self_actor(
+    source: str, object_type: str, actor: ActorIdentity, self_actor_ids: set[str]
+) -> bool:
+    if source == "git":
+        return actor.email_hash is not None and actor.email_hash in self_actor_ids
+    if source == "gitlab":
+        if actor.source_actor_id.isascii() and actor.source_actor_id.isdecimal():
+            return int(actor.source_actor_id) > 0 and actor.source_actor_id in self_actor_ids
+        # Only email-identified commit actors may use configured/verified aliases.
+        # A different provider user ID must never be overridden by its email.
+        return (
+            object_type == "merge_request_commit"
+            and actor.email_hash is not None
+            and actor.source_actor_id == actor.email_hash
+            and actor.email_hash in self_actor_ids
+        )
+    return actor.source_actor_id in self_actor_ids
+
+
 def record_to_object(
     record: NormalizedRecord,
     self_actor_ids: set[str],
@@ -63,6 +82,8 @@ def record_to_object(
     *,
     completeness: Completeness = Completeness.COMPLETE,
 ) -> NormalizedObject:
+    # Kept for existing adapter callers; names are display data, never identity evidence.
+    del self_display_names
     identity = record.identity
     payload = dict(record.payload)
     payload["_untrusted_text_fields"] = list(record.untrusted_text_fields)
@@ -97,12 +118,8 @@ def record_to_object(
                 external_actor_id=actor.source_actor_id,
                 display_name=actor.display_name or actor.username or "Unknown source actor",
                 email_hash=actor.email_hash,
-                is_self=(
-                    actor.source_actor_id in self_actor_ids
-                    or bool(
-                        actor.display_name
-                        and actor.display_name.casefold() in (self_display_names or set())
-                    )
+                is_self=_is_self_actor(
+                    identity.source_kind, identity.object_type, actor, self_actor_ids
                 ),
             ),
         )

--- a/src/worktrace/mcp_server/tools.py
+++ b/src/worktrace/mcp_server/tools.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from worktrace.config import WorkTraceConfig, load_config
 from worktrace.constants import DEFAULT_EXCERPT_CHARS
 from worktrace.db.connection import connect_read_only
+from worktrace.db.readiness import DatabaseReadinessStatus, database_readiness
+from worktrace.errors import DatabaseError
 from worktrace.mcp_server.limits import enforce_total_limit
 from worktrace.mcp_server.schemas import app_id as validate_app_id
 from worktrace.mcp_server.schemas import (
@@ -51,6 +53,8 @@ class WorkTraceTools:
         path = (self._database_path or config.database_path).expanduser().resolve()
         connection = connect_read_only(path)
         try:
+            if database_readiness(connection).status is not DatabaseReadinessStatus.READY:
+                raise DatabaseError("unsupported database schema; use the matching CLI to upgrade")
             yield PacketBuilder(connection, config)
         finally:
             connection.close()

--- a/src/worktrace/packets/builder.py
+++ b/src/worktrace/packets/builder.py
@@ -36,6 +36,7 @@ from worktrace.db.authority import (
 )
 from worktrace.domain.enums import ClaimStatus, ObservationType
 from worktrace.errors import NotFound, ScopeViolation
+from worktrace.identity import identity_policy_status
 from worktrace.packets.authority import (
     attested_answer,
     find_attestation,
@@ -851,12 +852,14 @@ class PacketBuilder:
 
     def contribution_summary(self, identifier: str) -> dict[str, object]:
         contribution = self._resolve_contribution(identifier)
+        identity_state = identity_policy_status(self.connection, self.config, contribution.app_id)
         records = self._records(contribution)
         title_provenance = self._title_provenance(contribution, records)
         participation = build_participation_summary(
             self.connection,
             records,
             contribution.attestations,
+            self_identity_valid=bool(identity_state["valid"]),
             current_participation_rows=(
                 self._authority_context.participation_rows_by_observation
                 if self._authority_context is not None
@@ -915,10 +918,12 @@ class PacketBuilder:
             "modules": modules,
             "module_evidence_ids": [record.evidence_id for record in module_evidence],
             "participation": participation,
+            "identity_policy": identity_state,
             "release_ladder": release_ladder,
             "source_status": self.source_status(contribution.app_id),
             "contradictions": contradictions,
             "limitations": [
+                *identity_state["warnings"],
                 "Context-only records are not used as implementation or ownership proof.",
                 "Source text is untrusted and available only through bounded excerpts.",
                 *(
@@ -1423,6 +1428,7 @@ class PacketBuilder:
             },
             "sections": sections,
             "participation": summary["participation"],
+            "identity_policy": summary["identity_policy"],
             "release_ladder": summary["release_ladder"],
             "contradictions": summary["contradictions"],
             "defensibility": {
@@ -1480,6 +1486,9 @@ class PacketBuilder:
             self.connection,
             records,
             [],
+            self_identity_valid=bool(
+                identity_policy_status(self.connection, self.config, app_id)["valid"]
+            ),
             current_participation_rows=(
                 self._authority_context.participation_rows_by_observation
                 if self._authority_context is not None
@@ -1781,7 +1790,10 @@ class PacketBuilder:
         participation = self.connection.execute(
             f"""
             WITH {authoritative_current_participation_ctes()}
-            SELECT p.*, a.display_name, a.is_self, so.app_id, so.source, so.kind,
+            SELECT p.*, a.display_name,
+                   CASE WHEN a.identity_policy_version=1 OR a.source='manual'
+                        THEN a.is_self ELSE 0 END AS is_self,
+                   so.app_id, so.source, so.kind,
                    so.external_id, sr.status AS run_status,
                    sr.completeness AS run_completeness
             FROM authoritative_current_participations p
@@ -1805,7 +1817,11 @@ class PacketBuilder:
                 "external_id": str(participation["external_id"]),
                 "role": str(participation["role"]),
                 "actor_display_name": str(participation["display_name"]),
-                "is_self": bool(participation["is_self"]),
+                "is_self": bool(participation["is_self"])
+                and bool(
+                    participation["source"] == "manual"
+                    or identity_policy_status(self.connection, self.config, app_id)["valid"]
+                ),
                 "effective_from": participation["effective_from"],
                 "effective_to": participation["effective_to"],
                 "run_status": str(participation["run_status"]),

--- a/src/worktrace/packets/ownership.py
+++ b/src/worktrace/packets/ownership.py
@@ -25,6 +25,7 @@ def build_participation_summary(
     attestations: Sequence[HumanAttestation],
     *,
     current_participation_rows: Mapping[str, tuple[sqlite3.Row, ...]] | None = None,
+    self_identity_valid: bool = True,
 ) -> dict[str, object]:
     """Return role observations without converting them into ownership labels."""
 
@@ -51,7 +52,10 @@ def build_participation_summary(
                     WITH {authoritative_current_participation_ctes()}
                     SELECT p.id, p.source_object_id, p.observation_id, p.role,
                         p.effective_from, p.effective_to, a.id AS actor_id,
-                        a.display_name, a.is_self, so.source, so.kind, so.external_id
+                        a.display_name,
+                        CASE WHEN a.identity_policy_version=1 OR a.source='manual'
+                             THEN a.is_self ELSE 0 END AS is_self,
+                        so.source, so.kind, so.external_id
                     FROM authoritative_current_participations p
                     JOIN actors a ON a.id=p.actor_id
                     JOIN source_objects so ON so.id=p.source_object_id
@@ -62,8 +66,16 @@ def build_participation_summary(
                 )
             )
 
-    self_rows = [row for row in rows if bool(row["is_self"])]
-    other_rows = [row for row in rows if not bool(row["is_self"])]
+    self_rows = [
+        row
+        for row in rows
+        if (self_identity_valid or row["source"] == "manual") and bool(row["is_self"])
+    ]
+    other_rows = [
+        row
+        for row in rows
+        if not ((self_identity_valid or row["source"] == "manual") and bool(row["is_self"]))
+    ]
     data_by_object = {record.object_id: record.data for record in records}
     self_by_object: dict[str, set[str]] = {}
     for row in self_rows:

--- a/src/worktrace/services.py
+++ b/src/worktrace/services.py
@@ -66,7 +66,13 @@ def add_manual_evidence(
     return observation_ids[0]
 
 
-def export_app(connection: sqlite3.Connection, app_id: str, destination: Path) -> int:
+def export_app(
+    connection: sqlite3.Connection,
+    app_id: str,
+    destination: Path,
+    *,
+    identity_state: dict[str, object] | None = None,
+) -> int:
     current = EvidenceRepository(connection).current_observations(app_id)
     current_object_ids = {str(row["source_object_id"]) for row in current}
     current_observation_ids = {str(row["id"]) for row in current}
@@ -251,8 +257,13 @@ def export_app(connection: sqlite3.Connection, app_id: str, destination: Path) -
         "selection": "authoritative current observations only; legacy overbroad runs excluded",
     }
     payload["apps"] = [
-        dict(row) for row in connection.execute("SELECT * FROM apps WHERE id=?", (app_id,))
+        dict(row)
+        for row in connection.execute(
+            "SELECT id, name, market, business_type FROM apps WHERE id=?", (app_id,)
+        )
     ]
+    if identity_state is not None:
+        payload["identity_policy"] = identity_state
     sync_run_rows = [
         dict(row)
         for row in connection.execute(
@@ -300,11 +311,15 @@ def export_app(connection: sqlite3.Connection, app_id: str, destination: Path) -
         for row in connection.execute(
             f"""
             WITH {authoritative_current_participation_ctes()}
-            SELECT DISTINCT a.* FROM actors a
+            SELECT DISTINCT a.id, a.source, a.source_instance, a.external_actor_id,
+                a.display_name, a.email_hash,
+                CASE WHEN a.source='manual' OR (a.identity_policy_version=1 AND ?)
+                     THEN a.is_self ELSE 0 END AS is_self
+            FROM actors a
             JOIN authoritative_current_participations p ON p.actor_id=a.id
             WHERE p.observation_id IN ({placeholders(observation_ids)})
             """,
-            observation_ids,
+            [identity_state is None or bool(identity_state["valid"]), *observation_ids],
         )
     ]
     payload["source_object_availability_events"] = availability_rows

--- a/tests/test_acceptance_recovery.py
+++ b/tests/test_acceptance_recovery.py
@@ -571,6 +571,9 @@ def test_import_all_uses_git_then_gitlab_then_jira_discovery(
             self.source = source
             self.source_instance = str(cast(AdapterConfigView, adapter_config).source_instance)
 
+        def resolved_self_ids(self, configured_email_hashes: set[str]) -> set[str]:
+            return {"7", *configured_email_hashes}
+
         def iter_pages(self) -> Iterator[NormalizedPage]:
             yield NormalizedPage(
                 source_kind=self.source,

--- a/tests/test_availability_migration.py
+++ b/tests/test_availability_migration.py
@@ -72,8 +72,8 @@ def test_populated_v2_upgrade_preserves_ids_and_seeds_baseline(tmp_path: Path) -
         )
         connection.commit()
 
-        assert migrate(connection, database_path) == [3]
-        assert user_version(connection) == 3
+        assert migrate(connection, database_path) == [3, 4]
+        assert user_version(connection) == 4
         assert connection.execute("SELECT id FROM source_objects").fetchone()[0] == "obj:stable"
         assert connection.execute("SELECT id FROM observations").fetchone()[0] == "obs:stable"
         assert (

--- a/tests/test_candidate_paging.py
+++ b/tests/test_candidate_paging.py
@@ -21,6 +21,7 @@ from worktrace.config import AppConfig, IdentityConfig, WorkTraceConfig
 from worktrace.db.connection import connect, connect_read_only
 from worktrace.db.migrations import migrate
 from worktrace.errors import ScopeViolation
+from worktrace.identity import identity_fingerprint
 from worktrace.packets.builder import PacketBuilder, _build_authority_evidence_context
 from worktrace.read_models.candidates import (
     _ACTIVE_GENERATION_SQL,
@@ -99,6 +100,10 @@ def _initialize(database_path: Path) -> sqlite3.Connection:
     connection.execute(
         "INSERT INTO apps(id, name, market, business_type) VALUES (?, ?, ?, ?)",
         (_APP_ID, "Sample Store", "XX", "fixture"),
+    )
+    connection.execute(
+        "INSERT INTO app_identity_policy(app_id, version, fingerprint) VALUES (?, 1, ?)",
+        (_APP_ID, identity_fingerprint(_config(database_path.parent))),
     )
     return connection
 
@@ -304,8 +309,9 @@ def _build_scale_database(database_path: Path, *, candidate_count: int = 3_000) 
         connection.executemany(
             """
             INSERT INTO actors(
-                id, source, source_instance, external_actor_id, display_name, is_self
-            ) VALUES (?, ?, ?, ?, ?, 1)
+                id, source, source_instance, external_actor_id, display_name, is_self,
+                identity_policy_version
+            ) VALUES (?, ?, ?, ?, ?, 1, 1)
             """,
             actor_rows,
         )

--- a/tests/test_candidates_decisions.py
+++ b/tests/test_candidates_decisions.py
@@ -332,15 +332,17 @@ def test_mr_author_with_complete_paths_and_other_authored_commit_is_not_implemen
         connection.execute(
             """
             INSERT INTO actors(
-                id, source, source_instance, external_actor_id, display_name, is_self
-            ) VALUES ('actor:gitlab:self', 'gitlab', '101', '7', 'Fixture Engineer', 1)
+                id, source, source_instance, external_actor_id, display_name, is_self,
+                identity_policy_version
+            ) VALUES ('actor:gitlab:self', 'gitlab', '101', '7', 'Fixture Engineer', 1, 1)
             """
         )
         connection.execute(
             """
             INSERT INTO actors(
-                id, source, source_instance, external_actor_id, display_name, is_self
-            ) VALUES ('actor:gitlab:other', 'gitlab', '101', '8', 'Collaborator', 0)
+                id, source, source_instance, external_actor_id, display_name, is_self,
+                identity_policy_version
+            ) VALUES ('actor:gitlab:other', 'gitlab', '101', '8', 'Collaborator', 0, 1)
             """
         )
         connection.execute(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,7 +64,7 @@ def test_cli_help_init_status_search_export_and_confirmed_purge(
 
     first_init = runner.invoke(app, ["init", "--config", str(config)])
     assert first_init.exit_code == 0, first_init.stdout
-    assert json.loads(first_init.stdout)["migrations_applied"] == [1, 2, 3]
+    assert json.loads(first_init.stdout)["migrations_applied"] == [1, 2, 3, 4]
 
     second_init = runner.invoke(app, ["init", "--config", str(config)])
     assert second_init.exit_code == 0, second_init.stdout
@@ -77,7 +77,10 @@ def test_cli_help_init_status_search_export_and_confirmed_purge(
 
     status = runner.invoke(app, ["status", "sample_store", "--config", str(config)])
     assert status.exit_code == 0, status.stdout
-    assert json.loads(status.stdout) == {"app_id": "sample_store", "sources": []}
+    status_body = json.loads(status.stdout)
+    assert status_body["app_id"] == "sample_store"
+    assert status_body["sources"] == []
+    assert status_body["identity"]["valid"] is True
 
     search = runner.invoke(
         app,

--- a/tests/test_coherent_backup.py
+++ b/tests/test_coherent_backup.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import sqlite3
+import stat
+import time
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+import worktrace.db.migrations as migration_module
+from worktrace.db.connection import connect
+from worktrace.db.migrations import Migration, backup_database, migrate, user_version
+from worktrace.errors import DatabaseError
+
+
+def _populate(path: Path, *, wal: bool = False) -> sqlite3.Connection:
+    connection = sqlite3.connect(path, autocommit=True)
+    if wal:
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA wal_autocheckpoint=0")
+    connection.execute("CREATE TABLE sentinel(value TEXT)")
+    connection.execute("INSERT INTO sentinel VALUES ('original')")
+    return connection
+
+
+def _one_migration(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    migration = Migration(1, tmp_path / "001_fixture.sql", "CREATE TABLE added(value TEXT);\n")
+    monkeypatch.setattr(migration_module, "migrations", lambda: (migration,))
+
+
+def test_backup_contains_latest_committed_wal_pages(tmp_path: Path) -> None:
+    path = tmp_path / "ledger ?# .sqlite3"
+    destination = tmp_path / "private" / "snapshot.backup"
+    with closing(_populate(path, wal=True)) as writer:
+        writer.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        main_before = path.read_bytes()
+        writer.execute("INSERT INTO sentinel VALUES ('committed-in-wal')")
+        assert path.read_bytes() == main_before
+        assert Path(f"{path}-wal").stat().st_size > 0
+
+        assert backup_database(path, destination) == destination
+        with closing(sqlite3.connect(destination)) as restored:
+            assert restored.execute("SELECT value FROM sentinel ORDER BY rowid").fetchall() == [
+                ("original",),
+                ("committed-in-wal",),
+            ]
+            assert restored.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        assert stat.S_IMODE(destination.stat().st_mode) == 0o600
+        assert stat.S_IMODE(destination.parent.stat().st_mode) == 0o700
+
+
+@pytest.mark.parametrize("symlink", [False, True])
+def test_backup_never_replaces_existing_destination(tmp_path: Path, symlink: bool) -> None:
+    path = tmp_path / "ledger.sqlite3"
+    destination = tmp_path / "snapshot.backup"
+    protected = tmp_path / "protected"
+    protected.write_bytes(b"keep this")
+    if symlink:
+        destination.symlink_to(protected)
+    else:
+        destination.write_bytes(b"keep this")
+    with closing(_populate(path)), pytest.raises(FileExistsError):
+        backup_database(path, destination)
+    assert destination.read_bytes() == protected.read_bytes() == b"keep this"
+    assert destination.is_symlink() is symlink
+
+
+def test_backup_contention_is_bounded_and_retry_recovers(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(migration_module, "BACKUP_TIMEOUT_SECONDS", 0.05)
+    path = tmp_path / "ledger.sqlite3"
+    destination = tmp_path / "snapshot.backup"
+    with closing(_populate(path)) as writer:
+        writer.execute("BEGIN EXCLUSIVE")
+        writer.execute("INSERT INTO sentinel VALUES ('uncommitted')")
+        started = time.monotonic()
+        with pytest.raises(DatabaseError, match="backup timed out"):
+            backup_database(path, destination)
+        assert time.monotonic() - started < 1
+        assert not destination.exists()
+        writer.execute("ROLLBACK")
+        assert backup_database(path, destination) == destination
+        with closing(sqlite3.connect(destination)) as restored:
+            assert restored.execute("SELECT value FROM sentinel").fetchall() == [("original",)]
+
+
+def test_backup_failure_cleans_only_new_destination(tmp_path: Path) -> None:
+    path = tmp_path / "corrupt.sqlite3"
+    original = b"not a SQLite database"
+    path.write_bytes(original)
+    destination = tmp_path / "snapshot.backup"
+    with pytest.raises(DatabaseError, match="backup failed"):
+        backup_database(path, destination)
+    assert not destination.exists()
+    assert path.read_bytes() == original
+
+
+@pytest.mark.parametrize("wal", [False, True])
+def test_migration_backs_up_before_changes_with_autocommit_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, wal: bool
+) -> None:
+    _one_migration(tmp_path, monkeypatch)
+    path = tmp_path / "ledger.sqlite3"
+    with closing(_populate(path, wal=wal)) as writer, closing(connect(path)) as connection:
+        writer.execute("INSERT INTO sentinel VALUES ('latest')")
+        assert connection.autocommit is False
+        assert migrate(connection, path) == [1]
+        assert connection.autocommit is False
+        assert connection.execute("PRAGMA busy_timeout").fetchone()[0] == 10_000
+        assert user_version(connection) == 1
+        backups = list(tmp_path.glob("*.backup"))
+        assert len(backups) == 1
+        with closing(sqlite3.connect(backups[0])) as restored:
+            assert user_version(restored) == 0
+            assert restored.execute("SELECT value FROM sentinel ORDER BY rowid").fetchall() == [
+                ("original",),
+                ("latest",),
+            ]
+            assert (
+                restored.execute("SELECT name FROM sqlite_master WHERE name='added'").fetchone()
+                is None
+            )
+
+
+def test_migration_contention_aborts_before_backup_or_mutation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _one_migration(tmp_path, monkeypatch)
+    monkeypatch.setattr(migration_module, "MIGRATION_BUSY_TIMEOUT_MS", 50)
+    path = tmp_path / "ledger.sqlite3"
+    with closing(_populate(path)) as writer, closing(connect(path)) as connection:
+        writer.execute("BEGIN IMMEDIATE")
+        started = time.monotonic()
+        with pytest.raises(DatabaseError, match="lock"):
+            migrate(connection, path)
+        assert time.monotonic() - started < 1
+        assert not list(tmp_path.glob("*.backup"))
+        assert user_version(connection) == 0
+        assert connection.autocommit is False
+        writer.execute("ROLLBACK")
+        assert migrate(connection, path) == [1]
+
+
+def test_migration_keeps_writer_reservation_during_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _one_migration(tmp_path, monkeypatch)
+    path = tmp_path / "ledger.sqlite3"
+    original_backup = backup_database
+    blocked_writes: list[bool] = []
+
+    def inspect_backup(path: Path, destination: Path | None = None) -> Path | None:
+        with closing(sqlite3.connect(path, autocommit=True, timeout=0)) as other:
+            with pytest.raises(sqlite3.OperationalError, match="locked"):
+                other.execute("INSERT INTO sentinel VALUES ('interloper')")
+            blocked_writes.append(True)
+        return original_backup(path, destination)
+
+    monkeypatch.setattr(migration_module, "backup_database", inspect_backup)
+    with closing(_populate(path)), closing(connect(path)) as connection:
+        assert migrate(connection, path) == [1]
+    assert blocked_writes == [True]
+
+
+def test_reader_blocking_migration_commit_rolls_back_and_can_retry(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _one_migration(tmp_path, monkeypatch)
+    monkeypatch.setattr(migration_module, "MIGRATION_BUSY_TIMEOUT_MS", 50)
+    path = tmp_path / "ledger.sqlite3"
+    with closing(_populate(path)) as reader, closing(connect(path)) as connection:
+        reader.execute("BEGIN")
+        reader.execute("SELECT * FROM sentinel").fetchall()
+        started = time.monotonic()
+        with pytest.raises(DatabaseError, match="lock"):
+            migrate(connection, path)
+        assert time.monotonic() - started < 1
+        assert user_version(connection) == 0
+        assert (
+            connection.execute("SELECT name FROM sqlite_master WHERE name='added'").fetchone()
+            is None
+        )
+        assert len(list(tmp_path.glob("*.backup"))) == 1
+        reader.execute("ROLLBACK")
+        assert migrate(connection, path) == [1]
+
+
+def test_later_migration_failure_rolls_back_the_whole_upgrade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "ledger.sqlite3"
+    migrations = (
+        Migration(1, tmp_path / "001_first.sql", "CREATE TABLE added(value TEXT);\n"),
+        Migration(2, tmp_path / "002_broken.sql", "INSERT INTO missing VALUES (1);\n"),
+    )
+    monkeypatch.setattr(migration_module, "migrations", lambda: migrations)
+    with closing(_populate(path)), closing(connect(path)) as connection:
+        with pytest.raises(DatabaseError, match="002_broken"):
+            migrate(connection, path)
+        assert user_version(connection) == 0
+        assert (
+            connection.execute("SELECT name FROM sqlite_master WHERE name='added'").fetchone()
+            is None
+        )
+        assert connection.execute("SELECT value FROM sentinel").fetchone()[0] == "original"
+
+
+def test_newer_schema_is_rejected_without_backup_or_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _one_migration(tmp_path, monkeypatch)
+    path = tmp_path / "ledger.sqlite3"
+    with closing(_populate(path)) as writer:
+        writer.execute("PRAGMA user_version=99")
+    with closing(connect(path)) as connection:
+        with pytest.raises(DatabaseError, match="newer"):
+            migrate(connection, path)
+        assert user_version(connection) == 99
+        assert connection.execute("SELECT value FROM sentinel").fetchone()[0] == "original"
+        assert connection.autocommit is False
+        assert not list(tmp_path.glob("*.backup"))
+
+
+def test_backup_failure_prevents_migration_and_releases_writer(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _one_migration(tmp_path, monkeypatch)
+    path = tmp_path / "ledger.sqlite3"
+
+    def failed_backup(path: Path, destination: Path | None = None) -> Path | None:
+        raise DatabaseError("synthetic backup failure")
+
+    monkeypatch.setattr(migration_module, "backup_database", failed_backup)
+    with closing(_populate(path)), closing(connect(path)) as connection:
+        with pytest.raises(DatabaseError, match="synthetic backup failure"):
+            migrate(connection, path)
+        assert user_version(connection) == 0
+        connection.rollback()
+        with closing(sqlite3.connect(path, autocommit=True, timeout=0)) as other:
+            other.execute("INSERT INTO sentinel VALUES ('writer released')")

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -15,9 +15,9 @@ def test_init_and_migrations_are_idempotent(tmp_path: Path) -> None:
     database_path = tmp_path / "worktrace.sqlite3"
     connection = connect(database_path)
     try:
-        assert migrate(connection, database_path) == [1, 2, 3]
+        assert migrate(connection, database_path) == [1, 2, 3, 4]
         assert migrate(connection, database_path) == []
-        assert user_version(connection) == 3
+        assert user_version(connection) == 4
 
         tables = {
             str(row[0])
@@ -161,7 +161,7 @@ def test_database_readiness_is_read_only_and_distinguishes_schema_drift(
     try:
         ready = database_readiness(read_only)
         assert ready.status is DatabaseReadinessStatus.READY
-        assert ready.current_version == ready.supported_version == 3
+        assert ready.current_version == ready.supported_version == 4
     finally:
         read_only.close()
 

--- a/tests/test_evidence_authority.py
+++ b/tests/test_evidence_authority.py
@@ -64,10 +64,7 @@ def _ledger(tmp_path: Path) -> tuple[sqlite3.Connection, Path]:
     database_path = tmp_path / "ledger.sqlite3"
     connection = connect(database_path)
     migrate(connection, database_path)
-    connection.execute(
-        "INSERT INTO apps(id, name, market, business_type) "
-        "VALUES ('sample_store', 'Sample Store', 'XX', 'fixture')"
-    )
+    EvidenceRepository(connection).ensure_apps(_config(tmp_path))
     connection.commit()
     return connection, database_path
 
@@ -797,9 +794,10 @@ def test_failed_reference_cannot_contradict_supported_claim_and_v2_control_can(
         connection.execute(
             """
             INSERT INTO actors(
-                id, source, source_instance, external_actor_id, display_name, is_self
+                id, source, source_instance, external_actor_id, display_name, is_self,
+                identity_policy_version
             ) VALUES ('actor:git-self', 'git', 'fixture-repo', 'fixture-self',
-                      'Fixture Engineer', 1)
+                      'Fixture Engineer', 1, 1)
             """
         )
         connection.execute(
@@ -1222,7 +1220,10 @@ def test_export_preserves_app_scoped_decision_closure_and_unsupported_history(
             "('candidate:legacy-history', 'obj:legacy-history', 'seed', 0)"
         )
 
-        connection.execute("INSERT INTO apps VALUES ('other_app', 'Other App', 'YY', 'fixture')")
+        connection.execute(
+            "INSERT INTO apps(id, name, market, business_type) "
+            "VALUES ('other_app', 'Other App', 'YY', 'fixture')"
+        )
         connection.execute(
             """
             INSERT INTO sync_runs(
@@ -1521,7 +1522,10 @@ def test_cross_app_creation_payload_cannot_override_candidate_or_export_scope(
             completed_at="2026-08-27T10:00:00+00:00",
             title="Scoped authoritative title",
         )
-        connection.execute("INSERT INTO apps VALUES ('other_app', 'Other App', 'YY', 'fixture')")
+        connection.execute(
+            "INSERT INTO apps(id, name, market, business_type) "
+            "VALUES ('other_app', 'Other App', 'YY', 'fixture')"
+        )
         connection.execute(
             """
             INSERT INTO candidate_groups(
@@ -2036,7 +2040,10 @@ def test_legacy_nested_undo_scope_follows_lineage_not_timestamp_order(
             "obj:legacy-undo-order",
             "Provider title",
         )
-        connection.execute("INSERT INTO apps VALUES ('other_app', 'Other App', 'YY', 'fixture')")
+        connection.execute(
+            "INSERT INTO apps(id, name, market, business_type) "
+            "VALUES ('other_app', 'Other App', 'YY', 'fixture')"
+        )
         connection.commit()
 
         confirmation_id = append_decision(
@@ -2712,7 +2719,10 @@ def test_secondary_alias_collision_is_app_scoped_and_ambiguous_decisions_fail_cl
 ) -> None:
     connection, database_path = _ledger(tmp_path)
     try:
-        connection.execute("INSERT INTO apps VALUES ('other_app', 'Other App', 'YY', 'fixture')")
+        connection.execute(
+            "INSERT INTO apps(id, name, market, business_type) "
+            "VALUES ('other_app', 'Other App', 'YY', 'fixture')"
+        )
         for app_id, suffix, hour in (
             ("sample_store", "a", 8),
             ("other_app", "b", 9),
@@ -2973,7 +2983,10 @@ def test_cross_app_contribution_collision_is_scoped_for_packets_and_export(
             "obj:collision-a",
             "Public app A title",
         )
-        connection.execute("INSERT INTO apps VALUES ('other_app', 'Other App', 'YY', 'fixture')")
+        connection.execute(
+            "INSERT INTO apps(id, name, market, business_type) "
+            "VALUES ('other_app', 'Other App', 'YY', 'fixture')"
+        )
         connection.execute(
             """
             INSERT INTO sync_runs(

--- a/tests/test_file_safety.py
+++ b/tests/test_file_safety.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import stat
 from pathlib import Path
 
@@ -72,7 +73,7 @@ def test_export_and_backup_are_mode_0600_before_content_is_written(
     export_observation: list[tuple[int, int]] = []
     backup_observation: list[tuple[int, int]] = []
     original_dump = services_module.json.dump
-    original_copy = migration_module.shutil.copyfileobj
+    original_connect = migration_module.sqlite3.connect
 
     def inspect_dump(value: object, output: object, **kwargs: object) -> None:
         descriptor = output.fileno()  # type: ignore[attr-defined]
@@ -81,15 +82,13 @@ def test_export_and_backup_are_mode_0600_before_content_is_written(
         )
         original_dump(value, output, **kwargs)  # type: ignore[arg-type]
 
-    def inspect_copy(source: object, target: object) -> None:
-        descriptor = target.fileno()  # type: ignore[attr-defined]
-        backup_observation.append(
-            (stat.S_IMODE(os.fstat(descriptor).st_mode), os.fstat(descriptor).st_size)
-        )
-        original_copy(source, target)  # type: ignore[arg-type]
+    def inspect_connect(database: str | Path, **kwargs: object) -> sqlite3.Connection:
+        if database == backup_path:
+            backup_observation.append((_mode(backup_path), backup_path.stat().st_size))
+        return original_connect(database, **kwargs)  # type: ignore[arg-type]
 
     monkeypatch.setattr(services_module.json, "dump", inspect_dump)
-    monkeypatch.setattr(migration_module.shutil, "copyfileobj", inspect_copy)
+    monkeypatch.setattr(migration_module.sqlite3, "connect", inspect_connect)
     try:
         assert export_app(connection, "sample_store", export_path) == 0
         assert backup_database(database_path, backup_path) == backup_path

--- a/tests/test_identity_cli.py
+++ b/tests/test_identity_cli.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from worktrace.cli import app
+from worktrace.errors import DatabaseError
+from worktrace.mcp_server.tools import WorkTraceTools
+
+
+@pytest.mark.parametrize("schema_version", [3, 99])
+def test_mcp_rejects_unsupported_schema_without_mutating_it(
+    tmp_path: Path, schema_version: int
+) -> None:
+    config, _, database = _workspace(tmp_path)
+    with sqlite3.connect(database) as connection:
+        connection.execute(f"PRAGMA user_version={schema_version}")
+    with pytest.raises(DatabaseError, match="unsupported database schema"):
+        WorkTraceTools(config_path=config).list_contribution_candidates(app_id="sample_store")
+    with sqlite3.connect(database) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == schema_version
+
+
+@pytest.fixture(autouse=True)
+def _isolate_identity_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in tuple(os.environ):
+        if name.startswith("WORKTRACE_"):
+            monkeypatch.delenv(name)
+
+
+def _git(repository: Path, *arguments: str, environment: dict[str, str] | None = None) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    ).stdout.strip()
+
+
+def _workspace(tmp_path: Path, *, providers: bool = False) -> tuple[Path, Path, Path]:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _git(repository, "init", "-q")
+    for index, (name, email, title) in enumerate(
+        [
+            ("Same Name", "colleague@example.test", "DEMO-1 collaborator change"),
+            ("Changed Name", "old-work@example.test", "DEMO-2 historical alias change"),
+        ],
+        start=1,
+    ):
+        (repository / f"change{index}.txt").write_text(title, encoding="utf-8")
+        _git(repository, "add", f"change{index}.txt")
+        environment = {
+            key: value for key, value in os.environ.items() if not key.startswith("GIT_")
+        }
+        environment.update(
+            GIT_AUTHOR_NAME=name,
+            GIT_AUTHOR_EMAIL=email,
+            GIT_COMMITTER_NAME="Integrator",
+            GIT_COMMITTER_EMAIL="current@example.test",
+            GIT_AUTHOR_DATE=f"2026-01-0{index}T10:00:00+00:00",
+            GIT_COMMITTER_DATE=f"2026-01-0{index}T11:00:00+00:00",
+            GIT_CONFIG_NOSYSTEM="1",
+            GIT_CONFIG_GLOBAL=os.devnull,
+        )
+        _git(
+            repository,
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-qm",
+            title,
+            environment=environment,
+        )
+    config = tmp_path / "config.toml"
+    config.write_text(
+        f"""schema_version = 1
+[data]
+directory = {str(tmp_path / "data")!r}
+[employment]
+from = "2026-01-01"
+to = "2026-01-31"
+[identity]
+display_name = "Same Name"
+git_author_emails = ["current@example.test", "old-work@example.test"]
+git_author_names = ["Same Name"]
+jira_account_id = "fixture-account"
+gitlab_username = "fixture-engineer"
+[[apps]]
+id = "sample_store"
+name = "Sample Store"
+market = "XX"
+business_type = "fixture"
+jira_project_keys = {'["DEMO"]' if providers else "[]"}
+gitlab_project_ids = {"[77]" if providers else "[]"}
+repo_paths = [{str(repository)!r}]
+""",
+        encoding="utf-8",
+    )
+    _invoke(config, "init")
+    return config, repository, tmp_path / "data" / "worktrace.sqlite3"
+
+
+def _invoke(config: Path, *arguments: str) -> Any:
+    result = CliRunner().invoke(app, [*arguments, "--config", str(config)])
+    assert result.exit_code == 0, f"{result.output}\n{result.exception!r}"
+    return json.loads(result.stdout)
+
+
+def _database_state(database: Path) -> str:
+    with sqlite3.connect(database) as connection:
+        return "\n".join(connection.iterdump())
+
+
+def test_public_git_import_preserves_exact_identity_and_packet_roles(tmp_path: Path) -> None:
+    config, repository, database = _workspace(tmp_path)
+    _invoke(config, "import", "git", "sample_store", str(repository))
+    with sqlite3.connect(database) as connection:
+        observed = connection.execute(
+            "SELECT DISTINCT a.display_name,a.is_self,p.role FROM actors a "
+            "JOIN participations p ON p.actor_id=a.id ORDER BY a.display_name,p.role"
+        ).fetchall()
+        unsupported_implementation = {
+            row[0]
+            for row in connection.execute(
+                "SELECT p.id FROM participations p JOIN actors a ON a.id=p.actor_id "
+                "WHERE a.is_self=0 OR p.role='git_committer'"
+            )
+        }
+    assert ("Same Name", 0, "git_author") in observed
+    assert ("Changed Name", 1, "git_author") in observed
+    assert ("Integrator", 1, "git_committer") in observed
+    _invoke(config, "rebuild", "all", "sample_store")
+    candidates = _invoke(config, "candidates", "list", "sample_store")
+    assert candidates
+    packets = [_invoke(config, "packet", candidate["id"]) for candidate in candidates]
+    supported_implementation: set[str] = set()
+    for packet in packets:
+        questions = {
+            question["question_id"]: question
+            for section in packet["sections"].values()
+            for question in section
+        }
+        assert len(questions) == 30
+        evidence = set(questions["action.implemented"]["supporting_evidence_ids"])
+        assert not evidence.intersection(unsupported_implementation)
+        supported_implementation.update(evidence)
+        assert questions["result.business"]["status"] in {"unknown", "unresolved"}
+        assert questions["result.business"]["answer_draft"] is None
+    assert supported_implementation
+    serialized = json.dumps(packets)
+    assert "git_author" in serialized
+    assert "action.implemented" in serialized
+    assert "old-work@example.test" not in serialized
+    assert "colleague@example.test" not in serialized
+
+
+def test_init_with_populated_ledger_never_recreates_missing_key(tmp_path: Path) -> None:
+    config, repository, database = _workspace(tmp_path)
+    _invoke(config, "import", "git", "sample_store", str(repository))
+    before = _database_state(database)
+    key = database.parent / "email-hmac.key"
+    key.unlink()
+    result = CliRunner().invoke(app, ["init", "--config", str(config)])
+    assert result.exit_code != 0
+    assert not key.exists()
+    assert _database_state(database) == before
+
+
+def test_repair_cli_dry_run_stale_proposal_and_apply_preserve_evidence(tmp_path: Path) -> None:
+    config, repository, database = _workspace(tmp_path)
+    _invoke(config, "import", "git", "sample_store", str(repository))
+    _invoke(config, "rebuild", "all", "sample_store")
+    candidates = _invoke(config, "candidates", "list", "sample_store")
+    assert candidates
+    for candidate in candidates:
+        _invoke(config, "confirm", candidate["id"])
+    with sqlite3.connect(database) as connection:
+        # Reproduce persisted legacy name-based classification, without fabricating discovery.
+        connection.execute(
+            "UPDATE actors SET is_self=1,identity_policy_version=0 WHERE display_name='Same Name'"
+        )
+        connection.execute(
+            "UPDATE actors SET identity_policy_version=0 WHERE display_name='Changed Name'"
+        )
+        evidence_before = {
+            table: connection.execute(f"SELECT id FROM {table} ORDER BY id").fetchall()
+            for table in ("source_objects", "observations", "participations", "human_decisions")
+        }
+    before = _database_state(database)
+    proposal = _invoke(config, "repair-identities", "sample_store")
+    assert proposal["demotions"] == 1
+    assert proposal["applied"] is False
+    assert proposal["confirmed_targets"]
+    assert _database_state(database) == before
+    stale = CliRunner().invoke(
+        app,
+        [
+            "repair-identities",
+            "sample_store",
+            "--apply",
+            "--expected-proposal",
+            "outdated-proposal",
+            "--config",
+            str(config),
+        ],
+    )
+    assert stale.exit_code != 0
+    assert "proposal changed" in f"{stale.output} {stale.exception}"
+    assert _database_state(database) == before
+    repaired = _invoke(
+        config,
+        "repair-identities",
+        "sample_store",
+        "--apply",
+        "--expected-proposal",
+        proposal["proposal_token"],
+    )
+    assert repaired["applied"] is True
+    with sqlite3.connect(database) as connection:
+        assert connection.execute(
+            "SELECT is_self FROM actors WHERE display_name='Same Name'"
+        ).fetchone() == (0,)
+        assert connection.execute("SELECT COUNT(*) FROM identity_repair_audit").fetchone() == (1,)
+        for table, ids in evidence_before.items():
+            assert connection.execute(f"SELECT id FROM {table} ORDER BY id").fetchall() == ids
+    _invoke(config, "rebuild", "all", "sample_store")
+    identity = _invoke(config, "status", "sample_store")["identity"]
+    assert identity["valid"] is True
+    assert identity["requires_rereview"]
+
+
+def test_repair_verifies_providers_only_when_explicitly_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config, repository, _ = _workspace(tmp_path, providers=True)
+    _invoke(config, "import", "git", "sample_store", str(repository))
+    for key, value in {
+        "WORKTRACE_JIRA_BASE_URL": "https://jira.example",
+        "WORKTRACE_JIRA_EMAIL": "fixture@example.test",
+        "WORKTRACE_JIRA_API_TOKEN": "synthetic-jira-token",
+        "WORKTRACE_GITLAB_BASE_URL": "https://gitlab.example",
+        "WORKTRACE_GITLAB_TOKEN": "synthetic-gitlab-token",
+    }.items():
+        monkeypatch.setenv(key, value)
+    with respx.mock(assert_all_called=False) as mocked:
+        jira = mocked.get("https://jira.example/rest/api/3/myself").mock(
+            return_value=httpx.Response(200, json={"accountId": "fixture-account"})
+        )
+        gitlab = mocked.get("https://gitlab.example/api/v4/user").mock(
+            return_value=httpx.Response(
+                200,
+                json={"id": 42, "username": "fixture-engineer", "email": "current@example.test"},
+            )
+        )
+        ordinary = _invoke(config, "repair-identities", "sample_store", "--dry-run")
+        assert ordinary["verified_sources"] == []
+        assert not mocked.calls
+        verified = _invoke(config, "repair-identities", "sample_store", "--verify-providers")
+        assert verified["verified_sources"] == ["gitlab", "jira"]
+        assert jira.call_count == gitlab.call_count == 1
+        assert len(mocked.calls) == 2

--- a/tests/test_identity_matching.py
+++ b/tests/test_identity_matching.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from datetime import date
+
+import httpx
+import pytest
+
+from worktrace.adapters.base import ActorIdentity, Participation, ParticipationRole
+from worktrace.adapters.gitlab import GitLabAdapter, GitLabConfig
+from worktrace.adapters.jira import JiraAdapter, JiraConfig
+from worktrace.domain.models import NormalizedObject
+from worktrace.errors import ConfigurationError, PermanentSourceError, ScopeViolation
+from worktrace.importers.orchestrator import record_to_object
+from worktrace.normalize import Redactor, actor_identity, build_record
+from worktrace.participation import is_implementation_role
+
+_REDACTOR = Redactor(b"synthetic-identity-key")
+_SELF_EMAIL = "engineer@example.com"
+_OLD_EMAIL = "old-work@example.com"
+_SELF_IDS = {_REDACTOR.hash_email(_SELF_EMAIL), _REDACTOR.hash_email(_OLD_EMAIL)}
+
+
+def _actor(
+    source: str,
+    *,
+    name: str = "Same Name",
+    email: str | None = None,
+    provider_id: str | None = None,
+) -> ActorIdentity:
+    return actor_identity(
+        source_kind=source,
+        source_instance="synthetic-source",
+        redactor=_REDACTOR,
+        provider_actor_id=provider_id,
+        display_name=name,
+        email=email,
+    )
+
+
+def _normalized(
+    source: str,
+    object_type: str,
+    participations: tuple[Participation, ...],
+    identities: set[str],
+) -> NormalizedObject:
+    record = build_record(
+        source_kind=source,
+        source_instance="synthetic-source",
+        object_type=object_type,
+        external_id="synthetic-object",
+        app_id="sample_store",
+        observed_at="2026-01-31T00:00:00Z",
+        source_updated_at="2026-01-01T00:00:00Z",
+        payload={"title": "Synthetic identity record"},
+        redactor=_REDACTOR,
+        participations=participations,
+    )
+    return record_to_object(record, identities, {"same name"})
+
+
+@pytest.mark.parametrize("email", ["someone-else@example.com", None])
+def test_same_name_different_or_missing_email_is_not_self(email: str | None) -> None:
+    actor = _actor("git", email=email)
+    result = _normalized(
+        "git", "commit", (Participation(actor, ParticipationRole.AUTHOR),), _SELF_IDS
+    )
+    assert not result.actors[0].is_self
+
+
+def test_configured_old_email_is_self_despite_name_change() -> None:
+    actor = _actor("git", name="Changed Name", email=_OLD_EMAIL)
+    result = _normalized(
+        "git", "commit", (Participation(actor, ParticipationRole.AUTHOR),), _SELF_IDS
+    )
+    assert result.actors[0].is_self
+
+
+def test_git_provider_id_cannot_substitute_for_configured_email() -> None:
+    actor = _actor("git", email="someone-else@example.com", provider_id="123")
+    result = _normalized(
+        "git", "commit", (Participation(actor, ParticipationRole.AUTHOR),), {"123"}
+    )
+    assert not result.actors[0].is_self
+
+
+def test_committer_only_is_not_implementation_and_coauthor_retains_role() -> None:
+    others = _actor("git", email="someone-else@example.com")
+    committer = _actor("git", email=_SELF_EMAIL)
+    coauthor = _actor("git", name="Old Name", email=_OLD_EMAIL)
+    result = _normalized(
+        "git",
+        "commit",
+        (
+            Participation(others, ParticipationRole.AUTHOR),
+            Participation(committer, ParticipationRole.COMMITTER),
+            Participation(coauthor, ParticipationRole.CO_AUTHOR),
+        ),
+        _SELF_IDS,
+    )
+    flags = {actor.external_actor_id: actor.is_self for actor in result.actors}
+    assert not flags[others.source_actor_id]
+    assert flags[committer.source_actor_id] and flags[coauthor.source_actor_id]
+    roles = {part.actor_external_id: part.role for part in result.participations}
+    assert roles[others.source_actor_id] == "git_author"
+    assert roles[committer.source_actor_id] == "git_committer"
+    assert not is_implementation_role("git", "git_commit", roles[committer.source_actor_id])
+    assert roles[coauthor.source_actor_id] == "git_coauthor"
+    assert is_implementation_role("git", "git_commit", roles[coauthor.source_actor_id])
+
+
+@pytest.mark.parametrize("provider_id, expected", [("configured-account", True), ("other", False)])
+def test_jira_requires_exact_configured_account(provider_id: str, expected: bool) -> None:
+    actor = _actor("jira", provider_id=provider_id, email=_SELF_EMAIL)
+    result = _normalized(
+        "jira",
+        "issue",
+        (Participation(actor, ParticipationRole.ASSIGNEE),),
+        {"configured-account"},
+    )
+    assert result.actors[0].is_self is expected
+
+
+@pytest.mark.parametrize(
+    "object_type, provider_id, email, expected",
+    [
+        ("merge_request", "42", "other@example.com", True),
+        ("merge_request", "99", _SELF_EMAIL, False),
+        ("merge_request_commit", "99", _SELF_EMAIL, False),
+        ("merge_request_commit", "invalid-provider", _SELF_EMAIL, False),
+        ("merge_request_commit", None, _SELF_EMAIL, True),
+        ("merge_request_commit", None, _OLD_EMAIL, True),
+        ("merge_request_commit", None, "other@example.com", False),
+        ("merge_request_commit", None, None, False),
+        ("merge_request", None, _SELF_EMAIL, False),
+    ],
+)
+def test_gitlab_provider_ids_take_precedence_and_email_only_commits_match_exactly(
+    object_type: str, provider_id: str | None, email: str | None, expected: bool
+) -> None:
+    actor = _actor("gitlab", provider_id=provider_id, email=email)
+    result = _normalized(
+        "gitlab",
+        object_type,
+        (Participation(actor, ParticipationRole.AUTHOR),),
+        {"42", *_SELF_IDS},
+    )
+    assert result.actors[0].is_self is expected
+
+
+def _config(*, user_id: int | None = None, username: str = "engineer") -> GitLabConfig:
+    return GitLabConfig(
+        base_url="https://gitlab.example",
+        source_instance="synthetic-source",
+        app_id="sample_store",
+        project_id=77,
+        email_key=b"synthetic-identity-key",
+        date_from=date(2026, 1, 1),
+        date_to=date(2026, 1, 31),
+        user_id=user_id,
+        username=username,
+    )
+
+
+def test_gitlab_username_resolves_numeric_identity_once_before_pages() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/api/v4/user":
+            return httpx.Response(
+                200, json={"id": 42, "username": "engineer", "email": _SELF_EMAIL}
+            )
+        return httpx.Response(200, json=[])
+
+    aliases = {_REDACTOR.hash_email(_OLD_EMAIL)}
+    with httpx.Client(
+        base_url="https://gitlab.example", transport=httpx.MockTransport(handler)
+    ) as client:
+        adapter = GitLabAdapter(_config(), client)
+        resolved = adapter.resolved_self_ids(aliases)
+        assert resolved == {"42", *_SELF_IDS}
+        assert aliases == {_REDACTOR.hash_email(_OLD_EMAIL)}
+        assert [request.url.path for request in requests] == ["/api/v4/user"]
+        list(adapter.iter_pages())
+        assert adapter.resolved_self_ids(set()) == {"42", _REDACTOR.hash_email(_SELF_EMAIL)}
+    assert sum(request.url.path == "/api/v4/user" for request in requests) == 1
+    assert any(request.url.params.get("author_id") == "42" for request in requests)
+
+
+@pytest.mark.parametrize("provider_id", [0, -1, True, "engineer", "\uff14\uff12", "", None])
+def test_gitlab_rejects_malformed_numeric_identity(provider_id: object) -> None:
+    with httpx.Client(
+        base_url="https://gitlab.example",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, json={"id": provider_id, "username": "engineer"})
+        ),
+    ) as client:
+        adapter = GitLabAdapter(_config(), client)
+        with pytest.raises(PermanentSourceError):
+            adapter.resolved_self_ids(_SELF_IDS)
+
+
+@pytest.mark.parametrize("provider_id, username", [(99, "engineer"), (42, "different-user")])
+def test_gitlab_identity_conflict_fails_before_resolving_aliases(
+    provider_id: int, username: str
+) -> None:
+    with httpx.Client(
+        base_url="https://gitlab.example",
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                200, json={"id": provider_id, "username": username, "email": _SELF_EMAIL}
+            )
+        ),
+    ) as client:
+        adapter = GitLabAdapter(_config(user_id=42), client)
+        with pytest.raises(ScopeViolation):
+            adapter.resolved_self_ids(_SELF_IDS)
+
+
+def _jira_config(account_id: str | None = "configured-account") -> JiraConfig:
+    return JiraConfig(
+        base_url="https://jira.example",
+        source_instance="synthetic-source",
+        app_id="sample_store",
+        project_keys=("DEMO",),
+        email_key=b"synthetic-identity-key",
+        date_from=date(2026, 1, 1),
+        date_to=date(2026, 1, 31),
+        account_id=account_id,
+        discovered_issue_keys=("DEMO-1",),
+    )
+
+
+def test_jira_resolves_configured_account_once_before_pages() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.url.path == "/rest/api/3/myself":
+            return httpx.Response(200, json={"accountId": "configured-account"})
+        return httpx.Response(200, json={"issues": [], "isLast": True})
+
+    with httpx.Client(
+        base_url="https://jira.example", transport=httpx.MockTransport(handler)
+    ) as client:
+        adapter = JiraAdapter(_jira_config(), client)
+        assert adapter.resolved_self_id() == "configured-account"
+        list(adapter.iter_pages())
+        assert adapter.resolved_self_id() == "configured-account"
+    assert sum(request.url.path == "/rest/api/3/myself" for request in requests) == 1
+
+
+@pytest.mark.parametrize("account_id", ["other-account", None])
+def test_jira_does_not_resolve_conflicting_provider_account(account_id: str | None) -> None:
+    with (
+        httpx.Client(
+            base_url="https://jira.example",
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(200, json={"accountId": account_id})
+            ),
+        ) as client,
+        pytest.raises(ScopeViolation),
+    ):
+        JiraAdapter(_jira_config(), client).resolved_self_id()
+
+
+def test_jira_exact_key_discovery_does_not_invent_self_identity() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        pytest.fail("Missing configured identity must fail before network access")
+
+    with (
+        httpx.Client(
+            base_url="https://jira.example", transport=httpx.MockTransport(handler)
+        ) as client,
+        pytest.raises(ConfigurationError, match="configured account_id"),
+    ):
+        JiraAdapter(_jira_config(None), client).resolved_self_id()

--- a/tests/test_identity_repair.py
+++ b/tests/test_identity_repair.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import replace
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from worktrace.config import AppConfig, IdentityConfig, WorkTraceConfig
+from worktrace.db.connection import connect
+from worktrace.db.migrations import migrate, migrations
+from worktrace.errors import ConfigurationError, ScopeViolation
+from worktrace.identity import (
+    finish_identity_rebuild,
+    identity_fingerprint,
+    identity_policy_status,
+    initialize_identity,
+    prepare_identity_import,
+    repair_identities,
+)
+from worktrace.normalize.redaction import Redactor
+
+KEY = b"synthetic-ledger-key"
+
+
+def _config(tmp_path: Path) -> WorkTraceConfig:
+    app = AppConfig("sample", "Sample", "", "", (), (), (tmp_path,), (), (), (), ())
+    return WorkTraceConfig(
+        1,
+        tmp_path,
+        date(2025, 1, 1),
+        date(2025, 12, 31),
+        IdentityConfig("Person", ("old@example.test",), ("Person",), None, None, None),
+        (app, replace(app, id="other")),
+        tmp_path / "config.toml",
+    )
+
+
+def _database(tmp_path: Path, *, legacy: bool = False) -> sqlite3.Connection:
+    path = tmp_path / "ledger.sqlite3"
+    connection = connect(path)
+    if legacy:
+        for migration in migrations()[:3]:
+            connection.executescript(migration.sql)
+            connection.execute(f"PRAGMA user_version={migration.version}")
+    else:
+        migrate(connection, path)
+    connection.executemany(
+        "INSERT INTO apps(id,name) VALUES (?,?)", [("sample", "Sample"), ("other", "Other")]
+    )
+    connection.commit()
+    return connection
+
+
+def _actor(
+    connection: sqlite3.Connection,
+    actor_id: str,
+    email: str | None,
+    *,
+    is_self: bool,
+    app_id: str = "sample",
+) -> None:
+    email_hash = Redactor(KEY).hash_email(email) if email else None
+    connection.execute(
+        "INSERT OR IGNORE INTO actors(id,source,source_instance,external_actor_id,"
+        "display_name,email_hash,is_self) "
+        "VALUES (?,'git','shared',?,'Person',?,?)",
+        (actor_id, actor_id, email_hash, int(is_self)),
+    )
+    object_id = f"obj:{app_id}:{actor_id}"
+    connection.execute(
+        "INSERT INTO source_objects(id,app_id,source,source_instance,kind,external_id) "
+        "VALUES (?,?,'git','shared','git_commit',?)",
+        (object_id, app_id, actor_id),
+    )
+    connection.execute(
+        "INSERT INTO participations(id,source_object_id,actor_id,role) VALUES (?,?,?,'git_author')",
+        (f"part:{app_id}:{actor_id}", object_id, actor_id),
+    )
+    connection.commit()
+
+
+def _legacy(tmp_path: Path) -> tuple[sqlite3.Connection, WorkTraceConfig]:
+    connection = _database(tmp_path, legacy=True)
+    _actor(connection, "actor:old", "old@example.test", is_self=False)
+    _actor(connection, "actor:imposter", "different@example.test", is_self=True)
+    migrate(connection, tmp_path / "ledger.sqlite3")
+    connection.commit()
+    return connection, _config(tmp_path)
+
+
+def _repair(
+    connection: sqlite3.Connection, config: WorkTraceConfig, **kwargs: object
+) -> dict[str, object]:
+    return repair_identities(  # type: ignore[arg-type]
+        connection, config, KEY, "sample", proof_actor_id="actor:old", proof_alias_index=0, **kwargs
+    )
+
+
+def test_populated_legacy_repair_preserves_ids_and_records_rereview(tmp_path: Path) -> None:
+    connection, config = _legacy(tmp_path)
+    try:
+        payload = {
+            "app_id": "sample",
+            "contribution_id": "contribution:old",
+            "members": ["obj:sample:actor:imposter"],
+        }
+        connection.execute(
+            "INSERT INTO human_decisions(id,action,target_id,payload_json,created_at) VALUES "
+            "('decision:confirm','confirm_candidate','candidate:gone',?,'2025-01-01')",
+            (json.dumps(payload),),
+        )
+        connection.commit()
+        before = list(connection.execute("SELECT id FROM source_objects ORDER BY id"))
+        proposal = _repair(connection, config)
+        assert proposal["promotions"] == proposal["demotions"] == 1
+        assert proposal["confirmed_targets"] == ["candidate:gone", "contribution:old"]
+        assert connection.execute("SELECT count(*) FROM identity_key_binding").fetchone()[0] == 0
+        with connection:
+            result = _repair(
+                connection, config, apply=True, expected_proposal=proposal["proposal_token"]
+            )
+        assert result["applied"] is True
+        assert list(connection.execute("SELECT id FROM source_objects ORDER BY id")) == before
+        assert connection.execute("SELECT count(*) FROM human_decisions").fetchone()[0] == 1
+        assert dict(connection.execute("SELECT id,is_self FROM actors")) == {
+            "actor:old": 1,
+            "actor:imposter": 0,
+        }
+        status = identity_policy_status(connection, config, "sample")
+        assert status["valid"] and status["rebuild_required"]
+        assert status["requires_rereview"] == ["candidate:gone", "contribution:old"]
+        audit = connection.execute("SELECT report_json FROM identity_repair_audit").fetchone()[0]
+        assert "@example.test" not in audit
+        assert KEY.decode() not in audit
+        with connection:
+            finish_identity_rebuild(connection, config, "sample")
+        assert not identity_policy_status(connection, config, "sample")["rebuild_required"]
+        assert identity_policy_status(connection, config, "sample")["requires_rereview"]
+        assert (
+            connection.execute("SELECT read_revision FROM apps WHERE id='sample'").fetchone()[0]
+            == 2
+        )
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("key", [b"", b"wrong-but-present"])
+def test_wrong_or_missing_key_cannot_enroll_legacy(tmp_path: Path, key: bytes) -> None:
+    connection, config = _legacy(tmp_path)
+    try:
+        with pytest.raises(ConfigurationError):
+            repair_identities(
+                connection,
+                config,
+                key,
+                "sample",
+                apply=True,
+                proof_actor_id="actor:old",
+                proof_alias_index=0,
+            )
+        assert connection.execute("SELECT count(*) FROM identity_key_binding").fetchone()[0] == 0
+        assert (
+            connection.execute("SELECT is_self FROM actors WHERE id='actor:imposter'").fetchone()[0]
+            == 1
+        )
+    finally:
+        connection.close()
+
+
+def test_legacy_needs_explicit_matching_alias_proof(tmp_path: Path) -> None:
+    connection, config = _legacy(tmp_path)
+    try:
+        for kwargs in (
+            {},
+            {"proof_actor_id": "actor:imposter", "proof_alias_index": 0},
+            {"proof_actor_id": "actor:old", "proof_alias_index": 1},
+        ):
+            with pytest.raises(ConfigurationError):
+                repair_identities(connection, config, KEY, "sample", apply=True, **kwargs)
+        with pytest.raises(ConfigurationError, match="continuity"):
+            initialize_identity(connection, config, KEY)
+        with pytest.raises(ConfigurationError):
+            prepare_identity_import(connection, config, KEY, "sample")
+    finally:
+        connection.close()
+
+
+def test_empty_ledger_binding_detects_override_and_policy_changes(tmp_path: Path) -> None:
+    connection = _database(tmp_path)
+    config = _config(tmp_path)
+    try:
+        with connection:
+            initialize_identity(connection, config, KEY)
+        binding = tuple(connection.execute("SELECT * FROM identity_key_binding").fetchone())
+        initialize_identity(connection, config, KEY)
+        prepare_identity_import(connection, config, KEY, "sample")
+        with pytest.raises(ConfigurationError, match="does not match"):
+            prepare_identity_import(connection, config, b"override-key", "sample")
+        changed = replace(
+            config, identity=replace(config.identity, git_author_emails=("new@example.test",))
+        )
+        initialize_identity(connection, changed, KEY)
+        with pytest.raises(ConfigurationError, match="requires repair"):
+            prepare_identity_import(connection, changed, KEY, "sample")
+        assert not identity_policy_status(connection, changed, "sample")["valid"]
+        assert tuple(connection.execute("SELECT * FROM identity_key_binding").fetchone()) == binding
+        renamed = replace(
+            config,
+            identity=replace(
+                config.identity, display_name="Renamed", git_author_names=("Renamed",)
+            ),
+        )
+        assert identity_fingerprint(renamed) == identity_fingerprint(config)
+    finally:
+        connection.close()
+
+
+def test_actual_shared_actor_reachability_refuses_cross_app_apply(tmp_path: Path) -> None:
+    connection, config = _legacy(tmp_path)
+    try:
+        _actor(connection, "actor:imposter", "different@example.test", is_self=True, app_id="other")
+        proposal = _repair(connection, config)
+        assert proposal["affected_apps"] == ["other", "sample"]
+        with pytest.raises(ScopeViolation, match="other apps"):
+            _repair(connection, config, apply=True)
+        assert connection.execute("SELECT count(*) FROM identity_repair_audit").fetchone()[0] == 0
+        assert connection.execute("SELECT count(*) FROM identity_key_binding").fetchone()[0] == 0
+    finally:
+        connection.close()
+
+
+def test_stale_dry_run_is_rejected_before_changes(tmp_path: Path) -> None:
+    connection, config = _legacy(tmp_path)
+    try:
+        proposal = _repair(connection, config)
+        _actor(connection, "actor:new", None, is_self=True)
+        with pytest.raises(ConfigurationError, match="proposal changed"):
+            _repair(connection, config, apply=True, expected_proposal=proposal["proposal_token"])
+        assert connection.execute("SELECT count(*) FROM identity_key_binding").fetchone()[0] == 0
+    finally:
+        connection.close()
+
+
+def test_audit_failure_rolls_back_entire_repair_but_preserves_caller_changes(
+    tmp_path: Path,
+) -> None:
+    connection, config = _legacy(tmp_path)
+    try:
+        connection.execute("UPDATE apps SET name='Caller edit' WHERE id='sample'")
+        connection.execute("DROP TABLE identity_repair_audit")
+        with pytest.raises(sqlite3.OperationalError):
+            _repair(connection, config, apply=True)
+        assert (
+            connection.execute("SELECT name FROM apps WHERE id='sample'").fetchone()[0]
+            == "Caller edit"
+        )
+        assert (
+            connection.execute("SELECT is_self FROM actors WHERE id='actor:imposter'").fetchone()[0]
+            == 1
+        )
+        assert connection.execute("SELECT count(*) FROM identity_key_binding").fetchone()[0] == 0
+        assert connection.execute("SELECT count(*) FROM app_identity_policy").fetchone()[0] == 0
+        assert (
+            connection.execute("SELECT read_revision FROM apps WHERE id='sample'").fetchone()[0]
+            == 0
+        )
+    finally:
+        connection.rollback()
+        connection.close()
+
+
+def test_missing_policy_never_accepts_unbound_typed_rows(tmp_path: Path) -> None:
+    connection, config = _legacy(tmp_path)
+    try:
+        connection.execute("UPDATE actors SET identity_policy_version=1")
+        assert not identity_policy_status(connection, config, "sample")["valid"]
+        with pytest.raises(ConfigurationError):
+            finish_identity_rebuild(connection, config, "sample")
+    finally:
+        connection.close()
+
+
+def test_provider_ids_require_authenticated_verification_before_policy_acceptance(
+    tmp_path: Path,
+) -> None:
+    connection, config = _legacy(tmp_path)
+    config = replace(config, identity=replace(config.identity, jira_account_id="account:actual"))
+    try:
+        _actor(connection, "actor:jira", None, is_self=True)
+        connection.execute(
+            "UPDATE actors SET source='jira',external_actor_id='account:other' "
+            "WHERE id='actor:jira'"
+        )
+        connection.commit()
+        with connection:
+            report = _repair(connection, config, apply=True)
+        assert report["provider_verification_required"] == ["actor:jira"]
+        assert (
+            connection.execute("SELECT is_self FROM actors WHERE id='actor:jira'").fetchone()[0]
+            == 1
+        )
+        assert not identity_policy_status(connection, config, "sample")["valid"]
+        with pytest.raises(ConfigurationError):
+            prepare_identity_import(connection, config, KEY, "sample")
+        with connection:
+            report = _repair(
+                connection, config, apply=True, verified_self_ids={"jira": "account:actual"}
+            )
+        assert report["demotions"] == 1
+        assert identity_policy_status(connection, config, "sample")["valid"]
+        assert (
+            connection.execute("SELECT is_self FROM actors WHERE id='actor:jira'").fetchone()[0]
+            == 0
+        )
+    finally:
+        connection.close()
+
+
+def test_changed_config_cannot_reaccept_old_verified_provider_flags(tmp_path: Path) -> None:
+    connection, config = _legacy(tmp_path)
+    config = replace(config, identity=replace(config.identity, jira_account_id="account:actual"))
+    try:
+        _actor(connection, "actor:jira", None, is_self=True)
+        connection.execute(
+            "UPDATE actors SET source='jira',external_actor_id='account:actual',"
+            "identity_policy_version=1 "
+            "WHERE id='actor:jira'"
+        )
+        with connection:
+            _repair(connection, config, apply=True, verified_self_ids={"jira": "account:actual"})
+        changed = replace(config, identity=replace(config.identity, jira_account_id="account:new"))
+        with connection:
+            report = _repair(connection, changed, apply=True)
+        assert report["provider_verification_required"] == ["actor:jira"]
+        assert not identity_policy_status(connection, changed, "sample")["valid"]
+        with connection:
+            repeated = _repair(connection, changed, apply=True)
+        assert repeated["provider_verification_required"] == ["actor:jira"]
+        assert not identity_policy_status(connection, changed, "sample")["valid"]
+    finally:
+        connection.close()
+
+
+def test_verified_gitlab_email_and_numeric_id_are_distinct(tmp_path: Path) -> None:
+    connection, config = _legacy(tmp_path)
+    config = replace(config, identity=replace(config.identity, gitlab_username="configured-user"))
+    try:
+        _actor(connection, "actor:gitlab", "provider@example.test", is_self=True)
+        connection.execute(
+            "UPDATE actors SET source='gitlab',external_actor_id=email_hash,"
+            "identity_policy_version=1 "
+            "WHERE id='actor:gitlab'"
+        )
+        _actor(connection, "actor:numeric", "old@example.test", is_self=True)
+        connection.execute(
+            "UPDATE actors SET source='gitlab',external_actor_id='99' WHERE id='actor:numeric'"
+        )
+        connection.commit()
+        with connection:
+            report = _repair(connection, config, apply=True)
+        assert set(report["provider_verification_required"]) == {"actor:gitlab", "actor:numeric"}
+        with connection:
+            report = _repair(
+                connection,
+                config,
+                apply=True,
+                verified_self_ids={"gitlab": "42"},
+                verified_gitlab_email_hashes=frozenset(
+                    {Redactor(KEY).hash_email("provider@example.test")}
+                ),
+            )
+        assert report["demotions"] == 1
+        flags = dict(connection.execute("SELECT id,is_self FROM actors"))
+        assert flags["actor:gitlab"] == 1
+        assert flags["actor:numeric"] == 0
+        assert identity_policy_status(connection, config, "sample")["valid"]
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize(
+    "verified", [{"jira": "wrong"}, {"gitlab": "0"}, {"gitlab": "42"}, {"git": "42"}]
+)
+def test_verified_provider_must_match_configured_identity(
+    tmp_path: Path, verified: dict[str, str]
+) -> None:
+    connection, config = _legacy(tmp_path)
+    try:
+        with pytest.raises(ConfigurationError):
+            _repair(connection, config, apply=True, verified_self_ids=verified)
+        assert connection.execute("SELECT count(*) FROM identity_key_binding").fetchone()[0] == 0
+    finally:
+        connection.close()
+
+
+def test_migration_key_binding_cannot_be_replaced_by_initialization(tmp_path: Path) -> None:
+    connection = _database(tmp_path)
+    config = _config(tmp_path)
+    try:
+        connection.execute(
+            "INSERT INTO app_identity_policy VALUES ('sample',1,'accepted-original-config',0)"
+        )
+        with connection:
+            initialize_identity(connection, config, KEY)
+        assert not identity_policy_status(connection, config, "sample")["valid"]
+        assert identity_policy_status(connection, config, "other")["valid"]
+    finally:
+        connection.close()

--- a/tests/test_packets_golden.py
+++ b/tests/test_packets_golden.py
@@ -14,6 +14,7 @@ from worktrace.config import (
 from worktrace.db.connection import connect
 from worktrace.db.migrations import migrate
 from worktrace.db.queries import source_status as query_source_status
+from worktrace.db.repository import EvidenceRepository
 from worktrace.mcp_server.tools import WorkTraceTools
 from worktrace.packets.builder import PacketBuilder
 
@@ -168,10 +169,8 @@ def _packet_state(
     database_path = tmp_path / "worktrace.sqlite3"
     connection = connect(database_path)
     migrate(connection, database_path)
-    connection.execute(
-        "INSERT INTO apps(id, name, market, business_type) "
-        "VALUES ('sample_store', 'Sample Store', 'XX', 'fixture')"
-    )
+    config = _config(tmp_path)
+    EvidenceRepository(connection).ensure_apps(config)
 
     _insert_run(
         connection,
@@ -277,9 +276,10 @@ def _packet_state(
     connection.execute(
         """
         INSERT INTO actors(
-            id, source, source_instance, external_actor_id, display_name, is_self
+            id, source, source_instance, external_actor_id, display_name, is_self,
+            identity_policy_version
         ) VALUES ('actor:self', 'git', 'fixture-repo', 'fixture-self',
-                  'Fixture Engineer', 1)
+                  'Fixture Engineer', 1, 1)
         """
     )
     connection.execute(
@@ -349,7 +349,7 @@ def _packet_state(
             ),
         )
     connection.commit()
-    return connection, database_path, _config(tmp_path), candidate_id
+    return connection, database_path, config, candidate_id
 
 
 def _all_questions(packet: dict[str, object]) -> list[dict[str, object]]:
@@ -383,11 +383,17 @@ def test_phase4_packet_preserves_claim_authority_and_independent_release_rungs(
         "evidence_summary",
         "sections",
         "participation",
+        "identity_policy",
         "release_ladder",
         "contradictions",
         "defensibility",
         "limitations",
     )
+    identity_policy = packet["identity_policy"]
+    assert isinstance(identity_policy, dict)
+    assert identity_policy["valid"] is True
+    assert identity_policy["version"] == 1
+    assert identity_policy["warnings"] == []
     assert questions
     assert tuple(question["question_id"] for question in questions) == EXPECTED_PHASE4_IDS
     assert len({question["question_id"] for question in questions}) == 30

--- a/tests/test_persistence_security.py
+++ b/tests/test_persistence_security.py
@@ -1,11 +1,25 @@
 from __future__ import annotations
 
 import sqlite3
-from datetime import UTC, datetime
+from collections.abc import Iterator
+from dataclasses import replace
+from datetime import UTC, date, datetime
 from pathlib import Path
 
+import pytest
+
+from worktrace.adapters.base import (
+    ActorIdentity,
+    NormalizedPage,
+    NormalizedRecord,
+    ObservationMetadata,
+    Participation,
+    ParticipationRole,
+    SourceObjectIdentity,
+)
 from worktrace.candidates.decisions import append_decision
-from worktrace.config import AppConfig
+from worktrace.config import AppConfig, IdentityConfig, WorkTraceConfig
+from worktrace.db.authority import authoritative_current_observations
 from worktrace.db.connection import connect
 from worktrace.db.migrations import migrate
 from worktrace.db.repository import EvidenceRepository
@@ -17,6 +31,9 @@ from worktrace.domain.models import (
     PendingReference,
     SourceIdentity,
 )
+from worktrace.errors import DatabaseError
+from worktrace.identity import initialize_identity, repair_identities
+from worktrace.importers.orchestrator import import_snapshot
 from worktrace.normalize.redaction import Redactor
 from worktrace.services import add_manual_evidence, export_app
 
@@ -304,17 +321,22 @@ def test_provider_identity_and_pending_references_are_pseudonymized_before_ids(
     assert b"fixture-release-secret" not in database_path.read_bytes()
 
 
-def test_current_verified_actor_classification_can_clear_a_removed_self_alias(
+@pytest.mark.parametrize("conflict", ["classification", "email"])
+def test_source_page_cannot_change_accepted_identity_and_retains_previous_authority(
     tmp_path: Path,
+    conflict: str,
 ) -> None:
-    connection, repository, _, _ = _open_repository(tmp_path)
+    connection, repository, _, redactor = _open_repository(tmp_path)
 
-    def observed_commit(external_id: str, *, is_self: bool) -> NormalizedObject:
+    def observed_commit(
+        external_id: str, *, is_self: bool, email: str = "first@example.test"
+    ) -> NormalizedObject:
         actor = ActorObservation(
             source="git",
             source_instance="fixture-repository",
             external_actor_id="stable-provider-actor",
             display_name="Fixture Engineer",
+            email_hash=redactor.hash_email(email),
             is_self=is_self,
         )
         return NormalizedObject(
@@ -348,24 +370,138 @@ def test_current_verified_actor_classification_can_clear_a_removed_self_alias(
             == 1
         )
 
-        corrected = repository.start_sync_run(
+        baseline = authoritative_current_observations(connection, "sample_store")
+        attempted = repository.start_sync_run(
             "sample_store", "git", "fixture-repository", {"mode": "fixture"}
         )
-        repository.store_page(corrected, [observed_commit("b" * 40, is_self=False)])
-        repository.finish_sync_run(corrected, "complete", "complete_for_scope")
+        conflicting = observed_commit(
+            "b" * 40,
+            is_self=conflict != "classification",
+            email="other@example.test" if conflict == "email" else "first@example.test",
+        )
+        with pytest.raises(DatabaseError, match="identity_reconciliation_required"):
+            repository.store_page(attempted, [conflicting])
+        repository.finish_sync_run(attempted, "failed", "partial", "identity conflict")
 
         assert (
             connection.execute(
                 "SELECT is_self FROM actors WHERE external_actor_id='stable-provider-actor'"
             ).fetchone()[0]
-            == 0
+            == 1
         )
         assert (
             connection.execute(
                 "SELECT COUNT(*) FROM participations WHERE actor_id IN "
                 "(SELECT id FROM actors WHERE external_actor_id='stable-provider-actor')"
             ).fetchone()[0]
-            == 2
+            == 1
         )
+        assert list(authoritative_current_observations(connection, "sample_store")) == list(
+            baseline
+        )
+        assert connection.execute("SELECT COUNT(*) FROM source_objects").fetchone()[0] == 1
+        assert connection.execute("SELECT COUNT(*) FROM observations").fetchone()[0] == 1
+        assert connection.execute("SELECT email_hash FROM actors").fetchone()[
+            0
+        ] == redactor.hash_email("first@example.test")
+
+        repeated = repository.start_sync_run(
+            "sample_store", "git", "fixture-repository", {"mode": "fixture"}
+        )
+        repository.store_page(repeated, [observed_commit("a" * 40, is_self=True)])
+        repository.finish_sync_run(repeated, "complete", "complete_for_scope")
+        assert connection.execute("SELECT COUNT(*) FROM actors").fetchone()[0] == 1
+        assert connection.execute("SELECT COUNT(*) FROM observations").fetchone()[0] == 2
+    finally:
+        connection.close()
+
+
+def test_failed_import_cannot_restore_classification_after_explicit_repair(tmp_path: Path) -> None:
+    connection, repository, _, redactor = _open_repository(tmp_path)
+    email_hash = redactor.hash_email("former@example.test")
+    app = _app()
+    config = WorkTraceConfig(
+        1,
+        tmp_path,
+        date(2026, 1, 1),
+        date(2026, 1, 31),
+        IdentityConfig("Fixture Engineer", ("former@example.test",), (), None, None, None),
+        (app,),
+        tmp_path / "config.toml",
+    )
+
+    class FixtureAdapter:
+        def iter_pages(self) -> Iterator[NormalizedPage]:
+            record = NormalizedRecord(
+                SourceObjectIdentity(
+                    "git", "fixture-repository", "commit", "a" * 40, "unused", app.id
+                ),
+                ObservationMetadata(
+                    "2026-01-10T10:00:00+00:00", "2026-01-10T10:00:00+00:00", "1", "1", "1"
+                ),
+                {"subject": "Synthetic work", "sha": "a" * 40},
+                (
+                    Participation(
+                        ActorIdentity(
+                            email_hash, "unused", "Fixture Engineer", email_hash=email_hash
+                        ),
+                        ParticipationRole.AUTHOR,
+                    ),
+                ),
+                (),
+                "fixture-hash",
+            )
+            yield NormalizedPage("git", "fixture-repository", "commit", None, None, True, (record,))
+
+    try:
+        with connection:
+            initialize_identity(connection, config, redactor.email_key)
+        first = import_snapshot(
+            app,
+            FixtureAdapter(),
+            repository,
+            source="git",
+            source_instance="fixture-repository",
+            date_from=config.employment_from,
+            date_to=config.employment_to,
+            self_actor_ids={email_hash},
+        )
+        assert first.status == "complete"
+        assert connection.execute("SELECT is_self FROM actors").fetchone()[0] == 1
+        changed = replace(
+            config, identity=replace(config.identity, git_author_emails=("current@example.test",))
+        )
+        with connection:
+            report = repair_identities(connection, changed, redactor.email_key, app.id, apply=True)
+        assert report["demotions"] == 1
+        assert connection.execute("SELECT is_self FROM actors").fetchone()[0] == 0
+
+        # Simulate a stale caller retaining the previous resolved identity set.
+        # The real import path must fail instead of reviving the shared actor flag.
+        failed = import_snapshot(
+            app,
+            FixtureAdapter(),
+            repository,
+            source="git",
+            source_instance="fixture-repository",
+            date_from=config.employment_from,
+            date_to=config.employment_to,
+            self_actor_ids={email_hash},
+        )
+        assert failed.status == "partial"
+        assert failed.pages == failed.records == 0
+        assert "identity_reconciliation_required" in (failed.error or "")
+        assert connection.execute("SELECT is_self FROM actors").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM observations").fetchone()[0] == 1
+        assert (
+            connection.execute(
+                "SELECT status FROM sync_runs WHERE id=?", (failed.run_id,)
+            ).fetchone()[0]
+            == "failed"
+        )
+        current = authoritative_current_observations(connection, app.id)
+        assert current
+        assert {row["sync_run_id"] for row in current} == {first.run_id}
+        assert connection.execute("SELECT COUNT(*) FROM identity_repair_audit").fetchone()[0] == 1
     finally:
         connection.close()


### PR DESCRIPTION
## Summary

- Replaces name-based self attribution with exact source identities, and resolves GitLab account/email identity before persistence, so another engineer with the same name cannot become personal implementation evidence.
- Adds explicit identity repair with ledger-bound key continuity, preview tokens, atomic audit/revision updates and confirmed-history re-review. Existing observations and decisions survive; staged imports cannot rewrite accepted actor classification.
- Makes migration backups coherent with committed WAL data and rejects unsupported schemas. Read projections mask unaccepted identity flags, while CLI status and private exports expose repair readiness.

Refs #26. Parent: #3. Implements slice A only; historical Jira discovery, broader coverage, agent cursor/context changes and final workflow proof remain #27–#31.

AgDR: [AgDR-0007](docs/agdr/AgDR-0007-agent-evidence-workflow-migration.md), accepted through PR #32.

## Behavior and upgrade

Schema 4 adds identity policy/key binding, repair audit/re-review metadata and the read-revision foundation. Existing actor flags remain stored but cannot support self claims until reconciled. `repair-identities APP_ID` defaults to dry-run; `--apply --expected-proposal TOKEN` applies the reviewed proposal. Legacy key enrollment requires explicit stored-actor/configured-alias proof. Missing/wrong keys, stale proposals and unexpected cross-app impact fail closed. Provider verification is explicit through `--verify-providers`.

Stop other consumers for upgrade/repair, preserve the database/key recovery pair, then rebuild references and candidates. Rebuild does not clear human re-review warnings. No real ledger repair, imports or provider checks were performed for this PR. MCP remains six read-only tools and the TUI has no new actions.

## Validation

- Full suite: 343 tests passed with 86% branch-enabled coverage.
- After adding MCP schema admission checks, final focused identity-CLI/MCP-security tests passed (including older/newer schema rejection without mutation).
- Ruff lint/format, strict mypy and source/wheel build passed; final diff checked.
- Synthetic regressions cover same-name identity collision, historical aliases, author/committer distinctions, real CLI repair and packet output, missing/wrong keys, preserved decisions, stale proposals, provider verification, failed import after repair, shared scope, WAL backup and recovery.

Final-head [Quality CI](https://github.com/AmrMohamad/WorkTrace/actions/runs/33975662409) passed at `3775b053d9a9483cdd14e074cf7a8918f51737eb`: **345 tests, 86% branch-enabled coverage**, lint, strict types and source/wheel builds. Unit/CLI fixtures are not live-provider, production-ledger or final STDIO-workflow acceptance.

## Glossary

| Term | Meaning |
|---|---|
| Key continuity | Evidence that the supplied identity HMAC key matches this ledger. |
| Identity reconciliation | Explicit correction of self flags while preserving source and decision history. |
| Proposal token | Detects a changed repair proposal between preview and apply. |
| WAL | SQLite's write-ahead log; committed pages must be included in a coherent backup. |
