### PR TITLE
fix(#27): recover historical Jira activity without freshness bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ to verify configured accounts using their existing credentials. This reads ident
 does not import evidence, and never falls back to display names. Unverified provider flags remain
 pending. Corrected full-range source imports are still needed for the later discovery fixes.
 
+## Historical Jira activity
+
+Jira discovery independently searches historical updates, assignment, creation, and exact
+configured-project keys. Later issue edits do not erase earlier work. Selection reasons explain
+why an issue was collected; they do not prove authorship or a precise work date. Day-level Jira
+queries use conservative expanded bounds, with the verified Jira calendar recorded separately
+from the optional `[employment].timezone` work calendar (default `UTC`).
+
+Comments retain creation and visible last-edit actors/times separately. A historically created
+comment edited later contains **current wording**, not a recovered historical text version.
+Assignment intervals require matching stable account IDs on both transitions; missing or
+ambiguous endpoints remain unknown. Predecessor/successor records are contextual evidence.
+Candidate periods, evidence date filters, and `identity.when` use activity dates, never fetch
+or issue freshness dates. Undated evidence is included without date filters and excluded when
+filtering; `period_status` distinguishes known, partially known, and unknown periods.
+
+Schema 5 adds CLI-owned, run-scoped staging of redacted Jira records. Discovery deduplicates by
+stable issue ID, unions reasons, and retains the first observed version if Jira changes between
+queries. Interrupted staging is nonauthoritative and never reused by a new run; successful
+finalization removes its temporary rows. Existing observations and human decisions are preserved.
+
+After the coherent backup/forward migration described above, existing Jira ledgers need an
+explicit **full configured-range reimport** to gain this metadata; there is no synthetic backfill.
+Do not shrink the configured interval to work around an import failure. After authorization:
+
+```console
+uv run worktrace import all APP_ID
+uv run worktrace status APP_ID
+```
+
+`import all` rebuilds references and candidates; separate source imports require an explicit
+`worktrace rebuild all APP_ID`. The six-tool MCP contract and cursor encoding are unchanged.
+
 ## Human review UI
 
 Launch the keyboard-first, read-only evidence workstation in an interactive terminal:

--- a/config.example.toml
+++ b/config.example.toml
@@ -6,6 +6,8 @@ directory = "~/Library/Application Support/WorkTrace"
 [employment]
 from = "2024-01-01"
 to = "2026-08-26"
+# Optional IANA work calendar; omitted means UTC. Jira events are stored as UTC instants.
+timezone = "UTC"
 
 [identity]
 display_name = "Your Name"

--- a/migrations/005_jira_import_stage.sql
+++ b/migrations/005_jira_import_stage.sql
@@ -1,0 +1,9 @@
+CREATE TABLE jira_import_stage (
+    run_id TEXT NOT NULL REFERENCES sync_runs(id),
+    kind TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    event_at TEXT NOT NULL DEFAULT '',
+    record_json TEXT NOT NULL,
+    PRIMARY KEY (run_id, kind, external_id)
+);
+CREATE INDEX idx_jira_stage_order ON jira_import_stage(run_id, kind, event_at, external_id);

--- a/src/worktrace/adapters/base.py
+++ b/src/worktrace/adapters/base.py
@@ -19,6 +19,7 @@ class ParticipationRole(StrEnum):
     """Observed roles; a role is a relationship, never an ownership claim."""
 
     AUTHOR = "author"
+    EDITOR = "editor"
     COMMITTER = "committer"
     CO_AUTHOR = "co_author"
     REVIEWER = "reviewer"

--- a/src/worktrace/adapters/jira.py
+++ b/src/worktrace/adapters/jira.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator, Mapping
-from dataclasses import dataclass
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass, replace
 from datetime import UTC, date, datetime, time, timedelta
 from urllib.parse import quote, urlsplit
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
 
@@ -59,6 +60,13 @@ class JiraConfig:
     max_hierarchy_depth: int = 3
     page_size: int = 100
     retry_policy: RetryPolicy = DEFAULT_RETRY_POLICY
+    work_timezone: str = "UTC"
+
+
+@dataclass(frozen=True, slots=True)
+class JiraDiscoveryQuery:
+    reason: str
+    jql: str
 
 
 def _mapping(value: object) -> Mapping[str, object]:
@@ -114,12 +122,19 @@ class JiraAdapter:
         self._client = client
         self._redactor = Redactor(config.email_key)
         self._identity_verified = False
-        self._window_start = datetime.combine(config.date_from, time.min, tzinfo=UTC)
+        try:
+            self._work_zone = ZoneInfo(config.work_timezone)
+        except (ZoneInfoNotFoundError, ValueError) as exc:
+            raise ConfigurationError("invalid Jira work timezone") from exc
+        self._provider_zone: ZoneInfo | None = None
+        self._window_start = datetime.combine(
+            config.date_from, time.min, tzinfo=self._work_zone
+        ).astimezone(UTC)
         self._window_end = datetime.combine(
             config.date_to + timedelta(days=1),
             time.min,
-            tzinfo=UTC,
-        )
+            tzinfo=self._work_zone,
+        ).astimezone(UTC)
 
     @staticmethod
     def _origin(url: str) -> tuple[str, str, int | None]:
@@ -141,21 +156,17 @@ class JiraAdapter:
             raise ConfigurationError("Jira credentials require HTTPS outside loopback tests")
         return parts.scheme, parts.hostname.casefold(), parts.port
 
-    def iter_pages(self) -> Iterator[NormalizedPage]:
+    def iter_discovery_pages(self) -> Iterator[NormalizedPage]:
         observed_at = observed_now()
         self._verify_identity()
-        unique_issues: dict[str, object] = {}
-        for query_index, (jql, enforce_window) in enumerate(self._discovery_queries()):
-            for cursor, next_cursor, is_last, raw_issues in self._search_pages(jql):
-                page_issues: list[object] = []
+        for query_index, query in enumerate(self._discovery_queries()):
+            for cursor, next_cursor, is_last, raw_issues in self._search_pages(query.jql):
+                records: list[NormalizedRecord] = []
                 for issue in raw_issues:
-                    issue_id, _ = self._issue_identity(issue)
-                    if enforce_window and not self._issue_in_window(issue):
-                        continue
-                    if issue_id in unique_issues:
-                        continue
-                    unique_issues[issue_id] = issue
-                    page_issues.append(issue)
+                    record = self._normalize_issue(issue, observed_at)
+                    records.append(
+                        replace(record, payload={**record.payload, "selected_by": [query.reason]})
+                    )
                 yield NormalizedPage(
                     source_kind="jira",
                     source_instance=self._config.source_instance,
@@ -165,15 +176,27 @@ class JiraAdapter:
                         f"{query_index}:{next_cursor}" if next_cursor is not None else None
                     ),
                     is_last=is_last,
-                    records=tuple(
-                        self._normalize_issue(issue, observed_at) for issue in page_issues
+                    records=tuple(records),
+                    limitations=(
+                        ("Jira calendar timezone unavailable; discovery uses expanded day bounds.",)
+                        if self._provider_zone is None
+                        else ()
                     ),
                 )
-        for issue in unique_issues.values():
-            issue_id, issue_key = self._issue_identity(issue)
-            yield from self._comment_pages(issue_id, issue_key, observed_at)
-            yield from self._changelog_pages(issue_id, issue_key, observed_at)
-        yield from self._hierarchy_pages(tuple(unique_issues.values()), observed_at)
+
+    def issue_context_pages(self, issue: NormalizedRecord) -> Iterator[NormalizedPage]:
+        issue_id = issue.identity.external_id
+        issue_key = str(issue.payload["key"])
+        observed_at = issue.observation.observed_at
+        yield from self._comment_pages(issue_id, issue_key, observed_at)
+        yield from self._changelog_pages(issue_id, issue_key, observed_at)
+
+    def import_scope(self) -> dict[str, str]:
+        return {"activity_policy_version": "1", "work_timezone": self._config.work_timezone}
+
+    @property
+    def work_window(self) -> tuple[datetime, datetime]:
+        return self._window_start, self._window_end
 
     def resolved_self_id(self) -> str:
         """Verify and return the configured account before accepting its actor policy."""
@@ -197,38 +220,43 @@ class JiraAdapter:
         if _text(document.get("accountId")) != self._config.account_id:
             raise ScopeViolation("Jira authenticated identity does not match configured account")
         self._identity_verified = True
+        zone = _text(document.get("timeZone"))
+        if zone:
+            try:
+                self._provider_zone = ZoneInfo(zone)
+            except (ZoneInfoNotFoundError, ValueError):
+                self._provider_zone = None
 
-    def _discovery_queries(self) -> tuple[tuple[str, bool], ...]:
+    def _discovery_queries(self) -> tuple[JiraDiscoveryQuery, ...]:
         quoted_projects = ", ".join(f'"{key}"' for key in self._projects)
-        exclusive_end = self._config.date_to + timedelta(days=1)
-        window = (
-            f'updated >= "{self._config.date_from.isoformat()}" '
-            f'AND updated < "{exclusive_end.isoformat()}"'
-        )
-        queries: list[tuple[str, bool]] = []
+        zone = self._provider_zone or ZoneInfo("UTC")
+        # Provider functions are day-granular. Expand a day at both edges; event
+        # timestamps, not latest issue versions, determine the local period.
+        start = (self._window_start.astimezone(zone).date() - timedelta(days=1)).isoformat()
+        end = (self._window_end.astimezone(zone).date() + timedelta(days=1)).isoformat()
+        queries: list[JiraDiscoveryQuery] = []
         if self._config.account_id is not None:
             account = f'"{self._config.account_id}"'
-            start = self._config.date_from.isoformat()
-            end = exclusive_end.isoformat()
-            participation = (
-                f'issue in updatedBy({account}, "{start}", "{end}") '
-                f"OR reporter = {account} OR creator = {account} OR assignee = {account} "
-                f'OR assignee WAS {account} DURING ("{start}", "{end}")'
-            )
-            queries.append(
+            for reason, selection in (
+                ("historical_updater", f'issue in updatedBy({account}, "{start}", "{end}")'),
+                ("historical_assignee", f'assignee WAS {account} DURING ("{start}", "{end}")'),
                 (
-                    f"project in ({quoted_projects}) AND {window} "
-                    f"AND ({participation}) ORDER BY key ASC",
-                    True,
+                    "creator_created",
+                    f'creator = {account} AND created >= "{start}" AND created < "{end}"',
+                ),
+            ):
+                queries.append(
+                    JiraDiscoveryQuery(
+                        reason, f"project in ({quoted_projects}) AND {selection} ORDER BY key ASC"
+                    )
                 )
-            )
         for offset in range(0, len(self._discovered_keys), self._config.exact_key_chunk_size):
             keys = self._discovered_keys[offset : offset + self._config.exact_key_chunk_size]
             quoted_keys = ", ".join(f'"{key}"' for key in keys)
             queries.append(
-                (
+                JiraDiscoveryQuery(
+                    "exact_key",
                     f"project in ({quoted_projects}) AND key in ({quoted_keys}) ORDER BY key ASC",
-                    False,
                 )
             )
         return tuple(queries)
@@ -274,20 +302,24 @@ class JiraAdapter:
                 break
             cursor = next_cursor
 
-    def _hierarchy_pages(
+    def hierarchy_pages(
         self,
-        discovered_issues: tuple[object, ...],
+        discovered_issues: Iterable[NormalizedRecord],
         observed_at: str,
+        known_issue: Callable[[str], bool],
     ) -> Iterator[NormalizedPage]:
-        seen_ids = {self._issue_identity(issue)[0] for issue in discovered_issues}
+        seen_ids: set[str] = set()
         queued: set[str] = set()
         queue: list[tuple[str, str | None, int]] = []
+        omitted = False
         for issue in discovered_issues:
-            parent = _mapping(_mapping(issue).get("fields")).get("parent")
-            parent_value = _mapping(parent)
+            parent_value = _mapping(issue.payload.get("parent"))
             parent_id = _identifier(parent_value.get("id"))
             target = parent_id or _text(parent_value.get("key"))
-            if target is not None and target not in seen_ids and target not in queued:
+            if target is not None and not known_issue(target) and target not in queued:
+                if len(queue) >= self._config.max_hierarchy_roots:
+                    omitted = True
+                    continue
                 queue.append((target, parent_id, 1))
                 queued.add(target)
 
@@ -325,7 +357,7 @@ class JiraAdapter:
                 continue
             document = self._response_mapping(response, "hierarchy issue")
             issue_id, issue_key = self._issue_identity(document)
-            if issue_id in seen_ids:
+            if issue_id in seen_ids or known_issue(issue_id):
                 continue
             seen_ids.add(issue_id)
             hydrated += 1
@@ -348,6 +380,17 @@ class JiraAdapter:
             ):
                 queue.append((parent_target, parent_id, depth + 1))
                 queued.add(parent_target)
+        if queue or omitted:
+            yield NormalizedPage(
+                "jira",
+                self._config.source_instance,
+                "issue_hierarchy",
+                None,
+                None,
+                True,
+                (),
+                limitations=("Jira hierarchy context limited by the configured root bound.",),
+            )
 
     def _issue_identity(self, raw_issue: object) -> tuple[str, str]:
         issue = _mapping(raw_issue)
@@ -431,7 +474,6 @@ class JiraAdapter:
             normalized = (
                 self._normalize_changelog(issue_id, issue_key, history, observed_at)
                 for history in histories
-                if self._subresource_in_window(history, ("created",), "changelog")
             )
             records = tuple(record for record in normalized if record is not None)
             next_start = self._next_offset(document, start_at, len(histories), "changelog")
@@ -492,19 +534,22 @@ class JiraAdapter:
         resource: str,
     ) -> bool:
         item = _mapping(value)
-        raw = next(
-            (_text(item.get(field)) for field in timestamp_fields if _text(item.get(field))),
-            None,
-        )
-        if raw is None:
+        values = [_text(item.get(field)) for field in timestamp_fields if _text(item.get(field))]
+        if not values:
             raise PermanentSourceError(f"Jira {resource} omitted its scope timestamp")
-        try:
-            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
-        except ValueError:
-            raise PermanentSourceError(f"Jira {resource} returned an invalid timestamp") from None
-        if parsed.tzinfo is None:
-            raise PermanentSourceError(f"Jira {resource} timestamp omitted its timezone")
-        return self._window_start <= parsed.astimezone(UTC) < self._window_end
+        timestamps: list[datetime] = []
+        for raw in values:
+            assert raw is not None
+            try:
+                parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            except ValueError:
+                raise PermanentSourceError(
+                    f"Jira {resource} returned an invalid timestamp"
+                ) from None
+            if parsed.tzinfo is None:
+                raise PermanentSourceError(f"Jira {resource} timestamp omitted its timezone")
+            timestamps.append(parsed.astimezone(UTC))
+        return any(self._window_start <= value < self._window_end for value in timestamps)
 
     def _normalize_comment(
         self,
@@ -519,7 +564,7 @@ class JiraAdapter:
             raise PermanentSourceError("Jira comment omitted its stable identity")
         author = _mapping(comment.get("author"))
         account_id = _text(author.get("accountId"))
-        participations = (
+        participations: tuple[Participation, ...] = (
             (
                 Participation(
                     actor=actor_identity(
@@ -537,6 +582,23 @@ class JiraAdapter:
             if account_id
             else ()
         )
+        editor = _mapping(comment.get("updateAuthor"))
+        editor_id = _text(editor.get("accountId"))
+        if editor_id and comment.get("updated") != comment.get("created"):
+            participations += (
+                Participation(
+                    actor=actor_identity(
+                        source_kind="jira",
+                        source_instance=self._config.source_instance,
+                        redactor=self._redactor,
+                        provider_actor_id=editor_id,
+                        display_name=_text(editor.get("displayName")),
+                        email=_text(editor.get("emailAddress")),
+                    ),
+                    role=ParticipationRole.EDITOR,
+                    effective_from=_text(comment.get("updated")),
+                ),
+            )
         return build_record(
             source_kind="jira",
             source_instance=self._config.source_instance,
@@ -547,6 +609,12 @@ class JiraAdapter:
             source_updated_at=_text(comment.get("updated")) or _text(comment.get("created")),
             payload={
                 "id": comment_id,
+                "activity_policy_version": 1,
+                "observation_semantics": "current_source_version",
+                "creation_author_id": account_id,
+                "update_author_id": editor_id,
+                "historical_wording_unknown": comment.get("created") != comment.get("updated"),
+                "work_timezone": self._config.work_timezone,
                 "issue_id": issue_id,
                 "issue_key": issue_key,
                 "body": extract_jira_text(comment.get("body")),
@@ -652,6 +720,8 @@ class JiraAdapter:
             source_updated_at=created_at,
             payload={
                 "id": history_id,
+                "activity_policy_version": 1,
+                "observation_semantics": "current_source_version",
                 "issue_id": issue_id,
                 "issue_key": issue_key,
                 "created_at": created_at,
@@ -684,19 +754,6 @@ class JiraAdapter:
             effective_from=effective_from,
             effective_to=effective_to,
         )
-
-    def _issue_in_window(self, raw_issue: object) -> bool:
-        raw_updated = _text(_mapping(_mapping(raw_issue).get("fields")).get("updated"))
-        if raw_updated is None:
-            raise PermanentSourceError("Jira issue omitted its scope timestamp")
-        try:
-            parsed = datetime.fromisoformat(raw_updated.replace("Z", "+00:00"))
-        except ValueError:
-            raise PermanentSourceError("Jira issue returned an invalid timestamp") from None
-        if parsed.tzinfo is None:
-            raise PermanentSourceError("Jira issue timestamp omitted its timezone")
-        timestamp = parsed.astimezone(UTC)
-        return self._window_start <= timestamp < self._window_end
 
     def _normalize_issue(self, raw_issue: object, observed_at: str) -> NormalizedRecord:
         issue = _mapping(raw_issue)
@@ -789,6 +846,11 @@ class JiraAdapter:
             source_updated_at=_text(fields.get("updated")),
             payload={
                 "id": issue_id,
+                "activity_policy_version": 1,
+                "observation_semantics": "current_source_version",
+                "work_timezone": self._config.work_timezone,
+                "provider_timezone": str(self._provider_zone) if self._provider_zone else None,
+                "selection_time_precision": "expanded_calendar_days",
                 "key": key,
                 "project_key": project_key,
                 "summary": summary,

--- a/src/worktrace/candidates/builder.py
+++ b/src/worktrace/candidates/builder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sqlite3
 from collections import deque
 from datetime import UTC, datetime
@@ -16,7 +17,7 @@ from worktrace.participation import (
     supports_category,
 )
 
-GENERATOR_VERSION = "3"
+GENERATOR_VERSION = "4"
 MAX_DEPTH = 3
 MAX_MEMBERS = 200
 MAX_CONTEXT = 50
@@ -85,6 +86,7 @@ def rebuild_candidates(app_id: str, repository: EvidenceRepository) -> int:
     connection = repository.connection
     current = repository.current_observations(app_id)
     objects = {str(row["source_object_id"]): row for row in current}
+    data = {identifier: json.loads(str(row["data_json"])) for identifier, row in objects.items()}
     references = list(
         connection.execute(
             f"""
@@ -106,7 +108,18 @@ def rebuild_candidates(app_id: str, repository: EvidenceRepository) -> int:
         kind = str(row["kind"])
         self_roles = roles.get(object_id, set())
         qualifies = (
-            (kind == "jira_issue" and (self_roles or object_id in linked_ids))
+            (
+                kind == "jira_issue"
+                and (
+                    self_roles
+                    or object_id in linked_ids
+                    or (
+                        data[object_id].get("activity_policy_version") == 1
+                        and set(data[object_id].get("selected_by", []))
+                        & {"historical_updater", "historical_assignee", "creator_created"}
+                    )
+                )
+            )
             or (
                 kind == "gitlab_mr"
                 and (
@@ -177,6 +190,12 @@ def rebuild_candidates(app_id: str, repository: EvidenceRepository) -> int:
                     if relationship == "jira_subtask_of" and not outbound:
                         continue
                     if relationship in STRUCTURAL:
+                        if data[target].get("boundary_context") is True:
+                            context.add(target)
+                            if len(context) > MAX_CONTEXT:
+                                overflow = True
+                                break
+                            continue
                         if target not in members:
                             members.add(target)
                             queue.append((target, depth + 1))

--- a/src/worktrace/cli.py
+++ b/src/worktrace/cli.py
@@ -434,6 +434,7 @@ def _verified_repair_identities(
         ) as client:
             adapter = JiraAdapter(
                 JiraConfig(
+                    work_timezone=configuration.employment_timezone,
                     base_url=credentials.base_url,
                     source_instance=_source_instance(app_id, "jira", credentials.base_url),
                     app_id=app_id,
@@ -734,6 +735,7 @@ def import_jira(
         ) as client:
             adapter = JiraAdapter(
                 JiraConfig(
+                    work_timezone=configuration.employment_timezone,
                     base_url=credentials.base_url,
                     source_instance=source_instance,
                     app_id=app_id,
@@ -1086,6 +1088,7 @@ def import_all(
                         configured_app,
                         JiraAdapter(
                             JiraConfig(
+                                work_timezone=configuration.employment_timezone,
                                 base_url=jira_auth.base_url,
                                 source_instance=source_instance,
                                 app_id=app_id,

--- a/src/worktrace/config.py
+++ b/src/worktrace/config.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from worktrace.errors import ConfigurationError, ScopeViolation
 from worktrace.paths import default_config_path, default_data_directory
@@ -102,6 +103,7 @@ class WorkTraceConfig:
     identity: IdentityConfig
     apps: tuple[AppConfig, ...]
     config_path: Path
+    employment_timezone: str = "UTC"
 
     @property
     def database_path(self) -> Path:
@@ -223,6 +225,13 @@ def load_config(path: Path | None = None) -> WorkTraceConfig:
     employment_to = _date(employment.get("to"), "employment.to")
     if employment_from > employment_to:
         raise ConfigurationError("employment.from must not be after employment.to")
+    employment_timezone = employment.get("timezone", "UTC")
+    if not isinstance(employment_timezone, str):
+        raise ConfigurationError("employment.timezone must be an IANA timezone")
+    try:
+        ZoneInfo(employment_timezone)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ConfigurationError("employment.timezone must be an IANA timezone") from exc
 
     display_name = str(identity_raw.get("display_name", "")).strip()
     if not display_name:
@@ -237,6 +246,7 @@ def load_config(path: Path | None = None) -> WorkTraceConfig:
         data_directory=directory,
         employment_from=employment_from,
         employment_to=employment_to,
+        employment_timezone=employment_timezone,
         identity=IdentityConfig(
             display_name=display_name,
             git_author_emails=_strings(

--- a/src/worktrace/db/queries.py
+++ b/src/worktrace/db/queries.py
@@ -65,6 +65,11 @@ def source_status(connection: sqlite3.Connection, app_id: str) -> list[dict[str,
         )
         if limitation and limitation not in limitations:
             limitations.append(limitation)
+        if row["source"] == "jira" and scope.get("activity_policy_version") != "1":
+            limitations.append(
+                "Full configured-range Jira reimport required for historical activity "
+                "metadata; existing observations were not backfilled."
+            )
         complete = authoritative and completeness_is_full_scope(str(row["completeness"]))
         result.append(
             {

--- a/src/worktrace/importers/jira_staging.py
+++ b/src/worktrace/importers/jira_staging.py
@@ -1,0 +1,267 @@
+"""CLI-owned, run-scoped staging; adapters never receive a database connection."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Iterator
+from dataclasses import asdict, replace
+from datetime import UTC, datetime
+
+from worktrace.adapters.base import (
+    ActorIdentity,
+    JSONValue,
+    NormalizedPage,
+    NormalizedRecord,
+    ObservationMetadata,
+    Participation,
+    ParticipationRole,
+    Reference,
+    ReferenceStrength,
+    SourceObjectIdentity,
+)
+from worktrace.adapters.jira import JiraAdapter
+from worktrace.db.repository import EvidenceRepository
+from worktrace.errors import PermanentSourceError, ScopeViolation
+
+
+def _reasons(value: object) -> set[str]:
+    return {item for item in value if isinstance(item, str)} if isinstance(value, list) else set()
+
+
+def _assignments(record: NormalizedRecord) -> list[dict[str, JSONValue]]:
+    value = record.payload.get("transitions")
+    return (
+        [item for item in value if isinstance(item, dict) and item.get("field") == "assignee"]
+        if isinstance(value, list)
+        else []
+    )
+
+
+def _decode(text: str) -> NormalizedRecord:
+    value = json.loads(text)
+    return NormalizedRecord(
+        identity=SourceObjectIdentity(**value["identity"]),
+        observation=ObservationMetadata(**value["observation"]),
+        payload=value["payload"],
+        payload_hash=value["payload_hash"],
+        participations=tuple(
+            Participation(
+                actor=ActorIdentity(**p["actor"]),
+                role=ParticipationRole(p["role"]),
+                effective_from=p["effective_from"],
+                effective_to=p["effective_to"],
+            )
+            for p in value["participations"]
+        ),
+        references=tuple(
+            Reference(**{**r, "strength": ReferenceStrength(r["strength"])})
+            for r in value["references"]
+        ),
+        untrusted_text_fields=tuple(value["untrusted_text_fields"]),
+    )
+
+
+class JiraStage:
+    def __init__(self, repository: EvidenceRepository, run_id: str) -> None:
+        self.connection = repository.connection
+        self.run_id = run_id
+        self.run = self.connection.execute(
+            "SELECT * FROM sync_runs WHERE id=?", (run_id,)
+        ).fetchone()
+        if self.run is None:
+            raise ScopeViolation("Jira stage requires a source run")
+
+    def put(self, kind: str, record: NormalizedRecord) -> bool:
+        return self.put_page(kind, (record,))
+
+    def put_page(self, kind: str, records: Iterable[NormalizedRecord]) -> bool:
+        changed = False
+        with self.connection:
+            for record in records:
+                changed = self._put(kind, record) or changed
+        return changed
+
+    def _put(self, kind: str, record: NormalizedRecord) -> bool:
+        identity = record.identity
+        if (
+            identity.app_id != self.run["app_id"]
+            or identity.source_kind != "jira"
+            or identity.source_instance != self.run["source_instance"]
+        ):
+            raise ScopeViolation("Jira staged record escaped source scope")
+        event_at = ""
+        if kind.startswith("history:"):
+            try:
+                at = datetime.fromisoformat(
+                    str(record.payload["created_at"]).replace("Z", "+00:00")
+                )
+                if at.tzinfo is None:
+                    raise ValueError("timezone missing")
+                event_at = at.astimezone(UTC).isoformat()
+            except (KeyError, ValueError) as exc:
+                raise PermanentSourceError("Jira history has invalid activity time") from exc
+        changed = False
+        previous = self.connection.execute(
+            "SELECT record_json FROM jira_import_stage WHERE run_id=? AND kind=? AND external_id=?",
+            (self.run_id, kind, identity.external_id),
+        ).fetchone()
+        if previous:
+            old = _decode(str(previous[0]))
+            reasons = sorted(
+                _reasons(old.payload.get("selected_by"))
+                | _reasons(record.payload.get("selected_by"))
+            )
+            changed = old.payload_hash != record.payload_hash
+            record = replace(old, payload={**old.payload, "selected_by": list[JSONValue](reasons)})
+        self.connection.execute(
+            "INSERT INTO jira_import_stage VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(run_id,kind,external_id) "
+            "DO UPDATE SET record_json=excluded.record_json",
+            (
+                self.run_id,
+                kind,
+                identity.external_id,
+                event_at,
+                json.dumps(asdict(record), sort_keys=True),
+            ),
+        )
+        return changed
+
+    def records(self, kind: str, *, by_time: bool = False) -> Iterator[NormalizedRecord]:
+        order = "event_at, external_id" if by_time else "external_id"
+        count = "COUNT(*) OVER (PARTITION BY event_at)" if by_time else "1"
+        cursor = self.connection.execute(
+            f"SELECT record_json, {count} AS time_count "
+            f"FROM jira_import_stage WHERE run_id=? AND kind=? ORDER BY {order}",
+            (self.run_id, kind),
+        )
+        while rows := cursor.fetchmany(100):
+            for row in rows:
+                record = _decode(str(row[0]))
+                if by_time and row[1] > 1:
+                    record = replace(record, payload={**record.payload, "ambiguous_time": True})
+                yield record
+
+    def known_issue(self, issue_id: str) -> bool:
+        return (
+            self.connection.execute(
+                "SELECT 1 FROM jira_import_stage WHERE run_id=? AND kind='issue' AND external_id=?",
+                (self.run_id, issue_id),
+            ).fetchone()
+            is not None
+        )
+
+
+def _histories(
+    adapter: JiraAdapter, stage: JiraStage, issue: NormalizedRecord
+) -> Iterator[NormalizedRecord]:
+    previous: NormalizedRecord | None = None
+    predecessor: NormalizedRecord | None = None
+    successor_seen = False
+    start, end = adapter.work_window
+    for record in stage.records("history:" + issue.identity.external_id, by_time=True):
+        at = datetime.fromisoformat(str(record.payload["created_at"]).replace("Z", "+00:00"))
+        transitions = _assignments(record)
+        intervals: list[JSONValue] = []
+        if transitions and previous:
+            old_transitions = _assignments(previous)
+            if (
+                len(transitions) == len(old_transitions) == 1
+                and not record.payload.get("ambiguous_time")
+                and not previous.payload.get("ambiguous_time")
+            ):
+                old, new = old_transitions[0], transitions[0]
+                before = datetime.fromisoformat(
+                    str(previous.payload["created_at"]).replace("Z", "+00:00")
+                )
+                if old["to_id"] and old["to_id"] == new["from_id"] and before < at:
+                    intervals.append(
+                        {
+                            "actor_id": old["to_id"],
+                            "from": before.isoformat(),
+                            "to": at.isoformat(),
+                            "start_history_id": previous.identity.external_id,
+                            "end_history_id": record.identity.external_id,
+                        }
+                    )
+        if transitions:
+            previous = record
+        if at < start:
+            if transitions:
+                predecessor = record
+            continue
+        if predecessor:
+            yield replace(predecessor, payload={**predecessor.payload, "boundary_context": True})
+            predecessor = None
+        if at >= end and (not transitions or successor_seen):
+            continue
+        if at >= end:
+            successor_seen = True
+        yield replace(
+            record,
+            payload={
+                **record.payload,
+                "boundary_context": at >= end,
+                "assignment_intervals": intervals,
+                "assignment_period_status": "known" if intervals else "unknown",
+            },
+        )
+    if predecessor:
+        yield replace(predecessor, payload={**predecessor.payload, "boundary_context": True})
+
+
+def jira_pages(
+    adapter: JiraAdapter, repository: EvidenceRepository, run_id: str
+) -> Iterator[NormalizedPage]:
+    stage = JiraStage(repository, run_id)
+    for page in adapter.iter_discovery_pages():
+        changed = stage.put_page("issue", page.records)
+        yield replace(
+            page,
+            records=(),
+            limitations=page.limitations
+            + (
+                ("Jira changed during discovery; the first issue version was retained.",)
+                if changed
+                else ()
+            ),
+        )
+    last_time = ""
+    for issue in stage.records("issue"):
+        last_time = issue.observation.observed_at
+        yield NormalizedPage(
+            "jira",
+            issue.identity.source_instance,
+            "issue",
+            issue.identity.external_id,
+            None,
+            True,
+            (issue,),
+        )
+        for page in adapter.issue_context_pages(issue):
+            if page.resource_type == "issue_changelog":
+                changed = stage.put_page("history:" + issue.identity.external_id, page.records)
+                yield replace(
+                    page,
+                    records=(),
+                    limitations=page.limitations
+                    + (
+                        ("Jira history changed during paging; first version retained.",)
+                        if changed
+                        else ()
+                    ),
+                )
+            else:
+                yield page
+        for record in _histories(adapter, stage, issue):
+            yield NormalizedPage(
+                "jira",
+                issue.identity.source_instance,
+                "issue_changelog",
+                record.identity.external_id,
+                None,
+                True,
+                (record,),
+            )
+    if last_time:
+        yield from adapter.hierarchy_pages(stage.records("issue"), last_time, stage.known_issue)

--- a/src/worktrace/importers/orchestrator.py
+++ b/src/worktrace/importers/orchestrator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime
 
 from worktrace.adapters.base import ActorIdentity, NormalizedRecord, SnapshotAdapter
+from worktrace.adapters.jira import JiraAdapter
 from worktrace.config import AppConfig
 from worktrace.db.repository import EvidenceRepository
 from worktrace.domain.enums import Completeness
@@ -17,6 +18,7 @@ from worktrace.domain.models import (
     SourceIdentity,
 )
 from worktrace.errors import SourceError
+from worktrace.importers.jira_staging import jira_pages
 from worktrace.participation import canonical_role
 
 
@@ -173,7 +175,7 @@ def record_to_object(
 
 def import_snapshot(
     app: AppConfig,
-    adapter: SnapshotAdapter,
+    adapter: SnapshotAdapter | JiraAdapter,
     repository: EvidenceRepository,
     *,
     source: str,
@@ -201,6 +203,8 @@ def import_snapshot(
     }
     if scope_details:
         scope.update(scope_details)
+    if isinstance(adapter, JiraAdapter):
+        scope.update(adapter.import_scope())
     run_id = repository.start_sync_run(
         app.id,
         source,
@@ -226,7 +230,12 @@ def import_snapshot(
     if limitations or selection_events:
         selection_biased = True
     try:
-        for page in adapter.iter_pages():
+        pages_iterator = (
+            jira_pages(adapter, repository, run_id)
+            if isinstance(adapter, JiraAdapter)
+            else adapter.iter_pages()
+        )
+        for page in pages_iterator:
             if page.source_kind != source or page.source_instance != source_instance:
                 raise SourceError("adapter page escaped its configured source scope")
             if any(
@@ -313,6 +322,9 @@ def import_snapshot(
         Completeness.SELECTION_BIASED.value if selection_biased else Completeness.COMPLETE.value
     )
     repository.finish_sync_run(run_id, "complete", completeness)
+    if isinstance(adapter, JiraAdapter):
+        with repository.connection:
+            repository.connection.execute("DELETE FROM jira_import_stage WHERE run_id=?", (run_id,))
     if finish_session:
         repository.finish_import_session(
             session_id,

--- a/src/worktrace/mcp_server/limits.py
+++ b/src/worktrace/mcp_server/limits.py
@@ -105,6 +105,7 @@ _STABLE_IDENTIFIER_LIST_KEYS = frozenset(
         "decision_ids",
         "evidence_ids",
         "module_evidence_ids",
+        "period_evidence_ids",
         "supporting_evidence_ids",
         "title_supporting_evidence_ids",
         "unsupported_member_ids",
@@ -170,7 +171,9 @@ def redact_output(value: object, *, field_name: str | None = None) -> JsonValue:
 
 
 def _serialized_size(value: JsonValue) -> int:
-    return len(json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")))
+    # Count the conservative escaped representation too: truncation markers and
+    # provider Unicode must not put an otherwise bounded response over the cap.
+    return len(json.dumps(value, ensure_ascii=True, sort_keys=True, separators=(",", ":")))
 
 
 def _longest_string(

--- a/src/worktrace/packets/activity.py
+++ b/src/worktrace/packets/activity.py
@@ -1,0 +1,138 @@
+"""Dated activity projection; source freshness is never a work-date fallback."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+from worktrace.packets.models import EvidenceRecord
+
+
+def timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        return parsed.astimezone(UTC) if parsed.tzinfo else None
+    except ValueError:
+        return None
+
+
+@dataclass(frozen=True)
+class ActivityPeriod:
+    start: datetime | None
+    end: datetime | None  # exclusive, including one microsecond for point events
+    status: str
+    evidence_ids: tuple[str, ...]
+
+    def fields(self) -> dict[str, object]:
+        return {
+            "date_from": self.start.isoformat() if self.start else None,
+            "date_to": (self.end - timedelta(microseconds=1)).isoformat() if self.end else None,
+            "period_status": self.status,
+        }
+
+    def matches(self, first: str | None, last: str | None, zone: str) -> bool:
+        if not (first or last):
+            return True
+        if self.start is None or self.end is None:
+            return False
+        tz = ZoneInfo(zone)
+        lower = datetime.combine(date.fromisoformat(first), time.min, tzinfo=tz) if first else None
+        upper = (
+            datetime.combine(date.fromisoformat(last) + timedelta(days=1), time.min, tzinfo=tz)
+            if last
+            else None
+        )
+        return (lower is None or self.end > lower) and (upper is None or self.start < upper)
+
+
+def activity_period(
+    records: Iterable[EvidenceRecord],
+    *,
+    zone: str,
+    first: date,
+    last: date,
+    children: Callable[[EvidenceRecord], Iterable[EvidenceRecord]],
+) -> ActivityPeriod:
+    lower = datetime.combine(first, time.min, tzinfo=ZoneInfo(zone)).astimezone(UTC)
+    upper = datetime.combine(last + timedelta(days=1), time.min, tzinfo=ZoneInfo(zone)).astimezone(
+        UTC
+    )
+    earliest: datetime | None = None
+    latest: datetime | None = None
+    evidence: set[str] = set()
+    unknown = False
+
+    def include(record: EvidenceRecord, start: datetime | None, end: datetime | None) -> bool:
+        nonlocal earliest, latest
+        if start is None or end is None or start >= end or start >= upper or end <= lower:
+            return False
+        start, end = max(start, lower), min(end, upper)
+        earliest = min(earliest, start) if earliest else start
+        latest = max(latest, end) if latest else end
+        evidence.add(record.evidence_id)
+        return True
+
+    def points(record: EvidenceRecord, boundary_support: set[str] | None = None) -> bool:
+        data = record.data
+        fields = {
+            "git_commit": ("authored_at", "committed_at"),
+            "gitlab_merge_request_commit": ("authored_at", "committed_at"),
+            "jira_issue": ("created_at",),
+            "jira_issue_comment": ("created_at", "updated_at"),
+            "jira_issue_changelog": ("created_at",),
+            "gitlab_mr": ("created_at", "merged_at", "closed_at"),
+            "merge_request": ("created_at", "merged_at", "closed_at"),
+            "gitlab_release": ("created_at", "released_at"),
+            "release": ("created_at", "released_at"),
+            "gitlab_deployment": ("created_at", "finished_at"),
+            "git_deployment": ("created_at", "finished_at"),
+            "deployment": ("created_at", "finished_at"),
+            "gitlab_merge_request_reviewer_state": ("assigned_at",),
+            "gitlab_merge_request_discussion_note": ("created_at", "updated_at"),
+        }.get(record.kind, ("occurred_at", "event_at", "created_at"))
+        found = False
+        if data.get("boundary_context") is not True:
+            for field in fields:
+                at = timestamp(data.get(field))
+                if at:
+                    found = include(record, at, at + timedelta(microseconds=1)) or found
+        intervals = data.get("assignment_intervals", [])
+        if isinstance(intervals, list):
+            for interval in intervals:
+                if isinstance(interval, dict):
+                    included = include(
+                        record, timestamp(interval.get("from")), timestamp(interval.get("to"))
+                    )
+                    found = included or found
+                    if included and boundary_support is not None:
+                        start_id = interval.get("start_history_id")
+                        if isinstance(start_id, str):
+                            boundary_support.add(start_id)
+        return found
+
+    material = list(records)
+    contextual = {record.object_id for record in material if record.context_only}
+    for record in material:
+        if record.context_only or record.data.get("boundary_context") is True:
+            continue
+        found = points(record)
+        if record.kind == "jira_issue":
+            boundary_support: set[str] = set()
+            issue_children = list(children(record))
+            for child in issue_children:
+                if (child.context_only or child.object_id in contextual) and not child.data.get(
+                    "boundary_context"
+                ):
+                    continue
+                found = points(child, boundary_support) or found
+            if boundary_support:
+                for child in issue_children:
+                    if child.external_id in boundary_support:
+                        evidence.add(child.evidence_id)
+        unknown = unknown or not found
+    status = "unknown" if earliest is None else ("partially_known" if unknown else "known")
+    return ActivityPeriod(earliest, latest, status, tuple(sorted(evidence)))

--- a/src/worktrace/packets/builder.py
+++ b/src/worktrace/packets/builder.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 from fnmatch import fnmatchcase
 from types import MappingProxyType
 from typing import cast
+from zoneinfo import ZoneInfo
 
 from worktrace.candidates.decisions import (
     CREATION_ACTIONS,
@@ -37,6 +38,7 @@ from worktrace.db.authority import (
 from worktrace.domain.enums import ClaimStatus, ObservationType
 from worktrace.errors import NotFound, ScopeViolation
 from worktrace.identity import identity_policy_status
+from worktrace.packets.activity import ActivityPeriod, activity_period
 from worktrace.packets.authority import (
     attested_answer,
     find_attestation,
@@ -99,10 +101,10 @@ def _parse_timestamp(value: object) -> datetime | None:
     return parsed.astimezone(UTC)
 
 
-def _calendar_date(value: str | None) -> str | None:
+def _calendar_date(value: str | None, zone: str = "UTC") -> str | None:
     parsed = _parse_timestamp(value)
     if parsed is not None:
-        return parsed.date().isoformat()
+        return parsed.astimezone(ZoneInfo(zone)).date().isoformat()
     return value[:10] if value and len(value) >= 10 else value
 
 
@@ -533,6 +535,11 @@ class PacketBuilder:
                 )
                 if limitation and limitation not in limitations:
                     limitations.append(limitation)
+                if source == "jira" and scope.get("activity_policy_version") != "1":
+                    limitations.append(
+                        "Full configured-range Jira reimport required for historical activity "
+                        "metadata; existing observations were not backfilled."
+                    )
                 raw_selection_events = progress.get("selection_events", [])
                 selection_events = (
                     [value for value in raw_selection_events if isinstance(value, dict)]
@@ -654,15 +661,33 @@ class PacketBuilder:
                 )
         return contradictions
 
-    @staticmethod
-    def _date_range(records: Sequence[EvidenceRecord]) -> tuple[str | None, str | None]:
-        values = sorted(
-            value
-            for record in records
-            for value in (record.source_updated_at or record.fetched_at,)
-            if value
+    def _activity_children(self, issue: EvidenceRecord) -> Iterable[EvidenceRecord]:
+        rows = self.connection.execute(
+            f"""WITH {authoritative_current_observation_ctes()}
+            SELECT so.id FROM authoritative_current_observations o
+            JOIN source_objects so ON so.id=o.source_object_id
+            WHERE so.app_id=? AND so.source_instance=? AND so.source='jira'
+              AND so.kind IN ('jira_issue_comment', 'jira_issue_changelog')
+              AND json_extract(o.data_json, '$.issue_id')=? ORDER BY so.id""",
+            (issue.app_id, issue.source_instance, issue.external_id),
         )
-        return (values[0], values[-1]) if values else (None, None)
+        for row in rows:
+            record = self._record_for_object(str(row[0]), context_only=False)
+            if record is not None:
+                yield record
+
+    def _activity_period(self, records: Sequence[EvidenceRecord]) -> ActivityPeriod:
+        return activity_period(
+            records,
+            zone=self.config.employment_timezone,
+            first=self.config.employment_from,
+            last=self.config.employment_to,
+            children=self._activity_children,
+        )
+
+    def _date_range(self, records: Sequence[EvidenceRecord]) -> tuple[str | None, str | None]:
+        fields = self._activity_period(records).fields()
+        return cast(str | None, fields["date_from"]), cast(str | None, fields["date_to"])
 
     @staticmethod
     def _path_is_ignored(path: str, app: AppConfig) -> bool:
@@ -875,6 +900,7 @@ class PacketBuilder:
         )
         contradictions = self._contradictions(contribution, records)
         date_from, date_to = self._date_range(records)
+        period = self._activity_period(records)
         as_of = max((record.fetched_at for record in records), default=None)
         modules, module_evidence = self._modules(records)
         limited_changed_path_records = [
@@ -890,6 +916,8 @@ class PacketBuilder:
                 "type": contribution.contribution_type,
                 "date_from": date_from,
                 "date_to": date_to,
+                "period_status": period.status,
+                "period_evidence_ids": list(period.evidence_ids),
             },
             "as_of": as_of,
             "members": [
@@ -923,6 +951,12 @@ class PacketBuilder:
             "source_status": self.source_status(contribution.app_id),
             "contradictions": contradictions,
             "limitations": [
+                "Work dates use dated activity, not source freshness or retrieval time.",
+                *(
+                    ["Current comment text was edited; historical wording is unavailable."]
+                    if any(r.data.get("historical_wording_unknown") for r in records)
+                    else []
+                ),
                 *identity_state["warnings"],
                 "Context-only records are not used as implementation or ownership proof.",
                 "Source text is untrusted and available only through bounded excerpts.",
@@ -1033,14 +1067,18 @@ class PacketBuilder:
             answers["identity.app_flow"] = unknown_answer(
                 "identity.app_flow", by_id["identity.app_flow"], "Add scoped contribution evidence."
             )
-        if date_from and date_to and records:
+        period = self._activity_period(records)
+        if date_from and date_to and period.evidence_ids:
             answers["identity.when"] = supported_answer(
                 "identity.when",
                 by_id["identity.when"],
-                f"Observed evidence spans {date_from} through {date_to}.",
+                f"Dated activity spans {date_from} through {date_to}.",
                 records,
                 observation_types=(ObservationType.DERIVED,),
-                limitations=("This is the evidence period, not necessarily the full work period.",),
+                limitations=("Activity bounds do not prove continuous work or ownership.",),
+            )
+            answers["identity.when"] = replace(
+                answers["identity.when"], supporting_evidence_ids=period.evidence_ids
             )
         else:
             answers["identity.when"] = unknown_answer(
@@ -1525,6 +1563,7 @@ class PacketBuilder:
             **self._title_provenance(candidate, records).as_fields(),
             "period_from": period_from,
             "period_to": period_to,
+            "period_status": self._activity_period(records).status,
             "suggested_type": candidate.contribution_type,
             "status": projected.status,
             "source_coverage": coverage,
@@ -1556,8 +1595,14 @@ class PacketBuilder:
                 item = self.candidate_list_item(app_id, str(row["id"]))
             except NotFound:
                 continue
-            period_from_date = _calendar_date(cast(str | None, item["period_from"]))
-            period_to_date = _calendar_date(cast(str | None, item["period_to"]))
+            period_from_date = _calendar_date(
+                cast(str | None, item["period_from"]), self.config.employment_timezone
+            )
+            period_to_date = _calendar_date(
+                cast(str | None, item["period_to"]), self.config.employment_timezone
+            )
+            if (date_from or date_to) and not (period_from_date and period_to_date):
+                continue
             if date_from and period_to_date and period_to_date < date_from:
                 continue
             if date_to and period_from_date and period_from_date > date_to:
@@ -1587,6 +1632,9 @@ class PacketBuilder:
             "as_of": as_of,
             "source_status": self.source_status(app_id),
             "candidates": items,
+            "date_filter_policy": "undated_excluded"
+            if date_from or date_to
+            else "undated_included",
             "next_offset": offset + limit if len(visible_items) > offset + limit else None,
         }
 
@@ -1626,33 +1674,41 @@ class PacketBuilder:
             escaped_module = module.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
             clauses.append("lower(latest.data_json) LIKE lower(?) ESCAPE '\\'")
             parameters.append(f"%{escaped_module}%")
-        if date_from:
-            clauses.append("date(COALESCE(latest.source_updated_at, latest.fetched_at)) >= date(?)")
-            parameters.append(date_from)
-        if date_to:
-            clauses.append("date(COALESCE(latest.source_updated_at, latest.fetched_at)) <= date(?)")
-            parameters.append(date_to)
-        parameters.extend((limit + 1, offset))
-        rows = list(
-            self.connection.execute(
-                f"""
+        cursor_rows = self.connection.execute(
+            f"""
                 WITH {authoritative_current_participation_ctes()}
                 SELECT latest.*, so.source, so.source_instance, so.kind, so.external_id
                 FROM authoritative_current_observations latest
                 JOIN source_objects so ON so.id=latest.source_object_id
                 WHERE {" AND ".join(clauses)}
                 ORDER BY COALESCE(latest.source_updated_at, latest.fetched_at) DESC, latest.id
-                LIMIT ? OFFSET ?
                 """,
-                parameters,
-            )
+            parameters,
         )
+        rows: list[sqlite3.Row] = []
+        periods: dict[str, ActivityPeriod] = {}
+        eligible = 0
+        for row in cursor_rows:
+            record = self._record_for_object(str(row["source_object_id"]), context_only=False)
+            if record is None:
+                continue
+            period = self._activity_period([record])
+            if not period.matches(date_from, date_to, self.config.employment_timezone):
+                continue
+            eligible += 1
+            if eligible <= offset:
+                continue
+            rows.append(row)
+            periods[str(row["id"])] = period
+            if len(rows) == limit + 1:
+                break
         results = []
         for row in rows[:limit]:
             text = str(row["body_text"] or row["title"] or "")[:DEFAULT_EXCERPT_CHARS]
             results.append(
                 {
                     "evidence_id": str(row["id"]),
+                    **periods[str(row["id"])].fields(),
                     "object_id": str(row["source_object_id"]),
                     "source": str(row["source"]),
                     "source_instance": str(row["source_instance"]),
@@ -1671,6 +1727,9 @@ class PacketBuilder:
             "as_of": max((str(row["fetched_at"]) for row in rows), default=None),
             "source_status": self.source_status(app_id),
             "results": results,
+            "date_filter_policy": "undated_excluded"
+            if date_from or date_to
+            else "undated_included",
             "next_offset": offset + limit if len(rows) > limit else None,
         }
 

--- a/src/worktrace/participation.py
+++ b/src/worktrace/participation.py
@@ -44,6 +44,7 @@ _CANONICAL_BY_SOURCE_KIND_ROLE: dict[tuple[str, str, str], str] = {
     ("jira", "jira_issue", "reporter"): "jira_reporter",
     ("jira", "jira_issue", "creator"): "jira_creator",
     ("jira", "jira_issue_comment", "author"): "jira_comment_author",
+    ("jira", "jira_issue_comment", "editor"): "jira_comment_editor",
     ("jira", "jira_issue_changelog", "author"): "jira_changelog_author",
     ("jira", "jira_issue_changelog", "assignee"): "jira_assignee",
 }
@@ -69,6 +70,7 @@ _KNOWN_CANONICAL = {
     "jira_reporter",
     "jira_creator",
     "jira_comment_author",
+    "jira_comment_editor",
     "jira_changelog_author",
 }
 

--- a/tests/adapters/test_jira.py
+++ b/tests/adapters/test_jira.py
@@ -1,15 +1,44 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from datetime import date
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import httpx
 import pytest
 
-from worktrace.adapters.base import ParticipationRole
-from worktrace.adapters.jira import JiraAdapter, JiraConfig
+from worktrace.adapters.base import NormalizedPage, ParticipationRole
+from worktrace.adapters.jira import JiraAdapter as SourceJiraAdapter
+from worktrace.adapters.jira import JiraConfig
+from worktrace.db.connection import connect
+from worktrace.db.migrations import migrate
+from worktrace.db.repository import EvidenceRepository
 from worktrace.errors import PermanentSourceError, ScopeViolation
+from worktrace.importers.jira_staging import jira_pages
+
+
+class JiraAdapter(SourceJiraAdapter):
+    """Exercise the actual CLI-owned staging while keeping adapter assertions local."""
+
+    def iter_pages(self) -> Iterator[NormalizedPage]:
+        with TemporaryDirectory() as directory:
+            path = Path(directory) / "ledger.sqlite3"
+            connection = connect(path)
+            try:
+                migrate(connection, path)
+                connection.execute(
+                    "INSERT INTO apps(id,name) VALUES (?,?)", (self._config.app_id, "Test")
+                )
+                connection.commit()
+                repository = EvidenceRepository(connection)
+                run = repository.start_sync_run(
+                    self._config.app_id, "jira", self._config.source_instance, {}
+                )
+                yield from jira_pages(self, repository, run)
+            finally:
+                connection.close()
 
 
 def _issue(
@@ -121,11 +150,11 @@ def test_jira_page_is_scoped_normalized_and_redacted() -> None:
             ).iter_pages()
         )
 
-    record = pages[0].records[0]
+    record = next(p.records[0] for p in pages if p.records)
     assert "MOB" in observed_query
-    assert 'updated >= "2026-01-01"' in observed_query
-    assert 'updated < "2026-02-01"' in observed_query
-    assert len(pages[0].records) == 1
+    assert "updated >=" not in observed_query
+    assert "updated <" not in observed_query
+    assert {r.identity.external_id for p in pages for r in p.records} >= {"10001", "10002"}
     assert record.payload["status"] == "Done"
     assert "user@example.com" not in repr(record)
     assert "attachment" not in record.payload
@@ -207,12 +236,14 @@ def test_jira_imports_paged_comments_and_transition_intervals_redacted() -> None
         )
 
     comment_pages = [page for page in pages if page.resource_type == "issue_comment"]
-    changelog_pages = [page for page in pages if page.resource_type == "issue_changelog"]
+    changelog_pages = [
+        page for page in pages if page.resource_type == "issue_changelog" and page.records
+    ]
     assert [page.cursor for page in comment_pages] == ["MOB-42:0", "MOB-42:1"]
     assert [page.cursor for page in changelog_pages] == [
-        "MOB-42:0",
-        "MOB-42:1",
-        "MOB-42:2",
+        "10001:12001",
+        "10001:12002",
+        "10001:12003",
     ]
     nested_paths = [path for path in requested_paths if path.endswith(("/comment", "/changelog"))]
     assert all("/issue/10001/" in path for path in nested_paths)
@@ -316,11 +347,13 @@ def test_jira_verifies_identity_unions_discovery_and_hydrates_true_subtask_root(
             ).iter_pages()
         )
 
-    assert len(jql_queries) == 2
+    assert len(jql_queries) == 4
     assert "updatedBy" in jql_queries[0]
-    assert "assignee WAS" in jql_queries[0]
-    assert 'key in ("MOB-42")' in jql_queries[1]
-    issue = next(page.records[0] for page in pages if page.resource_type == "issue")
+    assert "assignee WAS" in jql_queries[1]
+    assert 'key in ("MOB-42")' in jql_queries[3]
+    issue = next(
+        page.records[0] for page in pages if page.resource_type == "issue" and page.records
+    )
     assert issue.payload["fix_versions"][0]["name"] == "Mobile 1.2"
     assert issue.payload["fix_versions"][0]["archived"] is False
     assert {(ref.reference_type, ref.target_external_id) for ref in issue.references} >= {

--- a/tests/test_activity_projection.py
+++ b/tests/test_activity_projection.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date
+
+import pytest
+
+from worktrace.packets.activity import ActivityPeriod, activity_period
+from worktrace.packets.models import EvidenceRecord
+
+
+def record(kind: str, data: dict[str, object], name: str = "1") -> EvidenceRecord:
+    return EvidenceRecord(
+        observation_id=f"obs:{name}",
+        object_id=f"obj:{name}",
+        app_id="sample",
+        source="jira" if kind.startswith("jira") else "gitlab",
+        source_instance="fixture",
+        kind=kind,
+        external_id=name,
+        title=None,
+        body_text=None,
+        data=data,
+        completeness="complete",
+        fetched_at="2024-01-31T00:00:00Z",
+        source_updated_at="2024-01-31T00:00:00Z",
+        availability="visible",
+        availability_evidence_id=None,
+        availability_reason=None,
+        availability_observed_at=None,
+        is_current=True,
+    )
+
+
+def project(*records: EvidenceRecord, children: tuple[EvidenceRecord, ...] = ()) -> ActivityPeriod:
+    return activity_period(
+        records,
+        zone="UTC",
+        first=date(2024, 1, 1),
+        last=date(2024, 1, 31),
+        children=lambda _: children,
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "field"),
+    [
+        ("gitlab_mr", "merged_at"),
+        ("gitlab_mr", "closed_at"),
+        ("merge_request", "merged_at"),
+        ("gitlab_release", "released_at"),
+        ("release", "released_at"),
+        ("gitlab_deployment", "finished_at"),
+        ("git_deployment", "finished_at"),
+        ("deployment", "finished_at"),
+        ("gitlab_merge_request_reviewer_state", "assigned_at"),
+        ("gitlab_merge_request_discussion_note", "created_at"),
+        ("gitlab_merge_request_discussion_note", "updated_at"),
+    ],
+)
+def test_existing_source_event_fields_remain_activity_dates(kind: str, field: str) -> None:
+    period = project(record(kind, {field: "2024-01-10T12:00:00Z"}))
+    assert period.fields() == {
+        "date_from": "2024-01-10T12:00:00+00:00",
+        "date_to": "2024-01-10T12:00:00+00:00",
+        "period_status": "known",
+    }
+
+
+@pytest.mark.parametrize("kind", ["git_commit", "gitlab_merge_request_commit"])
+def test_author_and_committer_dates_are_separate_from_freshness(kind: str) -> None:
+    period = project(
+        record(
+            kind, {"authored_at": "2024-01-03T00:00:00Z", "committed_at": "2024-01-05T00:00:00Z"}
+        )
+    )
+    assert period.fields()["date_from"] == "2024-01-03T00:00:00+00:00"
+    assert period.fields()["date_to"] == "2024-01-05T00:00:00+00:00"
+    assert project(record(kind, {})).status == "unknown"
+
+
+def test_context_child_never_expands_material_issue_period() -> None:
+    issue = record("jira_issue", {"created_at": "2024-01-03T00:00:00Z"})
+    comment = replace(
+        record("jira_issue_comment", {"created_at": "2024-01-20T00:00:00Z"}, "comment"),
+        context_only=True,
+    )
+    period = project(issue, children=(comment,))
+    assert period.fields()["date_to"] == "2024-01-03T00:00:00+00:00"
+    assert period.evidence_ids == ("obs:1",)
+    # Candidate context membership also overrides the independently loaded child.
+    assert project(issue, comment, children=(replace(comment, context_only=False),)) == period
+
+
+def test_assignment_boundaries_support_issue_overlap_without_boundary_events() -> None:
+    issue = record("jira_issue", {})
+    before = record(
+        "jira_issue_changelog",
+        {"created_at": "2023-12-01T00:00:00Z", "boundary_context": True},
+        "before",
+    )
+    after = record(
+        "jira_issue_changelog",
+        {
+            "created_at": "2024-02-01T00:00:00Z",
+            "boundary_context": True,
+            "assignment_intervals": [
+                {
+                    "from": "2023-12-01T00:00:00Z",
+                    "to": "2024-02-01T00:00:00Z",
+                    "start_history_id": "before",
+                }
+            ],
+        },
+        "after",
+    )
+    period = project(issue, children=(before, after))
+    assert period.fields() == {
+        "date_from": "2024-01-01T00:00:00+00:00",
+        "date_to": "2024-01-31T23:59:59.999999+00:00",
+        "period_status": "known",
+    }
+    assert period.evidence_ids == ("obs:after", "obs:before")
+    assert project(after).status == "unknown"
+    assert not project(after).matches("2024-01-01", "2024-01-31", "UTC")
+
+
+def test_nonoverlapping_interval_does_not_add_irrelevant_endpoint_citation() -> None:
+    issue = record("jira_issue", {})
+    before = record("jira_issue_changelog", {"boundary_context": True}, "before")
+    event = record(
+        "jira_issue_changelog",
+        {
+            "created_at": "2024-01-10T00:00:00Z",
+            "assignment_intervals": [
+                {
+                    "from": "2023-11-01T00:00:00Z",
+                    "to": "2023-12-01T00:00:00Z",
+                    "start_history_id": "before",
+                }
+            ],
+        },
+        "event",
+    )
+    assert project(issue, children=(before, event)).evidence_ids == ("obs:event",)
+
+
+def test_unknown_material_dates_are_explicit_and_filtering_uses_local_day() -> None:
+    dated = record("jira_issue_comment", {"created_at": "2024-01-02T01:00:00Z"})
+    undated = record("jira_issue_comment", {"created_at": "invalid"}, "unknown")
+    period = project(dated, undated)
+    assert period.status == "partially_known"
+    assert period.matches("2024-01-01", "2024-01-01", "America/New_York")
+    assert not period.matches("2024-01-02", "2024-01-02", "America/New_York")
+    assert project(undated).fields()["date_from"] is None
+    assert project(undated).matches(None, None, "UTC")
+    assert not project(undated).matches("2024-01-01", None, "UTC")

--- a/tests/test_availability_migration.py
+++ b/tests/test_availability_migration.py
@@ -72,8 +72,8 @@ def test_populated_v2_upgrade_preserves_ids_and_seeds_baseline(tmp_path: Path) -
         )
         connection.commit()
 
-        assert migrate(connection, database_path) == [3, 4]
-        assert user_version(connection) == 4
+        assert migrate(connection, database_path) == [3, 4, 5]
+        assert user_version(connection) == 5
         assert connection.execute("SELECT id FROM source_objects").fetchone()[0] == "obj:stable"
         assert connection.execute("SELECT id FROM observations").fetchone()[0] == "obs:stable"
         assert (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,7 +64,7 @@ def test_cli_help_init_status_search_export_and_confirmed_purge(
 
     first_init = runner.invoke(app, ["init", "--config", str(config)])
     assert first_init.exit_code == 0, first_init.stdout
-    assert json.loads(first_init.stdout)["migrations_applied"] == [1, 2, 3, 4]
+    assert json.loads(first_init.stdout)["migrations_applied"] == [1, 2, 3, 4, 5]
 
     second_init = runner.invoke(app, ["init", "--config", str(config)])
     assert second_init.exit_code == 0, second_init.stdout

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -15,9 +15,9 @@ def test_init_and_migrations_are_idempotent(tmp_path: Path) -> None:
     database_path = tmp_path / "worktrace.sqlite3"
     connection = connect(database_path)
     try:
-        assert migrate(connection, database_path) == [1, 2, 3, 4]
+        assert migrate(connection, database_path) == [1, 2, 3, 4, 5]
         assert migrate(connection, database_path) == []
-        assert user_version(connection) == 4
+        assert user_version(connection) == 5
 
         tables = {
             str(row[0])
@@ -161,7 +161,7 @@ def test_database_readiness_is_read_only_and_distinguishes_schema_drift(
     try:
         ready = database_readiness(read_only)
         assert ready.status is DatabaseReadinessStatus.READY
-        assert ready.current_version == ready.supported_version == 4
+        assert ready.current_version == ready.supported_version == 5
     finally:
         read_only.close()
 

--- a/tests/test_golden_end_to_end.py
+++ b/tests/test_golden_end_to_end.py
@@ -13,10 +13,11 @@ from typing import Any
 import httpx
 import pytest
 
+from tests.adapters.test_jira import JiraAdapter
 from worktrace.adapters.base import NormalizedPage
 from worktrace.adapters.git_local import LocalGitAdapter, LocalGitConfig
 from worktrace.adapters.gitlab import GitLabAdapter, GitLabConfig
-from worktrace.adapters.jira import JiraAdapter, JiraConfig
+from worktrace.adapters.jira import JiraConfig
 from worktrace.candidates.builder import rebuild_candidates
 from worktrace.candidates.decisions import append_decision
 from worktrace.candidates.projector import project_candidate

--- a/tests/test_identity_matching.py
+++ b/tests/test_identity_matching.py
@@ -245,7 +245,7 @@ def test_jira_resolves_configured_account_once_before_pages() -> None:
     ) as client:
         adapter = JiraAdapter(_jira_config(), client)
         assert adapter.resolved_self_id() == "configured-account"
-        list(adapter.iter_pages())
+        list(adapter.iter_discovery_pages())
         assert adapter.resolved_self_id() == "configured-account"
     assert sum(request.url.path == "/rest/api/3/myself" for request in requests) == 1
 

--- a/tests/test_jira_history.py
+++ b/tests/test_jira_history.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import replace
+from datetime import date, timedelta
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from worktrace.adapters.jira import JiraAdapter, JiraConfig
+from worktrace.cli import app
+from worktrace.config import load_config
+from worktrace.db.connection import connect
+from worktrace.db.repository import EvidenceRepository
+from worktrace.errors import ConfigurationError
+from worktrace.importers.orchestrator import import_snapshot
+from worktrace.packets.activity import activity_period
+from worktrace.packets.builder import PacketBuilder
+from worktrace.packets.models import EvidenceRecord
+
+
+def issue(number: int = 1, created: str | None = "2023-01-01T00:00:00Z") -> dict:
+    return {
+        "id": str(number),
+        "key": f"DEMO-{number}",
+        "fields": {
+            "project": {"key": "DEMO"},
+            "summary": "Historical investigation",
+            "created": created,
+            "updated": "2026-09-01T00:00:00Z",
+            "creator": {"accountId": "colleague"},
+            "assignee": {"accountId": "colleague"},
+        },
+    }
+
+
+def history(number: int, at: str, before: str | None, after: str | None) -> dict:
+    return {
+        "id": str(number),
+        "created": at,
+        "author": {"accountId": "colleague"},
+        "items": [{"field": "assignee", "from": before, "to": after}],
+    }
+
+
+class JiraFixture:
+    def __init__(self, issues: list[dict] | None = None) -> None:
+        self.issues = [issue()] if issues is None else issues
+        self.comments: list[dict] = []
+        self.histories: list[dict] = []
+        self.queries: list[str] = []
+        self.fail_discovery = False
+        self.different_duplicate = False
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/myself"):
+            data = {"accountId": "self", "timeZone": "America/New_York"}
+        elif path.endswith("/search/jql"):
+            query = json.loads(request.content)["jql"]
+            self.queries.append(query)
+            if self.fail_discovery:
+                data = {"issues": self.issues, "isLast": False, "nextPageToken": "repeated"}
+            else:
+                data = {"issues": self.issues, "isLast": True}
+                if self.different_duplicate and "assignee WAS" in query:
+                    changed = json.loads(json.dumps(self.issues))
+                    changed[0]["fields"]["summary"] = "Different later version"
+                    data["issues"] = changed
+        elif path.endswith("/comment"):
+            data = {
+                "comments": self.comments,
+                "startAt": 0,
+                "maxResults": 100,
+                "total": len(self.comments),
+            }
+        elif path.endswith("/changelog"):
+            data = {
+                "values": self.histories,
+                "startAt": 0,
+                "maxResults": 100,
+                "total": len(self.histories),
+                "isLast": True,
+            }
+        else:
+            raise AssertionError(f"Unexpected provider path: {path}")
+        return httpx.Response(200, json=data)
+
+
+def invoke(config: Path, *args: str, success: bool = True) -> dict:
+    result = CliRunner().invoke(app, [*args, "--config", str(config)])
+    if success:
+        assert result.exit_code == 0, f"{result.output}\n{result.exception!r}"
+    else:
+        assert result.exit_code != 0, result.output
+    return json.loads(result.stdout) if result.stdout else {}
+
+
+@pytest.fixture
+def workspace(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    for key in tuple(os.environ):
+        if key.startswith("WORKTRACE_"):
+            monkeypatch.delenv(key)
+    for key, value in {
+        "WORKTRACE_JIRA_BASE_URL": "https://jira.example",
+        "WORKTRACE_JIRA_EMAIL": "synthetic@example.test",
+        "WORKTRACE_JIRA_API_TOKEN": "synthetic-fixture-token",
+    }.items():
+        monkeypatch.setenv(key, value)
+    config = tmp_path / "config.toml"
+    config.write_text(f"""schema_version = 1
+[data]
+directory = {str(tmp_path / "data")!r}
+[employment]
+from = "2024-01-01"
+to = "2024-01-31"
+[identity]
+display_name = "Fixture"
+git_author_emails = ["synthetic@example.test"]
+jira_account_id = "self"
+[[apps]]
+id = "sample"
+name = "Sample"
+jira_project_keys = ["DEMO"]
+""")
+    invoke(config, "init")
+    return config
+
+
+def search(
+    builder: PacketBuilder,
+    *,
+    first: str | None = None,
+    last: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+) -> dict:
+    return builder.search_evidence(
+        "",
+        "sample",
+        source_types=(),
+        actor_id=None,
+        module=None,
+        date_from=first,
+        date_to=last,
+        limit=limit,
+        offset=offset,
+    )
+
+
+def test_cli_late_edits_discovery_union_and_canonical_packet(workspace: Path) -> None:
+    fixture = JiraFixture()
+    fixture.different_duplicate = True
+    fixture.comments = [
+        {
+            "id": "10",
+            "created": "2024-01-10T12:00:00Z",
+            "updated": "2026-09-01T00:00:00Z",
+            "author": {"accountId": "self"},
+            "updateAuthor": {"accountId": "colleague"},
+            "body": "Current investigation wording synthetic@example.test",
+        }
+    ]
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+    assert len(fixture.queries) == 3
+    assert all("updated <" not in query and "updated >=" not in query for query in fixture.queries)
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM human_decisions").fetchone()[0] == 0
+        assert connection.execute("SELECT COUNT(*) FROM jira_import_stage").fetchone()[0] == 0
+        rows = list(connection.execute("SELECT id,data_json FROM observations"))
+        values = [json.loads(row["data_json"]) for row in rows]
+        ticket = next(value for value in values if value.get("key") == "DEMO-1")
+        assert ticket["summary"] == "Historical investigation"
+        assert set(ticket["selected_by"]) == {
+            "historical_updater",
+            "historical_assignee",
+            "creator_created",
+        }
+        assert ticket["observation_semantics"] == "current_source_version"
+        comment = next(value for value in values if value.get("issue_id") == "1")
+        assert comment["creation_author_id"] == "self"
+        assert comment["update_author_id"] == "colleague"
+        assert comment["historical_wording_unknown"] is True
+        assert "synthetic@example.test" not in json.dumps(values)
+        scope = json.loads(connection.execute("SELECT scope_json FROM sync_runs").fetchone()[0])
+        assert scope["work_timezone"] == "UTC"
+        builder = PacketBuilder(connection, config)
+        candidates = builder.list_candidates(
+            "sample", date_from="2024-01-01", date_to="2024-01-31", limit=20, offset=0
+        )
+        assert len(candidates["candidates"]) == 1
+        candidate = candidates["candidates"][0]
+        assert candidate["period_from"].startswith("2024-01-10")
+        assert candidate["period_to"].startswith("2024-01-10")
+        packet = builder.build_packet(candidate["candidate_id"])
+        questions = {q["question_id"]: q for group in packet["sections"].values() for q in group}
+        assert len(questions) == 30
+        assert questions["identity.when"]["status"] == "supported"
+        assert questions["action.implemented"]["status"] == "unknown"
+        assert questions["result.release"]["status"] == "unknown"
+        found = search(builder, first="2024-01-10", last="2024-01-10")["results"]
+        assert {row["kind"] for row in found} == {"jira_issue", "jira_issue_comment"}
+        assert questions["identity.when"]["supporting_evidence_ids"]
+        assert any(
+            "first issue version" in text
+            for text in builder.source_status("sample")["jira"]["instances"][0]["limitations"]
+        )
+
+
+def test_historical_match_without_surviving_events_stays_undated(workspace: Path) -> None:
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=JiraFixture())
+        invoke(workspace, "import", "all", "sample")
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        builder = PacketBuilder(connection, config)
+        candidates = builder.list_candidates(
+            "sample", date_from=None, date_to=None, limit=20, offset=0
+        )
+        assert len(candidates["candidates"]) == 1
+        assert candidates["candidates"][0]["period_status"] == "unknown"
+        assert search(builder)["results"][0]["date_from"] is None
+        assert not search(builder, first="2024-01-01")["results"]
+        assert not builder.list_candidates(
+            "sample", date_from="2024-01-01", date_to=None, limit=20, offset=0
+        )["candidates"]
+
+
+@pytest.mark.parametrize("broken", [False, True])
+def test_assignment_boundary_pairing_and_citations(workspace: Path, broken: bool) -> None:
+    fixture = JiraFixture()
+    fixture.histories = [
+        history(2, "2024-02-10T00:00:00Z", "wrong" if broken else "self", "other"),
+        history(1, "2023-12-10T00:00:00Z", "other", "self"),
+    ]  # Provider order is deliberately reversed.
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        builder = PacketBuilder(connection, config)
+        items = builder.list_candidates("sample", date_from=None, date_to=None, limit=20, offset=0)[
+            "candidates"
+        ]
+        candidate = items[0]
+        assert candidate["period_status"] == ("unknown" if broken else "known")
+        if not broken:
+            assert candidate["period_from"].startswith("2024-01-01")
+            assert candidate["period_to"].startswith("2024-01-31")
+            packet = builder.build_packet(candidate["candidate_id"])
+            when = next(
+                q
+                for group in packet["sections"].values()
+                for q in group
+                if q["question_id"] == "identity.when"
+            )
+            history_ids = {
+                str(row[0])
+                for row in connection.execute(
+                    "SELECT id FROM observations "
+                    "WHERE json_extract(data_json,'$.boundary_context')=1"
+                )
+            }
+            assert history_ids <= set(when["supporting_evidence_ids"])
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM candidate_members WHERE context_only=1"
+            ).fetchone()[0]
+            == 2
+        )
+
+
+def test_interrupted_discovery_retains_previous_authority_and_is_not_reused(
+    workspace: Path,
+) -> None:
+    fixture = JiraFixture([issue(created="2024-01-02T00:00:00Z")])
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+        fixture.issues = [issue(2)]
+        fixture.fail_discovery = True
+        invoke(workspace, "import", "all", "sample", success=False)
+        config = load_config(workspace)
+        with connect(config.database_path) as connection:
+            assert {
+                r["external_id"] for r in search(PacketBuilder(connection, config))["results"]
+            } == {"1"}
+            assert connection.execute("SELECT COUNT(*) FROM jira_import_stage").fetchone()[0] == 1
+        fixture.fail_discovery = False
+        fixture.issues = [issue(3)]
+        invoke(workspace, "import", "all", "sample")
+    with connect(config.database_path) as connection:
+        assert {r["external_id"] for r in search(PacketBuilder(connection, config))["results"]} == {
+            "3"
+        }
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM source_objects WHERE external_id='2'"
+            ).fetchone()[0]
+            == 0
+        )
+
+
+def test_date_filter_precedes_offset_pagination(workspace: Path) -> None:
+    fixture = JiraFixture(
+        [issue(n, "2024-01-15T00:00:00Z" if n % 2 else None) for n in range(1, 12)]
+    )
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        builder = PacketBuilder(connection, config)
+        offset, delivered = 0, set()
+        while True:
+            page = search(builder, first="2024-01-01", limit=2, offset=offset)
+            ids = {r["external_id"] for r in page["results"]}
+            assert not delivered & ids
+            delivered |= ids
+            assert page["date_filter_policy"] == "undated_excluded"
+            if page["next_offset"] is None:
+                break
+            offset = page["next_offset"]
+        assert delivered == {str(n) for n in range(1, 12, 2)}
+
+
+def test_exact_key_discovery_does_not_manufacture_self(workspace: Path) -> None:
+    config = load_config(workspace)
+    fixture = JiraFixture()
+    with (
+        connect(config.database_path) as connection,
+        httpx.Client(
+            base_url="https://jira.example", transport=httpx.MockTransport(fixture)
+        ) as client,
+    ):
+        adapter = JiraAdapter(
+            JiraConfig(
+                "https://jira.example",
+                "jira",
+                "sample",
+                ("DEMO",),
+                b"test",
+                date(2024, 1, 1),
+                date(2024, 1, 31),
+                discovered_issue_keys=("DEMO-1",),
+            ),
+            client,
+        )
+        result = import_snapshot(
+            config.app("sample"),
+            adapter,
+            EvidenceRepository(connection),
+            source="jira",
+            source_instance="jira",
+            date_from=config.employment_from,
+            date_to=config.employment_to,
+        )
+        assert result.status == "complete"
+        data = json.loads(connection.execute("SELECT data_json FROM observations").fetchone()[0])
+        assert data["selected_by"] == ["exact_key"]
+        assert connection.execute("SELECT COUNT(*) FROM actors WHERE is_self=1").fetchone()[0] == 0
+
+
+def test_timezone_validation_and_dst_window(workspace: Path) -> None:
+    assert load_config(workspace).employment_timezone == "UTC"
+    text = workspace.read_text().replace(
+        "[employment]", '[employment]\ntimezone="America/New_York"'
+    )
+    workspace.write_text(text)
+    assert load_config(workspace).employment_timezone == "America/New_York"
+    with httpx.Client(base_url="https://jira.example") as client:
+        adapter = JiraAdapter(
+            JiraConfig(
+                "https://jira.example",
+                "jira",
+                "sample",
+                ("DEMO",),
+                b"test",
+                date(2024, 3, 10),
+                date(2024, 3, 10),
+                work_timezone="America/New_York",
+                account_id="self",
+            ),
+            client,
+        )
+        start, end = adapter.work_window
+        assert end - start == timedelta(hours=23)
+        assert adapter._subresource_in_window(
+            {"created": "2024-03-11T03:59:59Z"}, ("created",), "comment"
+        )
+        assert not adapter._subresource_in_window(
+            {"created": "2024-03-11T04:00:00Z"}, ("created",), "comment"
+        )
+    workspace.write_text(text.replace("America/New_York", "Invalid/Zone"))
+    with pytest.raises(ConfigurationError, match="timezone"):
+        load_config(workspace)
+
+
+def test_activity_dates_do_not_use_freshness_or_context() -> None:
+    record = EvidenceRecord(
+        "obs:1",
+        "obj:1",
+        "sample",
+        "git",
+        "git",
+        "git_commit",
+        "sha",
+        None,
+        None,
+        {},
+        "complete",
+        "2024-01-31T00:00:00Z",
+        "2024-01-31T00:00:00Z",
+        "visible",
+        None,
+        None,
+        None,
+        True,
+    )
+    dated = replace(
+        record, data={"authored_at": "2024-01-02T00:00:00Z", "committed_at": "2024-01-03T00:00:00Z"}
+    )
+    context = replace(
+        record,
+        observation_id="obs:2",
+        object_id="obj:2",
+        context_only=True,
+        data={"authored_at": "2024-01-20T00:00:00Z"},
+    )
+
+    def period(records):
+        return activity_period(
+            records,
+            zone="UTC",
+            first=date(2024, 1, 1),
+            last=date(2024, 1, 31),
+            children=lambda _: (),
+        )
+
+    assert period([record]).status == "unknown"
+    known = period([dated, context])
+    assert known.status == "known"
+    assert known.fields()["date_to"].startswith("2024-01-03")
+    assert known.evidence_ids == ("obs:1",)
+    assert period([dated, replace(record, observation_id="obs:3")]).status == "partially_known"

--- a/tests/test_jira_history_edges.py
+++ b/tests/test_jira_history_edges.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import date, datetime
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+from tests.test_jira_history import JiraFixture, history, invoke, issue, search
+from tests.test_jira_history import workspace as workspace
+from worktrace.adapters.jira import JiraAdapter, JiraConfig
+from worktrace.config import load_config
+from worktrace.db.connection import connect
+from worktrace.db.repository import EvidenceRepository
+from worktrace.errors import ScopeViolation
+from worktrace.importers.jira_staging import JiraStage
+from worktrace.packets.builder import PacketBuilder
+
+
+def imported_histories(workspace: Path, fixture: JiraFixture) -> list[dict]:
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+    with connect(load_config(workspace).database_path) as connection:
+        return [
+            json.loads(row[0])
+            for row in connection.execute(
+                "SELECT data_json FROM observations "
+                "WHERE json_extract(data_json, '$.transitions') IS NOT NULL"
+            )
+        ]
+
+
+@pytest.mark.parametrize("missing", ["start", "end"])
+def test_missing_assignment_endpoint_remains_undated(workspace: Path, missing: str) -> None:
+    fixture = JiraFixture()
+    fixture.histories = [
+        history(1, "2023-12-10T00:00:00Z", "other", "self")
+        if missing == "end"
+        else history(2, "2024-02-10T00:00:00Z", "self", "other")
+    ]
+    records = imported_histories(workspace, fixture)
+    assert all(not record.get("assignment_intervals") for record in records)
+    with connect(load_config(workspace).database_path) as connection:
+        result = search(PacketBuilder(connection, load_config(workspace)))["results"][0]
+        assert result["date_from"] is None
+        assert result["date_to"] is None
+        assert result["period_status"] == "unknown"
+
+
+def test_reassignment_keeps_separate_actor_intervals_and_nearest_boundaries(
+    workspace: Path,
+) -> None:
+    fixture = JiraFixture()
+    fixture.histories = [
+        history(1, "2023-11-01T00:00:00Z", "someone", "other"),
+        history(2, "2023-12-10T00:00:00Z", "other", "self"),
+        history(3, "2024-01-10T00:00:00Z", "self", "other"),
+        history(4, "2024-01-20T00:00:00Z", "other", "self"),
+        history(5, "2024-02-10T00:00:00Z", "self", "other"),
+        history(6, "2024-03-10T00:00:00Z", "other", "someone"),
+    ]
+    records = imported_histories(workspace, fixture)
+    assert {record["created_at"] for record in records} == {
+        value["created"] for value in fixture.histories[1:5]
+    }
+    intervals = [item for record in records for item in record.get("assignment_intervals", [])]
+    assert [item["actor_id"] for item in sorted(intervals, key=lambda item: item["from"])] == [
+        "self",
+        "other",
+        "self",
+    ]
+    assert all(item["start_history_id"] and item["end_history_id"] for item in intervals)
+    assert sum(record["boundary_context"] for record in records) == 2
+
+
+def test_same_instant_with_different_offsets_does_not_pair_assignments(workspace: Path) -> None:
+    fixture = JiraFixture()
+    fixture.histories = [
+        history(1, "2023-12-10T00:00:00Z", "other", "self"),
+        history(2, "2024-02-10T01:00:00+01:00", "self", "other"),
+        history(3, "2024-02-10T00:00:00Z", "other", "third"),
+    ]
+    records = imported_histories(workspace, fixture)
+    assert all(not record.get("assignment_intervals") for record in records)
+    assert any(record.get("ambiguous_time") for record in records)
+
+
+def test_assignment_order_uses_instants_across_dst_fallback(workspace: Path) -> None:
+    workspace.write_text(
+        workspace.read_text()
+        .replace('from = "2024-01-01"', 'from = "2024-11-03"')
+        .replace('to = "2024-01-31"', 'to = "2024-11-03"')
+        .replace("[employment]", '[employment]\ntimezone = "America/New_York"')
+    )
+    fixture = JiraFixture()
+    fixture.histories = [
+        history(2, "2024-11-03T01:15:00-05:00", "self", "other"),
+        history(1, "2024-11-03T01:45:00-04:00", "other", "self"),
+    ]
+    records = imported_histories(workspace, fixture)
+    intervals = [item for record in records for item in record.get("assignment_intervals", [])]
+    assert len(intervals) == 1
+    assert intervals[0]["actor_id"] == "self"
+    assert (
+        datetime.fromisoformat(intervals[0]["to"]) - datetime.fromisoformat(intervals[0]["from"])
+    ).total_seconds() == 30 * 60
+
+
+@pytest.mark.parametrize("timestamp", ["not-a-date", "2024-01-10T12:00:00"])
+def test_invalid_history_time_preserves_previous_complete_authority(
+    workspace: Path, timestamp: str
+) -> None:
+    fixture = JiraFixture([issue(created="2024-01-02T00:00:00Z")])
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+        fixture.issues = [issue(2)]
+        fixture.histories = [history(1, timestamp, "other", "self")]
+        invoke(workspace, "import", "all", "sample", success=False)
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        results = search(PacketBuilder(connection, config))["results"]
+        assert {row["external_id"] for row in results} == {"1"}
+
+
+def test_failed_hydration_keeps_redacted_first_staged_version_and_prior_observations(
+    workspace: Path,
+) -> None:
+    fixture = JiraFixture([issue(created="2024-01-02T00:00:00Z")])
+    config = load_config(workspace)
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+    with connect(config.database_path) as connection:
+        before = dict(connection.execute("SELECT id,data_json FROM observations"))
+    fixture.issues = [issue(2)]
+    fixture.issues[0]["fields"]["summary"] = "First synthetic@example.test wording"
+    fixture.different_duplicate = True
+
+    def fail_hydration(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/changelog"):
+            return httpx.Response(403, json={"errorMessages": ["Denied"]})
+        return fixture(request)
+
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fail_hydration)
+        invoke(workspace, "import", "all", "sample", success=False)
+    with connect(config.database_path) as connection:
+        after = dict(connection.execute("SELECT id,data_json FROM observations"))
+        assert all(after[key] == value for key, value in before.items())
+        results = search(PacketBuilder(connection, config))["results"]
+        assert {row["external_id"] for row in results} == {"1"}
+        staged = connection.execute("SELECT record_json FROM jira_import_stage").fetchall()
+        assert len(staged) == 1
+        assert "synthetic@example.test" not in staged[0][0]
+        payload = json.loads(staged[0][0])["payload"]
+        assert payload["summary"].startswith("First ")
+        assert "Different later version" not in payload["summary"]
+        assert len(payload["selected_by"]) == 3
+
+
+def test_staged_page_rolls_back_when_second_record_escapes_scope(workspace: Path) -> None:
+    fixture = JiraFixture([issue(created="2024-01-02T00:00:00Z")])
+    imported_histories(workspace, fixture)
+    config = load_config(workspace)
+    with (
+        connect(config.database_path) as connection,
+        httpx.Client(
+            base_url="https://jira.example", transport=httpx.MockTransport(fixture)
+        ) as client,
+    ):
+        before = dict(connection.execute("SELECT id,data_json FROM observations"))
+        adapter = JiraAdapter(
+            JiraConfig(
+                "https://jira.example",
+                "jira",
+                "sample",
+                ("DEMO",),
+                b"test",
+                date(2024, 1, 1),
+                date(2024, 1, 31),
+                account_id="self",
+            ),
+            client,
+        )
+        record = next(adapter.iter_discovery_pages()).records[0]
+        invalid = replace(
+            record, identity=replace(record.identity, app_id="out-of-scope", external_id="2")
+        )
+        repository = EvidenceRepository(connection)
+        run = repository.start_sync_run("sample", "jira", "jira", {})
+        with pytest.raises(ScopeViolation, match="source scope"):
+            JiraStage(repository, run).put_page("issue", (record, invalid))
+        assert connection.execute("SELECT COUNT(*) FROM jira_import_stage").fetchone()[0] == 0
+        assert dict(connection.execute("SELECT id,data_json FROM observations")) == before
+
+
+def test_hierarchy_root_bound_limits_requests_and_reports_omission() -> None:
+    requests: list[str] = []
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        requests.append(request.url.path)
+        return httpx.Response(200, json=issue(10))
+
+    with httpx.Client(
+        base_url="https://jira.example", transport=httpx.MockTransport(respond)
+    ) as client:
+        adapter = JiraAdapter(
+            JiraConfig(
+                "https://jira.example",
+                "jira",
+                "sample",
+                ("DEMO",),
+                b"test",
+                date(2024, 1, 1),
+                date(2024, 1, 31),
+                max_hierarchy_roots=1,
+                account_id="self",
+            ),
+            client,
+        )
+        children = [issue(1), issue(2)]
+        children[0]["fields"]["parent"] = {"id": "10", "key": "DEMO-10"}
+        children[1]["fields"]["parent"] = {"id": "20", "key": "DEMO-20"}
+        records = [adapter._normalize_issue(child, "2026-09-01T00:00:00Z") for child in children]
+        pages = list(adapter.hierarchy_pages(records, "2026-09-01T00:00:00Z", lambda _: False))
+    assert requests == ["/rest/api/3/issue/10"]
+    assert sum(len(page.records) for page in pages) == 1
+    assert any("root bound" in limitation for page in pages for limitation in page.limitations)

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -23,6 +23,23 @@ from worktrace.packets.schema import PHASE4_QUESTIONS
 from worktrace.services import export_app
 
 
+def test_unicode_response_limit_counts_escaped_serialization() -> None:
+    result = enforce_total_limit({"text": "é" * 19_000})
+    for ensure_ascii in (False, True):
+        assert (
+            len(json.dumps(result, ensure_ascii=ensure_ascii, separators=(",", ":")))
+            <= MAX_RESPONSE_CHARS
+        )
+    assert result["response_truncated"] is True
+
+
+def test_period_citation_ids_are_not_redacted_as_phone_numbers() -> None:
+    identifier = "obs:123456789012345678901234"
+    assert enforce_total_limit({"period_evidence_ids": [identifier]}) == {
+        "period_evidence_ids": [identifier]
+    }
+
+
 def _config(tmp_path: Path) -> WorkTraceConfig:
     return WorkTraceConfig(
         schema_version=1,

--- a/tests/test_packets_golden.py
+++ b/tests/test_packets_golden.py
@@ -203,6 +203,8 @@ def _packet_state(
         external_id="a" * 40,
         title="Checkout validation",
         data={
+            "authored_at": "2026-08-25T23:59:59Z",
+            "committed_at": "2026-08-25T23:59:59Z",
             "changed_paths": [
                 "src/checkout/Validation.py",
                 "src/generated/Bindings.py",
@@ -258,7 +260,7 @@ def _packet_state(
         kind="jira_issue",
         external_id="DEMO-7",
         title="Validate checkout full name",
-        data={"priority": "High"},
+        data={"priority": "High", "created_at": "2026-08-25T23:59:59Z"},
     )
     _insert_object(
         connection,


### PR DESCRIPTION
## Summary

- Discover historical Jira updates, assignment and creation independently of latest issue freshness, retaining exact-key scope and recording why each issue was selected without inventing ownership.
- Stage redacted discoveries and history in the existing ledger so duplicate reasons are united, the first issue version stays immutable, memory is not proportional to all issue bodies, and failed runs retain previous authority.
- Preserve comment creators/editors and assignment boundaries, using the configured IANA work calendar and explicit current-text caveats so later edits cannot erase earlier activity.
- Share activity-date projection across candidate periods, evidence filtering and Phase 4 answers; exclude undated results only when dates are requested and filter before pagination. Keep all six MCP tools and cursor encoding.
- Preserve the existing MCP size bound for escaped Unicode and protect additive period citation IDs after integration exposed an over-budget packet.

Refs #27

AgDR: [AgDR-0007](https://github.com/AmrMohamad/WorkTrace/blob/main/docs/agdr/AgDR-0007-agent-evidence-workflow-migration.md)

## Validation

- Full local branch-coverage run: 370 passed, 11 legacy golden-harness calls failed after removal of the single-phase Jira adapter API.
- Updated those fixtures to the real staging path, then reran all golden and MCP security cases: 30 passed, including two new Unicode/citation regressions. All 383 collected cases are accounted for; final exact-head full run is also required in CI.
- Combined branch-enabled coverage: 87%. Formatting, Ruff, strict mypy (72 source files), and sdist/wheel build pass.
- Installed wheel CLI and schema-5 staging migration pass from a separate environment outside the checkout.
- Final exact-head [Quality CI](https://github.com/AmrMohamad/WorkTrace/actions/runs/33982667993) on `ecb13f9d988f92989dad94fc3c23e91881b928d2`: **383 passed, 87% coverage**, formatting, lint, strict types, package build and installed-wheel smoke all pass.
- New actual CLI import-all fixtures use mocked Jira HTTP and canonical linker/candidate/packet projection before any human grouping decisions. Additional tests cover no-code discovery, late text edits, missing/ambiguous assignment endpoints, reassignment, DST, duplicate versions, atomic page rollback, failed hydration, repeated continuation tokens and date-filtered pagination.

## Upgrade and scope

Migration 005 adds only run-scoped temporary staging. Existing observations, IDs and decisions are preserved; failed staging never becomes authoritative or is reused. Successful source finalization removes its staging rows.

Use the existing coherent private backup/forward-migration workflow, then an explicitly authorized full configured-range Jira reimport. No synthetic backfill, live-provider access, private-ledger migration, new dependencies, TUI redesign, discovery-cap changes, seventh tool or new cursor contract in this PR.

## Review and QA

- [x] [Independent exact-head code/security review](https://github.com/AmrMohamad/WorkTrace/pull/34#pullrequestreview-5122376430) approved; canonical Rex marker recorded.
- [x] Exact-head CI green
- [ ] Explicit per-PR human merge approval
- [ ] Post-merge acceptance QA before issue closure

## Glossary

| Term | Meaning |
|---|---|
| Activity time | Dated work evidence, separate from source-version freshness and fetch time. |
| Run-scoped staging | Redacted temporary rows owned by one import attempt, never authoritative evidence. |
| Assignment boundary | A predecessor or successor transition needed to establish an interval; contextual, not implementation proof. |
| Half-open interval | Includes the first local midnight and excludes the midnight after the last configured date. |
| Current source version | The visible record today; not a reconstruction of overwritten historical text. |
