### PR TITLE
fix(#28): report discovery coverage and preflight honestly

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,34 @@ uv run worktrace status APP_ID
 `import all` rebuilds references and candidates; separate source imports require an explicit
 `worktrace rebuild all APP_ID`. The six-tool MCP contract and cursor encoding are unchanged.
 
+## Discovery coverage and selector upgrades
+
+Jira exact-key discovery uses exact personal participation, canonically confirmed contributions,
+and explicit `--jira-key DEMO-42` inputs. Related collaborator/branch records remain context;
+Git ancestry is not a discovery traversal. All selected keys use existing provider chunks, with
+discovered/selected/omitted counts, policy and supporting observation IDs. Confirmed historical
+records can seed recovery, explicitly labelled as historical rather than current evidence.
+
+Jira selector v3 requires the full configured interval. If a replacement would remove current
+records, the import remains nonauthoritative and reports removed object IDs, affected confirmed
+contributions and a `proposal_token`. Review that impact before authorizing a repeat:
+
+```console
+uv run worktrace import all APP_ID --approve-selector-replacement PROPOSAL_TOKEN
+```
+
+The token binds the previous observations, proposed membership and confirmed contribution state;
+changed impact requires a new preview. Observations and human decisions are never deleted by this
+upgrade. Old selectors remain explicitly labelled until a successful approved replacement.
+
+Missing credentials, invalid origins and unverified identities are session preflight failures,
+not new provider source instances. `status` exposes current preparation separately from retained
+authoritative snapshots; a later successful attempt clears current failure without deleting its
+audit. Execution, coverage, snapshot activation, derived readiness and review availability are
+separate facts. Successful execution does not mean every historical record was recoverable.
+Provider/HMAC secrets and hostile Git overrides are stripped from local Git subprocesses; this
+reduces credential exposure but is not a process sandbox.
+
 ## Human review UI
 
 Launch the keyboard-first, read-only evidence workstation in an interactive terminal:

--- a/src/worktrace/adapters/git_local.py
+++ b/src/worktrace/adapters/git_local.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import os
 import re
 import subprocess
 from collections.abc import Iterator, Sequence
@@ -21,6 +20,7 @@ from worktrace.adapters.base import (
     ReferenceStrength,
 )
 from worktrace.errors import ConfigurationError, PermanentSourceError, ScopeViolation
+from worktrace.git_environment import local_git_environment
 from worktrace.normalize import (
     Redactor,
     actor_identity,
@@ -84,25 +84,13 @@ class LocalGitAdapter:
     def _run_git_bytes(self, args: Sequence[str]) -> bytes:
         if not args or args[0] not in _READ_ONLY_COMMANDS:
             raise PermanentSourceError("Attempted unsupported Git operation")
-        environment = os.environ.copy()
-        for variable in (
-            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
-            "GIT_COMMON_DIR",
-            "GIT_CONFIG",
-            "GIT_CONFIG_COUNT",
-            "GIT_DIR",
-            "GIT_OBJECT_DIRECTORY",
-            "GIT_WORK_TREE",
-        ):
-            environment.pop(variable, None)
-        environment["GIT_OPTIONAL_LOCKS"] = "0"
-        environment["GIT_NO_REPLACE_OBJECTS"] = "1"
-        environment["GIT_TERMINAL_PROMPT"] = "0"
+        if args[0] == "show":
+            args = ("show", "--no-ext-diff", "--no-textconv", *args[1:])
         try:
             result = subprocess.run(
                 ["git", "--no-optional-locks", "-C", str(self._repo), *args],
                 cwd=self._repo,
-                env=environment,
+                env=local_git_environment(),
                 check=False,
                 capture_output=True,
                 timeout=self._config.command_timeout_seconds,

--- a/src/worktrace/cli.py
+++ b/src/worktrace/cli.py
@@ -4,6 +4,7 @@ import json
 import os
 import sqlite3
 import sys
+from contextlib import ExitStack
 from dataclasses import asdict, dataclass
 from datetime import date
 from pathlib import Path
@@ -32,6 +33,7 @@ from worktrace.db.authority import (
     run_is_authoritative,
 )
 from worktrace.db.connection import connect
+from worktrace.db.import_status import readiness_contract, source_readiness
 from worktrace.db.migrations import backup_database, migrate
 from worktrace.db.queries import search_evidence, source_status
 from worktrace.db.readiness import DatabaseReadinessStatus, database_readiness
@@ -46,9 +48,9 @@ from worktrace.identity import (
     prepare_identity_import,
     repair_identities,
 )
+from worktrace.importers.jira_selection import select_jira_seeds
 from worktrace.importers.orchestrator import ImportResult, import_snapshot
 from worktrace.linking.builder import rebuild_references
-from worktrace.linking.extractors import extract_jira_keys
 from worktrace.local_security import email_hmac_key
 from worktrace.normalize.redaction import Redactor
 from worktrace.paths import ensure_private_directory
@@ -613,34 +615,6 @@ def _commit_seed_scope(selection: _CommitSeedSelection) -> dict[str, JsonValue]:
     return details
 
 
-def _discovered_jira_keys(
-    repository: EvidenceRepository, configured_app: AppConfig, *, limit: int = 500
-) -> tuple[str, ...]:
-    """Derive exact in-scope Jira keys from the authoritative current ledger view."""
-
-    app_config = configured_app
-    keys: set[str] = set()
-    for row in repository.current_observations(app_config.id):
-        text = f"{row['title'] or ''}\n{row['body_text'] or ''}"
-        keys.update(extract_jira_keys(text, app_config))
-        try:
-            data = json.loads(str(row["data_json"]))
-        except json.JSONDecodeError:
-            continue
-        if not isinstance(data, dict):
-            continue
-        pending = data.get("_pending_references", [])
-        if not isinstance(pending, list):
-            continue
-        for raw in pending:
-            if not isinstance(raw, dict) or raw.get("target_source") != "jira":
-                continue
-            key = str(raw.get("target_external_id", "")).upper()
-            if app_config.allows_jira_key(key):
-                keys.add(key)
-    return tuple(sorted(keys)[:limit])
-
-
 def _import_summary(
     result: ImportResult,
     *,
@@ -654,6 +628,368 @@ def _import_summary(
     return summary
 
 
+def _run_source_import(
+    configuration: WorkTraceConfig,
+    repository: EvidenceRepository,
+    configured_app: AppConfig,
+    source: str,
+    identifier: Path | int | None,
+    start: date,
+    end: date,
+    session_id: str,
+    *,
+    explicit_jira_keys: tuple[str, ...] = (),
+    approve_selector_replacement: str | None = None,
+    previous_results: list[dict[str, object]] | None = None,
+) -> dict[str, object]:
+    """Establish preparation and identity before creating a real source run."""
+    app_id = configured_app.id
+    target = (
+        str(identifier)
+        if source == "gitlab"
+        else (_source_instance(app_id, source, identifier) if source == "git" else "jira")
+    )
+    reason = "identity_policy_unready"
+    started = False
+    try:
+        with ExitStack() as stack:
+            credentials = None
+            if source in {"jira", "gitlab"}:
+                reason = "credentials_missing"
+                credentials = jira_credentials() if source == "jira" else gitlab_credentials()
+                if credentials is None:
+                    raise ConfigurationError("Provider credentials are not configured")
+                reason = "identity_missing"
+                if source == "jira" and not configuration.identity.jira_account_id:
+                    raise ConfigurationError("Jira identity is required")
+                if source == "gitlab" and (
+                    configuration.identity.gitlab_user_id is None
+                    and configuration.identity.gitlab_username is None
+                ):
+                    raise ConfigurationError("GitLab identity is required")
+            reason = "identity_policy_unready"
+            key = email_hmac_key(configuration.data_directory, create=False)
+            with repository.connection:
+                prepare_identity_import(repository.connection, configuration, key, app_id)
+            scope: dict[str, JsonValue] = {}
+            counts: dict[str, int] = {}
+            own_ids = _git_self_ids(configuration, key)
+            reason = "source_configuration_invalid"
+            adapter: LocalGitAdapter | GitLabAdapter | JiraAdapter
+            if source == "git":
+                assert isinstance(identifier, Path)
+                scoped_repo = configured_app.assert_repo_scope(identifier)
+                source_instance = _source_instance(app_id, source, scoped_repo)
+                adapter = LocalGitAdapter(
+                    LocalGitConfig(
+                        repository_path=scoped_repo,
+                        allowed_root=scoped_repo,
+                        source_instance=source_instance,
+                        app_id=app_id,
+                        email_key=key,
+                        jira_project_keys=configured_app.jira_project_keys,
+                        date_from=start,
+                        date_to=end,
+                    )
+                )
+                scope["selection_reasons"] = ["configured repository read-only snapshot"]
+            elif source == "gitlab":
+                assert credentials is not None and isinstance(identifier, int)
+                source_instance = _source_instance(app_id, source, identifier)
+                seeds = _relevant_git_commit_shas(repository, app_id)
+                counts = {
+                    "relevant_local_commit_shas": len(seeds.values),
+                    "relevant_local_commit_shas_total": seeds.total_count,
+                    "relevant_local_commit_shas_dropped": seeds.dropped_count,
+                }
+                reason = "origin_invalid"
+                client = stack.enter_context(
+                    httpx.Client(
+                        base_url=credentials.base_url,
+                        headers={"PRIVATE-TOKEN": credentials.token, "Accept": "application/json"},
+                        timeout=30,
+                    )
+                )
+                gitlab_adapter = GitLabAdapter(
+                    GitLabConfig(
+                        base_url=credentials.base_url,
+                        source_instance=source_instance,
+                        app_id=app_id,
+                        project_id=identifier,
+                        email_key=key,
+                        date_from=start,
+                        date_to=end,
+                        jira_project_keys=configured_app.jira_project_keys,
+                        user_id=configuration.identity.gitlab_user_id,
+                        username=configuration.identity.gitlab_username,
+                        production_environments=configured_app.production_environments,
+                        relevant_commit_shas=seeds.values,
+                    ),
+                    client,
+                )
+                reason = "identity_unverified"
+                own_ids = gitlab_adapter.resolved_self_ids(own_ids)
+                adapter = gitlab_adapter
+                scope = {
+                    **_commit_seed_scope(seeds),
+                    "selection_reasons": [
+                        "configured identity authored/assigned/reviewed merge requests",
+                        "current self-authored/coauthored local commits",
+                    ],
+                }
+            else:
+                assert credentials is not None
+                selection = select_jira_seeds(
+                    repository,
+                    configured_app,
+                    configuration=configuration,
+                    explicit_keys=explicit_jira_keys,
+                )
+                counts = {"exact_jira_keys": len(selection.keys)}
+                source_instance = _source_instance(app_id, source, credentials.base_url)
+                reason = "origin_invalid"
+                # This branch has JiraCredentials; keep the union's narrowing explicit.
+                jira_auth = jira_credentials()
+                assert jira_auth is not None
+                client = stack.enter_context(
+                    httpx.Client(
+                        base_url=jira_auth.base_url,
+                        auth=(jira_auth.email, jira_auth.token),
+                        headers={"Accept": "application/json"},
+                        timeout=30,
+                    )
+                )
+                jira_adapter = JiraAdapter(
+                    JiraConfig(
+                        work_timezone=configuration.employment_timezone,
+                        base_url=jira_auth.base_url,
+                        source_instance=source_instance,
+                        app_id=app_id,
+                        project_keys=configured_app.jira_project_keys,
+                        email_key=key,
+                        date_from=start,
+                        date_to=end,
+                        account_id=configuration.identity.jira_account_id,
+                        discovered_issue_keys=selection.keys,
+                    ),
+                    client,
+                )
+                reason = "identity_unverified"
+                own_ids = {jira_adapter.resolved_self_id()}
+                adapter = jira_adapter
+                scope = {
+                    "selection_policy_version": 3,
+                    "exact_jira_key_count": len(selection.keys),
+                    "jira_seed_selection": cast(JsonValue, selection.as_dict()),
+                    "limitations": selection.as_dict()["limitations"],
+                    "selection_reasons": [
+                        "configured identity participation",
+                        "selected exact-key roots",
+                    ],
+                    "known_selection_bias": "Deleted or inaccessible activity may be unavailable.",
+                }
+            if source in {"jira", "gitlab"}:
+                retained = source_readiness(repository.connection, app_id)
+                upstream: list[dict[str, object]] = []
+                for item in previous_results or []:
+                    previous_source = str(item.get("source"))
+                    if previous_source not in ({"git", "gitlab"} if source == "jira" else {"git"}):
+                        continue
+                    if item.get("status") == "complete":
+                        continue
+                    expected_instance = item.get("source_instance") or (
+                        item.get("target")
+                        if previous_source == "git"
+                        else _source_instance(app_id, "gitlab", item.get("target"))
+                    )
+                    known = retained.get(previous_source, {}).get(
+                        "last_authoritative_snapshots", []
+                    )
+                    snapshots = (
+                        [
+                            snapshot
+                            for snapshot in known
+                            if isinstance(snapshot, dict)
+                            and snapshot.get("source_instance") == expected_instance
+                        ]
+                        if isinstance(known, list)
+                        else []
+                    )
+                    upstream.append(
+                        {
+                            "source": previous_source,
+                            "run_id": item.get("run_id"),
+                            "status": item.get("status"),
+                            "snapshots": snapshots,
+                            "input_authority": "previous_authority"
+                            if snapshots
+                            else "no_authoritative_input",
+                        }
+                    )
+                scope["seed_input_authority"] = (
+                    cast(JsonValue, upstream) if upstream else "current_authority"
+                )
+                if upstream:
+                    previous_limitations = scope.get("limitations", [])
+                    scope["limitations"] = [
+                        *(previous_limitations if isinstance(previous_limitations, list) else []),
+                        "An upstream import did not complete; discovery uses only explicitly "
+                        "retained authority where available.",
+                    ]
+            started = True
+            if source == "jira":
+                result = import_snapshot(
+                    configured_app,
+                    adapter,
+                    repository,
+                    source=source,
+                    source_instance=source_instance,
+                    date_from=start,
+                    date_to=end,
+                    self_actor_ids=own_ids,
+                    import_session_id=session_id,
+                    finish_session=False,
+                    scope_details=scope,
+                    configuration=configuration,
+                    expected_selector_replacement=approve_selector_replacement,
+                )
+            else:
+                result = import_snapshot(
+                    configured_app,
+                    adapter,
+                    repository,
+                    source=source,
+                    source_instance=source_instance,
+                    date_from=start,
+                    date_to=end,
+                    self_actor_ids=own_ids,
+                    import_session_id=session_id,
+                    finish_session=False,
+                    scope_details=scope,
+                )
+        return {
+            **_import_summary(result, discovery_counts=counts),
+            "source": source,
+            "target": target,
+            "source_instance": source_instance,
+            **({"jira_seed_selection": scope["jira_seed_selection"]} if source == "jira" else {}),
+            "seed_input_authority": scope.get("seed_input_authority"),
+            "preflight": {"stage": "preflight", "status": "ready", "reason": None},
+            "requested_scope": {
+                "app_id": app_id,
+                "source": source,
+                "date_from": start.isoformat(),
+                "date_to": end.isoformat(),
+            },
+            **readiness_contract(
+                repository.connection,
+                app_id,
+                source,
+                result.status,
+                result.completeness,
+                source_instance=source_instance,
+            ),
+        }
+    except (WorkTraceError, httpx.HTTPError, ValueError) as exc:
+        if started:
+            raise
+        # Provider exception text can include credentials or private URLs; persist a category only.
+        if isinstance(exc, httpx.HTTPError):
+            reason = "provider_unavailable"
+        return {
+            "session_id": session_id,
+            "source": source,
+            "target": target,
+            "source_instance": None,
+            "stage": "preflight",
+            "status": "not_started",
+            "reason": reason,
+            "completeness": "unknown",
+            "preflight": {"stage": "preflight", "status": "not_started", "reason": reason},
+            "requested_scope": {
+                "app_id": app_id,
+                "source": source,
+                "date_from": start.isoformat(),
+                "date_to": end.isoformat(),
+            },
+            **readiness_contract(repository.connection, app_id, source, "not_started", "unknown"),
+        }
+
+
+def _finish_source_session(
+    repository: EvidenceRepository,
+    session_id: str,
+    results: list[dict[str, object]],
+    *,
+    derived_current: bool = False,
+) -> str:
+    complete = all(item["status"] == "complete" for item in results)
+    overall = (
+        "complete"
+        if complete
+        else "partial"
+        if any(item["status"] == "complete" for item in results)
+        else "failed"
+    )
+    for item in results:
+        item["derived_data"] = "current" if derived_current else "requires_rebuild"
+        if derived_current and item["coverage"] == "no-known-omissions":
+            item["agent_review"] = "available"
+    repository.finish_import_session(
+        session_id, overall, {"sources": cast(list[JsonValue], results)}
+    )
+    return overall
+
+
+def _import_one(
+    app_id: str,
+    source: str,
+    identifier: Path | int | None,
+    date_from: str | None,
+    date_to: str | None,
+    config: Path | None,
+    *,
+    jira_keys: tuple[str, ...] = (),
+    approve_selector_replacement: str | None = None,
+) -> None:
+    configuration, connection, repository = _open(config)
+    session_id: str | None = None
+    try:
+        start, end = _window(configuration, date_from, date_to)
+        configured_app = configuration.app(app_id)
+        _assert_no_scope_contraction(repository, app_id, start, end)
+        if source == "gitlab" and not configured_app.allows_gitlab_project(cast(int, identifier)):
+            raise WorkTraceError("GitLab project is not configured for this app")
+        session_id = repository.create_import_session(configured_app, start, end)
+        result = _run_source_import(
+            configuration,
+            repository,
+            configured_app,
+            source,
+            identifier,
+            start,
+            end,
+            session_id,
+            explicit_jira_keys=jira_keys,
+            approve_selector_replacement=approve_selector_replacement,
+        )
+        _finish_source_session(repository, session_id, [result])
+        _emit(result)
+        if result["status"] != "complete":
+            raise typer.Exit(2)
+    except typer.Exit:
+        raise
+    except Exception:
+        if session_id is not None:
+            connection.rollback()
+            repository.finish_import_session(
+                session_id, "failed", {"error": "source_execution_failed"}
+            )
+        raise
+    finally:
+        connection.close()
+
+
 @import_app.command("git")
 def import_git(
     app_id: str,
@@ -662,49 +998,7 @@ def import_git(
     date_to: DateArgument = None,
     config: ConfigOption = None,
 ) -> None:
-    configuration, connection, repository = _open(config)
-    try:
-        start, end = _window(configuration, date_from, date_to)
-        configured_app = configuration.app(app_id)
-        _assert_no_scope_contraction(repository, app_id, start, end)
-        scoped_repo = configured_app.assert_repo_scope(repo)
-        source_instance = _source_instance(app_id, "git", scoped_repo)
-        key = email_hmac_key(configuration.data_directory, create=False)
-        with connection:
-            prepare_identity_import(connection, configuration, key, app_id)
-        adapter = LocalGitAdapter(
-            LocalGitConfig(
-                repository_path=scoped_repo,
-                allowed_root=scoped_repo,
-                source_instance=source_instance,
-                app_id=app_id,
-                email_key=key,
-                jira_project_keys=configured_app.jira_project_keys,
-                date_from=start,
-                date_to=end,
-            )
-        )
-        result = import_snapshot(
-            configured_app,
-            adapter,
-            repository,
-            source="git",
-            source_instance=source_instance,
-            date_from=start,
-            date_to=end,
-            self_actor_ids=_git_self_ids(configuration, key),
-            scope_details={"selection_reasons": ["configured repository read-only snapshot"]},
-        )
-        _emit(
-            _import_summary(
-                result,
-                discovery_reasons=("configured repository read-only snapshot",),
-            )
-        )
-        if result.status != "complete":
-            raise typer.Exit(2)
-    finally:
-        connection.close()
+    _import_one(app_id, "git", repo, date_from, date_to, config)
 
 
 @import_app.command("jira")
@@ -713,79 +1007,21 @@ def import_jira(
     date_from: DateArgument = None,
     date_to: DateArgument = None,
     config: ConfigOption = None,
+    jira_key: Annotated[list[str] | None, typer.Option("--jira-key")] = None,
+    approve_selector_replacement: Annotated[
+        str | None, typer.Option("--approve-selector-replacement")
+    ] = None,
 ) -> None:
-    configuration, connection, repository = _open(config)
-    try:
-        start, end = _window(configuration, date_from, date_to)
-        configured_app = configuration.app(app_id)
-        _assert_no_scope_contraction(repository, app_id, start, end)
-        credentials = jira_credentials()
-        if credentials is None:
-            raise WorkTraceError("Jira credentials are not configured")
-        key = email_hmac_key(configuration.data_directory, create=False)
-        source_instance = _source_instance(app_id, "jira", credentials.base_url)
-        with connection:
-            prepare_identity_import(connection, configuration, key, app_id)
-        discovered_keys = _discovered_jira_keys(repository, configured_app)
-        with httpx.Client(
-            base_url=credentials.base_url,
-            auth=(credentials.email, credentials.token),
-            headers={"Accept": "application/json"},
-            timeout=30,
-        ) as client:
-            adapter = JiraAdapter(
-                JiraConfig(
-                    work_timezone=configuration.employment_timezone,
-                    base_url=credentials.base_url,
-                    source_instance=source_instance,
-                    app_id=app_id,
-                    project_keys=configured_app.jira_project_keys,
-                    email_key=key,
-                    date_from=start,
-                    date_to=end,
-                    account_id=configuration.identity.jira_account_id,
-                    discovered_issue_keys=discovered_keys,
-                ),
-                client,
-            )
-            result = import_snapshot(
-                configured_app,
-                adapter,
-                repository,
-                source="jira",
-                source_instance=source_instance,
-                date_from=start,
-                date_to=end,
-                self_actor_ids=(
-                    {configuration.identity.jira_account_id}
-                    if configuration.identity.jira_account_id
-                    else set()
-                ),
-                scope_details={
-                    "exact_jira_key_count": len(discovered_keys),
-                    "selection_reasons": [
-                        "configured identity participation",
-                        "current ledger exact-key references",
-                    ],
-                    "known_selection_bias": (
-                        "comment-only participation may not be discoverable by provider search"
-                    ),
-                },
-            )
-        _emit(
-            _import_summary(
-                result,
-                discovery_counts={"exact_jira_keys": len(discovered_keys)},
-                discovery_reasons=(
-                    "configured identity participation",
-                    "current ledger exact-key references",
-                ),
-            )
-        )
-        if result.status != "complete":
-            raise typer.Exit(2)
-    finally:
-        connection.close()
+    _import_one(
+        app_id,
+        "jira",
+        None,
+        date_from,
+        date_to,
+        config,
+        jira_keys=tuple(jira_key or ()),
+        approve_selector_replacement=approve_selector_replacement,
+    )
 
 
 @import_app.command("gitlab")
@@ -796,84 +1032,7 @@ def import_gitlab(
     date_to: DateArgument = None,
     config: ConfigOption = None,
 ) -> None:
-    configuration, connection, repository = _open(config)
-    try:
-        start, end = _window(configuration, date_from, date_to)
-        configured_app = configuration.app(app_id)
-        _assert_no_scope_contraction(repository, app_id, start, end)
-        if not configured_app.allows_gitlab_project(project_id):
-            raise WorkTraceError("GitLab project is not configured for this app")
-        credentials = gitlab_credentials()
-        if credentials is None:
-            raise WorkTraceError("GitLab credentials are not configured")
-        if (
-            configuration.identity.gitlab_user_id is None
-            and configuration.identity.gitlab_username is None
-        ):
-            raise WorkTraceError("GitLab identity is required for user-scoped discovery")
-        key = email_hmac_key(configuration.data_directory, create=False)
-        commit_seeds = _relevant_git_commit_shas(repository, app_id)
-        with connection:
-            prepare_identity_import(connection, configuration, key, app_id)
-        with httpx.Client(
-            base_url=credentials.base_url,
-            headers={"PRIVATE-TOKEN": credentials.token, "Accept": "application/json"},
-            timeout=30,
-        ) as client:
-            source_instance = _source_instance(app_id, "gitlab", project_id)
-            adapter = GitLabAdapter(
-                GitLabConfig(
-                    base_url=credentials.base_url,
-                    source_instance=source_instance,
-                    app_id=app_id,
-                    project_id=project_id,
-                    email_key=key,
-                    date_from=start,
-                    date_to=end,
-                    jira_project_keys=configured_app.jira_project_keys,
-                    user_id=configuration.identity.gitlab_user_id,
-                    username=configuration.identity.gitlab_username,
-                    production_environments=configured_app.production_environments,
-                    relevant_commit_shas=commit_seeds.values,
-                ),
-                client,
-            )
-            own_ids = adapter.resolved_self_ids(_git_self_ids(configuration, key))
-            result = import_snapshot(
-                configured_app,
-                adapter,
-                repository,
-                source="gitlab",
-                source_instance=source_instance,
-                date_from=start,
-                date_to=end,
-                self_actor_ids=own_ids,
-                scope_details={
-                    **_commit_seed_scope(commit_seeds),
-                    "selection_reasons": [
-                        "configured identity authored/assigned/reviewed merge requests",
-                        "current self-authored/coauthored local commits",
-                    ],
-                },
-            )
-        _emit(
-            _import_summary(
-                result,
-                discovery_counts={
-                    "relevant_local_commit_shas": len(commit_seeds.values),
-                    "relevant_local_commit_shas_total": commit_seeds.total_count,
-                    "relevant_local_commit_shas_dropped": commit_seeds.dropped_count,
-                },
-                discovery_reasons=(
-                    "configured identity authored/assigned/reviewed merge requests",
-                    "current self-authored/coauthored local commits",
-                ),
-            )
-        )
-        if result.status != "complete":
-            raise typer.Exit(2)
-    finally:
-        connection.close()
+    _import_one(app_id, "gitlab", project_id, date_from, date_to, config)
 
 
 @import_app.command("all")
@@ -882,275 +1041,56 @@ def import_all(
     date_from: DateArgument = None,
     date_to: DateArgument = None,
     config: ConfigOption = None,
+    jira_key: Annotated[list[str] | None, typer.Option("--jira-key")] = None,
+    approve_selector_replacement: Annotated[
+        str | None, typer.Option("--approve-selector-replacement")
+    ] = None,
 ) -> None:
-    """Import every configured source and report partial sources explicitly."""
+    """Import configured sources independently, retaining each preparation result."""
     configuration, connection, repository = _open(config)
-    start, end = _window(configuration, date_from, date_to)
-    configured_app = configuration.app(app_id)
-    _assert_no_scope_contraction(repository, app_id, start, end)
-    try:
-        key = email_hmac_key(configuration.data_directory, create=False)
-        with connection:
-            prepare_identity_import(connection, configuration, key, app_id)
-    except BaseException:
-        connection.close()
-        raise
-    session_id = repository.create_import_session(configured_app, start, end)
+    session_id: str | None = None
     results: list[dict[str, object]] = []
     try:
-        key = email_hmac_key(configuration.data_directory, create=False)
-        for repo_path in configured_app.repo_paths:
-            source_instance = _source_instance(app_id, "git", repo_path)
-            adapter = LocalGitAdapter(
-                LocalGitConfig(
-                    repository_path=repo_path,
-                    allowed_root=repo_path,
-                    source_instance=source_instance,
-                    app_id=app_id,
-                    email_key=key,
-                    jira_project_keys=configured_app.jira_project_keys,
-                    date_from=start,
-                    date_to=end,
-                )
-            )
-            result = import_snapshot(
-                configured_app,
-                adapter,
-                repository,
-                source="git",
-                source_instance=source_instance,
-                date_from=start,
-                date_to=end,
-                self_actor_ids=_git_self_ids(configuration, key),
-                import_session_id=session_id,
-                finish_session=False,
-                scope_details={"selection_reasons": ["configured repository read-only snapshot"]},
-            )
+        start, end = _window(configuration, date_from, date_to)
+        configured_app = configuration.app(app_id)
+        _assert_no_scope_contraction(repository, app_id, start, end)
+        session_id = repository.create_import_session(configured_app, start, end)
+        sources: list[tuple[str, Path | int | None]] = [
+            *(("git", repo) for repo in configured_app.repo_paths),
+            *(("gitlab", project) for project in configured_app.gitlab_project_ids),
+            *([("jira", None)] if configured_app.jira_project_keys else []),
+        ]
+        for source, identifier in sources:
             results.append(
-                _import_summary(
-                    result,
-                    discovery_reasons=("configured repository read-only snapshot",),
+                _run_source_import(
+                    configuration,
+                    repository,
+                    configured_app,
+                    source,
+                    identifier,
+                    start,
+                    end,
+                    session_id,
+                    explicit_jira_keys=tuple(jira_key or ()),
+                    approve_selector_replacement=approve_selector_replacement,
+                    previous_results=results,
                 )
             )
-
-        commit_seeds = _relevant_git_commit_shas(repository, app_id)
-        gitlab_auth = gitlab_credentials()
-        gitlab_identity_configured = (
-            configuration.identity.gitlab_user_id is not None
-            or configuration.identity.gitlab_username is not None
-        )
-        for project_id in configured_app.gitlab_project_ids:
-            source_instance = _source_instance(app_id, "gitlab", project_id)
-            if gitlab_auth is None or not gitlab_identity_configured:
-                failure = (
-                    "GitLab credentials are not configured"
-                    if gitlab_auth is None
-                    else "GitLab identity is required for user-scoped discovery"
+            # Keep preparation audit durable even if a later source or rebuild is interrupted.
+            with connection:
+                connection.execute(
+                    "UPDATE import_sessions SET summary_json=? WHERE id=?",
+                    (json.dumps({"sources": results}, sort_keys=True), session_id),
                 )
-                run_id = repository.start_sync_run(
-                    app_id,
-                    "gitlab",
-                    source_instance,
-                    {
-                        "project_id": project_id,
-                        "selection_policy_version": 2,
-                        "date_from": start.isoformat(),
-                        "date_to": end.isoformat(),
-                    },
-                    session_id,
-                )
-                repository.finish_sync_run(
-                    run_id,
-                    "failed",
-                    "source_unavailable",
-                    failure,
-                )
-                results.append(
-                    {
-                        "run_id": run_id,
-                        "source": "gitlab",
-                        "project_id": project_id,
-                        "status": "source_unavailable",
-                        "completeness": "partial",
-                        "discovery_counts": {
-                            "relevant_local_commit_shas": len(commit_seeds.values),
-                            "relevant_local_commit_shas_total": commit_seeds.total_count,
-                            "relevant_local_commit_shas_dropped": commit_seeds.dropped_count,
-                        },
-                        "discovery_reasons": [
-                            "configured identity authored/assigned/reviewed merge requests",
-                            "current self-authored/coauthored local commits",
-                        ],
-                    }
-                )
-                continue
-            with httpx.Client(
-                base_url=gitlab_auth.base_url,
-                headers={"PRIVATE-TOKEN": gitlab_auth.token, "Accept": "application/json"},
-                timeout=30,
-            ) as client:
-                gitlab_adapter = GitLabAdapter(
-                    GitLabConfig(
-                        base_url=gitlab_auth.base_url,
-                        source_instance=source_instance,
-                        app_id=app_id,
-                        project_id=project_id,
-                        email_key=key,
-                        date_from=start,
-                        date_to=end,
-                        jira_project_keys=configured_app.jira_project_keys,
-                        user_id=configuration.identity.gitlab_user_id,
-                        username=configuration.identity.gitlab_username,
-                        production_environments=configured_app.production_environments,
-                        relevant_commit_shas=commit_seeds.values,
-                    ),
-                    client,
-                )
-                own_ids = gitlab_adapter.resolved_self_ids(_git_self_ids(configuration, key))
-                result = import_snapshot(
-                    configured_app,
-                    gitlab_adapter,
-                    repository,
-                    source="gitlab",
-                    source_instance=source_instance,
-                    date_from=start,
-                    date_to=end,
-                    self_actor_ids=own_ids,
-                    import_session_id=session_id,
-                    finish_session=False,
-                    scope_details={
-                        **_commit_seed_scope(commit_seeds),
-                        "selection_reasons": [
-                            "configured identity authored/assigned/reviewed merge requests",
-                            "current self-authored/coauthored local commits",
-                        ],
-                    },
-                )
-                results.append(
-                    _import_summary(
-                        result,
-                        discovery_counts={
-                            "relevant_local_commit_shas": len(commit_seeds.values),
-                            "relevant_local_commit_shas_total": commit_seeds.total_count,
-                            "relevant_local_commit_shas_dropped": commit_seeds.dropped_count,
-                        },
-                        discovery_reasons=(
-                            "configured identity authored/assigned/reviewed merge requests",
-                            "current self-authored/coauthored local commits",
-                        ),
-                    )
-                )
-
-        discovered_keys = _discovered_jira_keys(repository, configured_app)
-        jira_auth = jira_credentials()
-        if configured_app.jira_project_keys:
-            if jira_auth is None:
-                run_id = repository.start_sync_run(
-                    app_id,
-                    "jira",
-                    _source_instance(app_id, "jira", "configured"),
-                    {
-                        "project_keys": list(configured_app.jira_project_keys),
-                        "selection_policy_version": 2,
-                        "date_from": start.isoformat(),
-                        "date_to": end.isoformat(),
-                    },
-                    session_id,
-                )
-                repository.finish_sync_run(
-                    run_id,
-                    "failed",
-                    "source_unavailable",
-                    "Jira credentials are not configured",
-                )
-                results.append(
-                    {
-                        "run_id": run_id,
-                        "source": "jira",
-                        "status": "source_unavailable",
-                        "completeness": "partial",
-                        "discovery_counts": {"exact_jira_keys": len(discovered_keys)},
-                        "discovery_reasons": [
-                            "configured identity participation",
-                            "current ledger exact-key references",
-                        ],
-                    }
-                )
-            else:
-                source_instance = _source_instance(app_id, "jira", jira_auth.base_url)
-                with httpx.Client(
-                    base_url=jira_auth.base_url,
-                    auth=(jira_auth.email, jira_auth.token),
-                    headers={"Accept": "application/json"},
-                    timeout=30,
-                ) as client:
-                    result = import_snapshot(
-                        configured_app,
-                        JiraAdapter(
-                            JiraConfig(
-                                work_timezone=configuration.employment_timezone,
-                                base_url=jira_auth.base_url,
-                                source_instance=source_instance,
-                                app_id=app_id,
-                                project_keys=configured_app.jira_project_keys,
-                                email_key=key,
-                                date_from=start,
-                                date_to=end,
-                                account_id=configuration.identity.jira_account_id,
-                                discovered_issue_keys=discovered_keys,
-                            ),
-                            client,
-                        ),
-                        repository,
-                        source="jira",
-                        source_instance=source_instance,
-                        date_from=start,
-                        date_to=end,
-                        self_actor_ids=(
-                            {configuration.identity.jira_account_id}
-                            if configuration.identity.jira_account_id
-                            else set()
-                        ),
-                        import_session_id=session_id,
-                        finish_session=False,
-                        scope_details={
-                            "exact_jira_key_count": len(discovered_keys),
-                            "selection_reasons": [
-                                "configured identity participation",
-                                "current ledger exact-key references",
-                            ],
-                            "known_selection_bias": (
-                                "comment-only participation may not be discoverable by provider "
-                                "search"
-                            ),
-                        },
-                    )
-                    results.append(
-                        _import_summary(
-                            result,
-                            discovery_counts={"exact_jira_keys": len(discovered_keys)},
-                            discovery_reasons=(
-                                "configured identity participation",
-                                "current ledger exact-key references",
-                            ),
-                        )
-                    )
-
-        reference_count = rebuild_references(configured_app, repository)
-        candidate_count = rebuild_candidates(app_id, repository)
-        with connection:
-            finish_identity_rebuild(connection, configuration, app_id)
-        complete = all(result.get("status") == "complete" for result in results)
-        overall = "complete" if complete else "partial"
-        repository.finish_import_session(
-            session_id,
-            overall,
-            {
-                "sources": cast(list[JsonValue], results),
-                "complete_sources": sum(r.get("status") == "complete" for r in results),
-                "reference_count": reference_count,
-                "candidate_count": candidate_count,
-            },
+        derived_current = bool(identity_policy_status(connection, configuration, app_id)["valid"])
+        reference_count = candidate_count = 0
+        if derived_current:
+            reference_count = rebuild_references(configured_app, repository)
+            candidate_count = rebuild_candidates(app_id, repository)
+            with connection:
+                finish_identity_rebuild(connection, configuration, app_id)
+        overall = _finish_source_session(
+            repository, session_id, results, derived_current=derived_current
         )
         _emit(
             {
@@ -1161,19 +1101,20 @@ def import_all(
                 "candidate_count": candidate_count,
             }
         )
-        if not complete:
+        if overall != "complete":
             raise typer.Exit(2)
     except typer.Exit:
         raise
-    except Exception as exc:
-        repository.finish_import_session(
-            session_id,
-            "partial",
-            {
-                "sources": cast(list[JsonValue], results),
-                "error": (str(exc)[:500] or type(exc).__name__),
-            },
-        )
+    except Exception:
+        if session_id is not None:
+            connection.rollback()
+            repository.finish_import_session(
+                session_id,
+                "partial"
+                if any(item.get("status") == "complete" for item in results)
+                else "failed",
+                {"sources": cast(list[JsonValue], results), "error": "source_or_rebuild_failed"},
+            )
         raise
     finally:
         connection.close()

--- a/src/worktrace/db/import_status.py
+++ b/src/worktrace/db/import_status.py
@@ -1,0 +1,159 @@
+"""SQLite-only preparation audit and readiness, independent of snapshot authority."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+from worktrace.db.authority import parse_scope, run_is_authoritative
+from worktrace.db.repository import stable_id
+
+
+def legacy_preflight_ids(connection: sqlite3.Connection, app_id: str) -> set[str]:
+    """Recognize only the exact old credential-placeholder writer's empty failed runs."""
+    return {
+        str(row[0])
+        for row in connection.execute(
+            """SELECT r.id FROM sync_runs r WHERE r.app_id=? AND r.source='jira'
+            AND r.source_instance=? AND r.status='failed'
+            AND r.completeness='source_unavailable'
+            AND r.error_summary='Jira credentials are not configured'
+            AND NOT EXISTS (SELECT 1 FROM observations o WHERE o.sync_run_id=r.id)""",
+            (app_id, stable_id("source", app_id, "jira", "configured")),
+        )
+    }
+
+
+def source_readiness(connection: sqlite3.Connection, app_id: str) -> dict[str, dict[str, object]]:
+    """Read latest preparation per configured target and retained authoritative snapshots."""
+    result: dict[str, dict[str, object]] = {}
+    seen: set[tuple[str, str]] = set()
+    for row in connection.execute(
+        "SELECT id, started_at, summary_json FROM import_sessions WHERE app_id=? "
+        "ORDER BY started_at DESC, id DESC",
+        (app_id,),
+    ):
+        try:
+            summary = json.loads(str(row["summary_json"]))
+        except (ValueError, TypeError):
+            continue
+        sources = summary.get("sources", []) if isinstance(summary, dict) else []
+        if not isinstance(sources, list):
+            continue
+        for item in sources:
+            if not isinstance(item, dict) or not isinstance(item.get("source"), str):
+                continue
+            source = item["source"]
+            target = str(item.get("target", source))
+            preflight = item.get("preflight")
+            if not isinstance(preflight, dict) or (source, target) in seen:
+                continue
+            seen.add((source, target))
+            entry = result.setdefault(source, {"preflight": [], "last_authoritative_snapshots": []})
+            attempts = entry["preflight"]
+            assert isinstance(attempts, list)
+            attempts.append(
+                {
+                    **preflight,
+                    "target": target,
+                    "session_id": row["id"],
+                    "attempted_at": row["started_at"],
+                    "source_instance": item.get("source_instance"),
+                }
+            )
+    snapshots: set[tuple[str, str]] = set()
+    legacy = legacy_preflight_ids(connection, app_id)
+    for row in connection.execute(
+        "SELECT * FROM sync_runs WHERE app_id=? ORDER BY started_at DESC, id DESC", (app_id,)
+    ):
+        source, instance = str(row["source"]), str(row["source_instance"])
+        entry = result.setdefault(source, {"preflight": [], "last_authoritative_snapshots": []})
+        if str(row["id"]) in legacy:
+            audit = entry.setdefault("legacy_preflight_audit", [])
+            assert isinstance(audit, list)
+            audit.append({"run_id": row["id"], "reason": "credentials_missing"})
+            continue
+        scope = parse_scope(row["scope_json"])
+        if (source, instance) in snapshots or not run_is_authoritative(
+            source, str(row["status"]), str(row["completeness"]), scope
+        ):
+            continue
+        snapshots.add((source, instance))
+        authoritative = entry["last_authoritative_snapshots"]
+        assert isinstance(authoritative, list)
+        authoritative.append(
+            {
+                "run_id": row["id"],
+                "source_instance": instance,
+                "completed_at": row["completed_at"],
+                "completeness": row["completeness"],
+                "selection_policy_version": scope.get("selection_policy_version"),
+                "jira_seed_selection": scope.get("jira_seed_selection")
+                if source == "jira"
+                else None,
+                "seed_input_authority": scope.get("seed_input_authority"),
+                "selector_policy": "legacy"
+                if source == "jira" and scope.get("selection_policy_version") != 3
+                else "current",
+                "coverage": "unknown"
+                if source == "jira" and scope.get("selection_policy_version") != 3
+                else "no-known-omissions"
+                if row["completeness"] == "complete_for_scope"
+                else "limited",
+                "requested_scope": {
+                    name: scope[name]
+                    for name in ("date_from", "date_to", "work_timezone")
+                    if name in scope
+                },
+            }
+        )
+    return result
+
+
+def readiness_contract(
+    connection: sqlite3.Connection,
+    app_id: str,
+    source: str,
+    status: str,
+    completeness: str,
+    *,
+    derived_current: bool = False,
+    source_instance: str | None = None,
+) -> dict[str, object]:
+    known = (
+        source_readiness(connection, app_id).get(source, {}).get("last_authoritative_snapshots", [])
+    )
+    snapshots = (
+        [
+            item
+            for item in known
+            if isinstance(item, dict)
+            and source_instance is not None
+            and item.get("source_instance") == source_instance
+        ]
+        if isinstance(known, list)
+        else []
+    )
+    activated = status == "complete"
+    coverage = (
+        "no-known-omissions"
+        if activated and completeness == "complete_for_scope"
+        else "limited"
+        if activated or snapshots
+        else "unknown"
+    )
+    return {
+        "execution": "complete" if activated else "failed" if status == "not_started" else status,
+        "coverage": coverage,
+        "snapshot_state": "activated"
+        if activated
+        else "previous_retained"
+        if snapshots
+        else "unavailable",
+        "derived_data": "current" if derived_current else "requires_rebuild",
+        "agent_review": "available"
+        if coverage == "no-known-omissions" and derived_current
+        else "available-with-gaps"
+        if snapshots
+        else "blocked",
+    }

--- a/src/worktrace/db/queries.py
+++ b/src/worktrace/db/queries.py
@@ -13,26 +13,32 @@ from worktrace.db.authority import (
     run_is_authoritative,
     selection_policy_version,
 )
+from worktrace.db.import_status import legacy_preflight_ids, source_readiness
 from worktrace.errors import NotFound, ScopeViolation
 
 
 def source_status(connection: sqlite3.Connection, app_id: str) -> list[dict[str, object]]:
+    readiness = source_readiness(connection, app_id)
+    legacy = legacy_preflight_ids(connection, app_id)
+    exclude = f"AND id NOT IN ({','.join('?' for _ in legacy)})" if legacy else ""
     rows = connection.execute(
-        """
+        f"""
         SELECT * FROM (
-            SELECT source, source_instance, status, completeness, started_at, completed_at,
+            SELECT id, source, source_instance, status, completeness, started_at, completed_at,
                    error_summary, progress_json, scope_json,
                    ROW_NUMBER() OVER (
                      PARTITION BY source, source_instance ORDER BY started_at DESC, id DESC
                    ) AS position
-            FROM sync_runs WHERE app_id=?
+            FROM sync_runs WHERE app_id=? {exclude}
         ) WHERE position=1 ORDER BY source, source_instance
         """,
-        (app_id,),
+        (app_id, *sorted(legacy)),
     )
     cutoff = datetime.now(UTC) - timedelta(days=STALE_AFTER_DAYS)
     result: list[dict[str, object]] = []
     for row in rows:
+        if str(row["id"]) in legacy:
+            continue
         completed = str(row["completed_at"] or row["started_at"])
         try:
             stale = datetime.fromisoformat(completed.replace("Z", "+00:00")) < cutoff
@@ -71,6 +77,11 @@ def source_status(connection: sqlite3.Connection, app_id: str) -> list[dict[str,
                 "metadata; existing observations were not backfilled."
             )
         complete = authoritative and completeness_is_full_scope(str(row["completeness"]))
+        if row["source"] == "jira" and selection_version != 3:
+            limitations.append(
+                "Jira discovery uses legacy selector policy; "
+                "full configured-range reimport required."
+            )
         result.append(
             {
                 "source": str(row["source"]),
@@ -86,8 +97,22 @@ def source_status(connection: sqlite3.Connection, app_id: str) -> list[dict[str,
                 "authoritative_current": authoritative,
                 "limitations": limitations,
                 "selection_events": progress.get("selection_events", []),
+                **readiness.get(str(row["source"]), {}),
             }
         )
+    represented = {str(item["source"]) for item in result}
+    for source, state in readiness.items():
+        if source not in represented:
+            result.append(
+                {
+                    "source": source,
+                    "source_instance": None,
+                    "status": "not_started",
+                    "complete": False,
+                    "authoritative_current": False,
+                    **state,
+                }
+            )
     return result
 
 

--- a/src/worktrace/doctor.py
+++ b/src/worktrace/doctor.py
@@ -20,6 +20,7 @@ from worktrace.config import WorkTraceConfig, gitlab_credentials, jira_credentia
 from worktrace.db.connection import connect_read_only
 from worktrace.db.migrations import migrations, user_version
 from worktrace.errors import ConfigurationError
+from worktrace.git_environment import local_git_environment
 
 CheckStatus = Literal["pass", "warn", "fail", "skipped"]
 
@@ -46,9 +47,6 @@ def _git(args: list[str], root: Path | None = None) -> subprocess.CompletedProce
     if root is not None:
         command.extend(("-C", str(root)))
     command.extend(args)
-    environment = os.environ.copy()
-    environment["GIT_OPTIONAL_LOCKS"] = "0"
-    environment["GIT_TERMINAL_PROMPT"] = "0"
     return subprocess.run(
         command,
         check=False,
@@ -58,7 +56,7 @@ def _git(args: list[str], root: Path | None = None) -> subprocess.CompletedProce
         errors="replace",
         timeout=10,
         shell=False,
-        env=environment,
+        env=local_git_environment(),
     )
 
 

--- a/src/worktrace/git_environment.py
+++ b/src/worktrace/git_environment.py
@@ -1,0 +1,58 @@
+"""Shared environment policy for local Git metadata reads, not a sandbox."""
+
+from __future__ import annotations
+
+import os
+
+_BLOCKED_PREFIXES = (
+    "WORKTRACE_JIRA_",
+    "WORKTRACE_GITLAB_",
+    "WORKTRACE_EMAIL_HMAC",
+    "GIT_CONFIG_",
+    "GIT_TRACE",
+)
+_BLOCKED_VARIABLES = frozenset(
+    {
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_CONFIG",
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_NAMESPACE",
+        "GIT_SHALLOW_FILE",
+        "GIT_GRAFT_FILE",
+        "GIT_REPLACE_REF_BASE",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+        "GIT_EXEC_PATH",
+        "GIT_EXTERNAL_DIFF",
+        "GIT_DIFF_OPTS",
+        "GIT_ASKPASS",
+        "SSH_ASKPASS",
+        "GIT_SSH",
+        "GIT_SSH_COMMAND",
+        "GIT_SSH_VARIANT",
+        "GIT_PAGER",
+    }
+)
+
+
+def local_git_environment() -> dict[str, str]:
+    """Copy ambient settings without provider secrets or Git execution/path overrides.
+
+    Normal repository and user configuration remains readable, including intentional
+    mailmap settings. This only narrows the environment inherited by local Git reads.
+    """
+    environment = {
+        name: value
+        for name, value in os.environ.items()
+        if name not in _BLOCKED_VARIABLES and not name.startswith(_BLOCKED_PREFIXES)
+    }
+    environment.update(
+        GIT_OPTIONAL_LOCKS="0",
+        GIT_NO_REPLACE_OBJECTS="1",
+        GIT_TERMINAL_PROMPT="0",
+    )
+    return environment

--- a/src/worktrace/importers/jira_selection.py
+++ b/src/worktrace/importers/jira_selection.py
@@ -1,0 +1,288 @@
+"""Auditable exact-key roots and conservative selector replacement proposals."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+from collections import defaultdict
+from dataclasses import dataclass
+
+from worktrace.candidates.builder import _self_roles
+from worktrace.candidates.decisions import decision_lineages
+from worktrace.candidates.projector import project_candidate
+from worktrace.config import AppConfig, WorkTraceConfig
+from worktrace.db.authority import parse_scope, run_is_authoritative
+from worktrace.db.repository import EvidenceRepository
+from worktrace.domain.models import JsonValue
+from worktrace.errors import NotFound, ScopeViolation
+from worktrace.linking.extractors import extract_jira_keys
+from worktrace.packets.builder import PacketBuilder
+
+JIRA_SELECTOR_VERSION = 3
+_PERSONAL_ROLES = frozenset(
+    {
+        "git_author",
+        "git_coauthor",
+        "git_committer",
+        "git_reviewer",
+        "git_tag_author",
+        "mr_author",
+        "mr_assignee",
+        "mr_reviewer",
+        "mr_merger",
+        "gitlab_commit_author",
+        "gitlab_commit_coauthor",
+        "gitlab_commit_committer",
+        "gitlab_commit_reviewer",
+        "gitlab_discussion_author",
+        "gitlab_deployer",
+        "gitlab_release_author",
+    }
+)
+_CONTEXT_RELATIONS = frozenset(
+    {
+        "gitlab_mr_commit",
+        "mr_contains_commit",
+        "commit_introduced_by_mr",
+        "gitlab_mr_discussion",
+        "gitlab_mr_changed_paths",
+        "mr_uses_source_branch",
+        "git_ref_target",
+        "tag_points_to_commit",
+        "deployment_contains_sha",
+    }
+)
+
+
+@dataclass(frozen=True)
+class JiraKeySeed:
+    key: str
+    supporting_observation_ids: tuple[str, ...]
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class JiraSeedSelection:
+    seeds: tuple[JiraKeySeed, ...]
+    discovered_count: int
+    policy: str = "personal_roots_v3_with_bounded_structural_context"
+
+    @property
+    def keys(self) -> tuple[str, ...]:
+        return tuple(seed.key for seed in self.seeds)
+
+    def as_dict(self) -> dict[str, JsonValue]:
+        return {
+            "policy": self.policy,
+            "policy_version": JIRA_SELECTOR_VERSION,
+            "discovered_count": self.discovered_count,
+            "selected_count": len(self.seeds),
+            "omitted_count": self.discovered_count - len(self.seeds),
+            "omission_reason": "outside_personal_roots"
+            if self.discovered_count > len(self.seeds)
+            else None,
+            "exhaustive_for_selected_roots": True,
+            "seeds": [
+                {
+                    "key": seed.key,
+                    "supporting_observation_ids": list(seed.supporting_observation_ids),
+                    "reasons": list(seed.reasons),
+                }
+                for seed in self.seeds
+            ],
+            "limitations": ["Provider search may omit deleted or inaccessible issues."],
+        }
+
+
+def confirmed_memberships(
+    connection: sqlite3.Connection, configuration: WorkTraceConfig, app_id: str
+) -> dict[str, set[str]]:
+    """Use canonical decisions, including lineages whose suggestion disappeared."""
+    result: dict[str, set[str]] = {}
+    builder = PacketBuilder(connection, configuration)
+    for row in connection.execute("SELECT id FROM candidate_groups WHERE app_id=?", (app_id,)):
+        try:
+            view = project_candidate(connection, str(row[0]))
+        except NotFound:
+            continue
+        if view.status == "confirmed":
+            resolved = builder._resolve_contribution(view.id)
+            result[view.id] = resolved.member_ids | resolved.context_ids
+    for lineage in decision_lineages(connection):
+        if lineage.app_id != app_id:
+            continue
+        try:
+            resolved = builder._resolve_contribution(lineage.canonical_candidate_id)
+        except NotFound:
+            continue
+        result[lineage.canonical_candidate_id] = resolved.member_ids | resolved.context_ids
+    return result
+
+
+def select_jira_seeds(
+    repository: EvidenceRepository,
+    app: AppConfig,
+    *,
+    configuration: WorkTraceConfig,
+    explicit_keys: tuple[str, ...] = (),
+) -> JiraSeedSelection:
+    explicit = {key.strip().upper() for key in explicit_keys}
+    if any(
+        re.fullmatch(r"[A-Z][A-Z0-9_]*-[0-9]+", key) is None or not app.allows_jira_key(key)
+        for key in explicit
+    ):
+        raise ScopeViolation("Explicit Jira keys must be exact keys in configured projects")
+    rows = {str(row["source_object_id"]): row for row in repository.current_observations(app.id)}
+    confirmed = confirmed_memberships(repository.connection, configuration, app.id)
+    historical: set[str] = set()
+    for members in confirmed.values():
+        for member in members - rows.keys():
+            for row in repository.connection.execute(
+                "SELECT o.*, so.source, so.source_instance, so.kind, so.external_id, "
+                "r.status AS run_status, r.completeness AS run_completeness, r.scope_json "
+                "FROM observations o JOIN source_objects so ON so.id=o.source_object_id "
+                "JOIN sync_runs r ON r.id=o.sync_run_id WHERE so.id=? AND so.app_id=? "
+                "ORDER BY o.fetched_at DESC, o.id DESC",
+                (member, app.id),
+            ):
+                if run_is_authoritative(
+                    str(row["source"]),
+                    str(row["run_status"]),
+                    str(row["run_completeness"]),
+                    parse_scope(row["scope_json"]),
+                ):
+                    rows[member] = row
+                    historical.add(member)
+                    break
+    data = {identifier: json.loads(str(row["data_json"])) for identifier, row in rows.items()}
+    roots: dict[str, set[str]] = {}
+    for identifier, roles in _self_roles(repository.connection, app.id).items():
+        accepted = roles & _PERSONAL_ROLES
+        if accepted and identifier in rows:
+            roots[identifier] = {"self_role:" + role for role in accepted}
+    for group, members in confirmed.items():
+        for member in members & rows.keys():
+            roots.setdefault(member, set()).add("confirmed_contribution:" + group)
+            if member in historical:
+                roots[member].add("historical_confirmed_observation_not_current")
+
+    # Two hops reach a review's MR and its collaborator records. Git parents are
+    # deliberately absent: sharing repository ancestry is not personal scope.
+    by_external: dict[tuple[str, str], set[str]] = defaultdict(set)
+    for identifier, row in rows.items():
+        by_external[str(row["source"]), str(row["external_id"])].add(identifier)
+    edges: dict[str, set[str]] = defaultdict(set)
+    pending_by_object: dict[str, list[dict[str, object]]] = {}
+    for identifier, payload in data.items():
+        pending = payload.get("_pending_references", []) if isinstance(payload, dict) else []
+        pending_by_object[identifier] = (
+            [p for p in pending if isinstance(p, dict)] if isinstance(pending, list) else []
+        )
+        for ref in pending_by_object[identifier]:
+            if ref.get("relationship_type") not in _CONTEXT_RELATIONS:
+                continue
+            for target in by_external.get(
+                (str(ref.get("target_source")), str(ref.get("target_external_id"))), ()
+            ):
+                # Same-source structural references cannot cross source instances.
+                if (
+                    rows[target]["source"] == rows[identifier]["source"]
+                    and rows[target]["source_instance"] != rows[identifier]["source_instance"]
+                ):
+                    continue
+                edges[identifier].add(target)
+                edges[target].add(identifier)
+    selected = {identifier: set(reasons) for identifier, reasons in roots.items()}
+    frontier = set(roots)
+    for _ in range(2):
+        following: set[str] = set()
+        for identifier in frontier:
+            for target in edges.get(identifier, ()):
+                if target not in selected:
+                    following.add(target)
+                    selected[target] = {"related_collaborator_context"}
+        frontier = following
+    all_keys = set(explicit)
+    support: dict[str, set[str]] = defaultdict(set)
+    reasons: dict[str, set[str]] = defaultdict(set)
+    for key in explicit:
+        reasons[key].add("explicit_user_key")
+    for identifier, row in rows.items():
+        keys = set(extract_jira_keys(f"{row['title'] or ''}\n{row['body_text'] or ''}", app))
+        for ref in pending_by_object[identifier]:
+            key = str(ref.get("target_external_id", "")).upper()
+            if (
+                ref.get("target_source") == "jira"
+                and re.fullmatch(r"[A-Z][A-Z0-9_]*-[0-9]+", key)
+                and app.allows_jira_key(key)
+            ):
+                keys.add(key)
+        all_keys.update(keys)
+        if identifier not in selected:
+            continue
+        for key in keys:
+            support[key].add(str(row["id"]))
+            reasons[key].update(selected[identifier])
+            if row["kind"] == "git_branch":
+                reasons[key].add("branch_reference_context_not_ownership")
+    return JiraSeedSelection(
+        tuple(
+            JiraKeySeed(key, tuple(sorted(support[key])), tuple(sorted(why)))
+            for key, why in sorted(reasons.items())
+        ),
+        len(all_keys),
+    )
+
+
+def selector_replacement_proposal(
+    repository: EvidenceRepository,
+    configuration: WorkTraceConfig,
+    app_id: str,
+    source_instance: str,
+    run_id: str,
+) -> dict[str, JsonValue] | None:
+    current = {
+        str(row["source_object_id"]): str(row["id"])
+        for row in repository.current_observations(app_id)
+        if row["source"] == "jira" and row["source_instance"] == source_instance
+    }
+    imported = {
+        str(row[0])
+        for row in repository.connection.execute(
+            "SELECT source_object_id FROM observations WHERE sync_run_id=?", (run_id,)
+        )
+    }
+    removed = sorted(current.keys() - imported)
+    if not removed:
+        return None
+    confirmed = confirmed_memberships(repository.connection, configuration, app_id)
+    affected = sorted(
+        group for group, members in confirmed.items() if members.intersection(removed)
+    )
+    material = {
+        "app_id": app_id,
+        "source_instance": source_instance,
+        "policy_version": JIRA_SELECTOR_VERSION,
+        "previous_observations": current,
+        "new_object_ids": sorted(imported),
+        "removed_object_ids": list[JsonValue](removed),
+        "confirmed_memberships": {
+            group: sorted(members) for group, members in sorted(confirmed.items())
+        },
+        "date_from": configuration.employment_from.isoformat(),
+        "date_to": configuration.employment_to.isoformat(),
+        "work_timezone": configuration.employment_timezone,
+    }
+    token = hashlib.sha256(json.dumps(material, sort_keys=True).encode()).hexdigest()
+    return {
+        "proposal_token": token,
+        "removed_object_ids": list[JsonValue](removed),
+        "removed_count": len(removed),
+        "affected_confirmed_contributions": list[JsonValue](affected),
+        "policy_version": JIRA_SELECTOR_VERSION,
+        "requires_approval": True,
+        "notice": "Previous authority retained. Review removals and repeat the full-range "
+        "import with this proposal token.",
+    }

--- a/src/worktrace/importers/jira_selection.py
+++ b/src/worktrace/importers/jira_selection.py
@@ -211,6 +211,12 @@ def select_jira_seeds(
         reasons[key].add("explicit_user_key")
     for identifier, row in rows.items():
         keys = set(extract_jira_keys(f"{row['title'] or ''}\n{row['body_text'] or ''}", app))
+        payload = data[identifier]
+        if row["source"] == "jira" and isinstance(payload, dict):
+            field = "key" if row["kind"] == "jira_issue" else "issue_key"
+            key = str(payload.get(field, "")).upper()
+            if re.fullmatch(r"[A-Z][A-Z0-9_]*-[0-9]+", key) and app.allows_jira_key(key):
+                keys.add(key)
         for ref in pending_by_object[identifier]:
             key = str(ref.get("target_external_id", "")).upper()
             if (

--- a/src/worktrace/importers/orchestrator.py
+++ b/src/worktrace/importers/orchestrator.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from datetime import date, datetime
 
 from worktrace.adapters.base import ActorIdentity, NormalizedRecord, SnapshotAdapter
 from worktrace.adapters.jira import JiraAdapter
-from worktrace.config import AppConfig
+from worktrace.config import AppConfig, WorkTraceConfig
 from worktrace.db.repository import EvidenceRepository
 from worktrace.domain.enums import Completeness
 from worktrace.domain.models import (
@@ -18,6 +19,7 @@ from worktrace.domain.models import (
     SourceIdentity,
 )
 from worktrace.errors import SourceError
+from worktrace.importers.jira_selection import selector_replacement_proposal
 from worktrace.importers.jira_staging import jira_pages
 from worktrace.participation import canonical_role
 
@@ -33,6 +35,8 @@ class ImportResult:
     completeness: str = Completeness.COMPLETE.value
     limitations: tuple[str, ...] = ()
     selection_events: tuple[dict[str, JsonValue], ...] = field(default_factory=tuple)
+    selector_replacement: dict[str, JsonValue] | None = None
+    jira_key_retrieval: dict[str, JsonValue] | None = None
 
 
 def _timestamp(value: str | None) -> datetime | None:
@@ -187,6 +191,8 @@ def import_snapshot(
     import_session_id: str | None = None,
     finish_session: bool = True,
     scope_details: dict[str, JsonValue] | None = None,
+    configuration: WorkTraceConfig | None = None,
+    expected_selector_replacement: str | None = None,
 ) -> ImportResult:
     """Persist a full snapshot one page per transaction.
 
@@ -195,6 +201,14 @@ def import_snapshot(
     """
     if date_from > date_to:
         raise ValueError("date_from must not be after date_to")
+    guarded_selector = (
+        source == "jira" and (scope_details or {}).get("selection_policy_version") == 3
+    )
+    if guarded_selector and (
+        configuration is None
+        or (date_from, date_to) != (configuration.employment_from, configuration.employment_to)
+    ):
+        raise SourceError("Jira selector v3 requires the full configured work interval")
     session_id = import_session_id or repository.create_import_session(app, date_from, date_to)
     scope: dict[str, JsonValue] = {
         "date_from": date_from.isoformat(),
@@ -318,10 +332,103 @@ def import_snapshot(
             limitations=tuple(limitations),
             selection_events=tuple(selection_events),
         )
+    key_retrieval: dict[str, JsonValue] | None = None
+    if guarded_selector:
+        selected_keys: set[str] = set()
+        seed_selection = scope.get("jira_seed_selection")
+        if isinstance(seed_selection, dict):
+            seeds = seed_selection.get("seeds", [])
+            if isinstance(seeds, list):
+                selected_keys = {
+                    str(seed["key"]) for seed in seeds if isinstance(seed, dict) and "key" in seed
+                }
+        observed_keys = {
+            str(row[0])
+            for row in repository.connection.execute(
+                "SELECT json_extract(data_json, '$.key') FROM observations WHERE sync_run_id=?",
+                (run_id,),
+            )
+            if row[0] is not None
+        }
+        missing_keys = sorted(selected_keys - observed_keys)
+        key_retrieval = {
+            "requested_count": len(selected_keys),
+            "observed_count": len(selected_keys & observed_keys),
+            "unreturned_count": len(missing_keys),
+            "unreturned_keys": list[JsonValue](missing_keys),
+        }
+        if missing_keys:
+            limitations.append(
+                f"Jira search did not return {len(missing_keys)} selected keys; "
+                "deletion or absence of work is not established."
+            )
+            selection_biased = True
+        with repository.connection:
+            row = repository.connection.execute(
+                "SELECT progress_json FROM sync_runs WHERE id=?", (run_id,)
+            ).fetchone()
+            key_progress = json.loads(str(row[0]))
+            key_progress["jira_key_retrieval"] = key_retrieval
+            key_progress["limitations"] = list(limitations)
+            repository.connection.execute(
+                "UPDATE sync_runs SET progress_json=? WHERE id=?",
+                (json.dumps(key_progress), run_id),
+            )
     completeness = (
         Completeness.SELECTION_BIASED.value if selection_biased else Completeness.COMPLETE.value
     )
-    repository.finish_sync_run(run_id, "complete", completeness)
+    proposal = None
+    # Page persistence is complete. Release its read cursor snapshot before
+    # acquiring the writer lock for the proposal-check/activation transaction.
+    repository.connection.commit()
+    with repository.connection:
+        if guarded_selector:
+            assert configuration is not None
+            repository.connection.execute(
+                "UPDATE apps SET read_revision=read_revision WHERE id=?", (app.id,)
+            )
+            proposal = selector_replacement_proposal(
+                repository, configuration, app.id, source_instance, run_id
+            )
+            if proposal is not None and proposal["proposal_token"] != expected_selector_replacement:
+                row = repository.connection.execute(
+                    "SELECT progress_json FROM sync_runs WHERE id=?", (run_id,)
+                ).fetchone()
+                progress_value = json.loads(str(row[0]))
+                progress_value["selector_replacement"] = proposal
+                repository.connection.execute(
+                    "UPDATE sync_runs SET progress_json=? WHERE id=?",
+                    (json.dumps(progress_value), run_id),
+                )
+                message = "selector_replacement_requires_approval"
+                repository.finish_sync_run(run_id, "failed", Completeness.PARTIAL.value, message)
+                if finish_session:
+                    repository.finish_import_session(
+                        session_id,
+                        "partial",
+                        {
+                            "source": source,
+                            "selector_replacement": proposal,
+                            "snapshot": "previous_retained",
+                        },
+                    )
+                return ImportResult(
+                    session_id,
+                    run_id,
+                    "partial",
+                    pages,
+                    records,
+                    message,
+                    completeness=Completeness.PARTIAL.value,
+                    limitations=tuple(limitations),
+                    selection_events=tuple(selection_events),
+                    selector_replacement=proposal,
+                    jira_key_retrieval=key_retrieval,
+                )
+            if proposal is not None:
+                proposal["requires_approval"] = False
+                proposal["approved"] = True
+        repository.finish_sync_run(run_id, "complete", completeness)
     if isinstance(adapter, JiraAdapter):
         with repository.connection:
             repository.connection.execute("DELETE FROM jira_import_stage WHERE run_id=?", (run_id,))
@@ -340,4 +447,6 @@ def import_snapshot(
         completeness=completeness,
         limitations=tuple(limitations),
         selection_events=tuple(selection_events),
+        selector_replacement=proposal,
+        jira_key_retrieval=key_retrieval,
     )

--- a/src/worktrace/packets/builder.py
+++ b/src/worktrace/packets/builder.py
@@ -35,6 +35,7 @@ from worktrace.db.authority import (
     run_is_authoritative,
     selection_policy_version,
 )
+from worktrace.db.import_status import legacy_preflight_ids, source_readiness
 from worktrace.domain.enums import ClaimStatus, ObservationType
 from worktrace.errors import NotFound, ScopeViolation
 from worktrace.identity import identity_policy_status
@@ -480,18 +481,21 @@ class PacketBuilder:
 
     def source_status(self, app_id: str) -> dict[str, object]:
         app = self._app(app_id)
+        readiness = source_readiness(self.connection, app_id)
+        legacy = legacy_preflight_ids(self.connection, app_id)
+        exclude = f"AND id NOT IN ({','.join('?' for _ in legacy)})" if legacy else ""
         rows = list(
             self.connection.execute(
-                """
+                f"""
                 SELECT * FROM (
                     SELECT sr.*, ROW_NUMBER() OVER (
                         PARTITION BY source, source_instance
                         ORDER BY COALESCE(completed_at, started_at) DESC, id DESC
                     ) AS position
-                    FROM sync_runs sr WHERE app_id=?
+                    FROM sync_runs sr WHERE app_id=? {exclude}
                 ) WHERE position=1 ORDER BY source, source_instance
                 """,
-                (app_id,),
+                (app_id, *sorted(legacy)),
             )
         )
         expected: set[str] = set()
@@ -503,10 +507,12 @@ class PacketBuilder:
             expected.add("gitlab")
         grouped: dict[str, list[sqlite3.Row]] = {}
         for row in rows:
+            if str(row["id"]) in legacy:
+                continue
             grouped.setdefault(str(row["source"]), []).append(row)
         result: dict[str, object] = {}
         now = datetime.now(UTC)
-        for source in sorted(expected | set(grouped)):
+        for source in sorted(expected | set(grouped) | set(readiness)):
             source_rows = grouped.get(source, [])
             instances: list[dict[str, object]] = []
             for row in source_rows:
@@ -547,6 +553,11 @@ class PacketBuilder:
                     else []
                 )
                 complete = authoritative and completeness_is_full_scope(str(row["completeness"]))
+                if source == "jira" and selection_version != 3:
+                    limitations.append(
+                        "Jira discovery uses legacy selector policy; "
+                        "full configured-range reimport required."
+                    )
                 instances.append(
                     {
                         "source_instance": str(row["source_instance"]),
@@ -564,6 +575,7 @@ class PacketBuilder:
                     }
                 )
             result[source] = {
+                **readiness.get(source, {}),
                 "complete": bool(instances) and all(bool(item["complete"]) for item in instances),
                 "stale": not instances or any(bool(item["stale"]) for item in instances),
                 "instances": instances,

--- a/tests/test_acceptance_recovery.py
+++ b/tests/test_acceptance_recovery.py
@@ -574,6 +574,9 @@ def test_import_all_uses_git_then_gitlab_then_jira_discovery(
         def resolved_self_ids(self, configured_email_hashes: set[str]) -> set[str]:
             return {"7", *configured_email_hashes}
 
+        def resolved_self_id(self) -> str:
+            return "account-7"
+
         def iter_pages(self) -> Iterator[NormalizedPage]:
             yield NormalizedPage(
                 source_kind=self.source,

--- a/tests/test_git_environment.py
+++ b/tests/test_git_environment.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from worktrace.adapters.git_local import LocalGitAdapter, LocalGitConfig
+from worktrace.doctor import _git
+from worktrace.git_environment import local_git_environment
+
+_SYNTHETIC_OVERRIDES = {
+    "WORKTRACE_JIRA_API_TOKEN": "synthetic-jira-token",
+    "WORKTRACE_JIRA_NEW_CREDENTIAL": "synthetic-future-jira",
+    "WORKTRACE_GITLAB_TOKEN": "synthetic-gitlab-token",
+    "WORKTRACE_GITLAB_NEW_CREDENTIAL": "synthetic-future-gitlab",
+    "WORKTRACE_EMAIL_HMAC_KEY": "synthetic-hmac-key",
+    "WORKTRACE_EMAIL_HMAC_FUTURE": "synthetic-future-hmac",
+    "GIT_CONFIG_COUNT": "1",
+    "GIT_CONFIG_KEY_0": "remote.origin.url",
+    "GIT_CONFIG_VALUE_0": "https://wrong.example.test/repo.git",
+    "GIT_CONFIG_KEY_99": "orphaned-key",
+    "GIT_CONFIG_VALUE_99": "orphaned-value",
+    "GIT_CONFIG_PARAMETERS": "'remote.origin.url=wrong'",
+    "GIT_CONFIG": "/nonexistent/synthetic-config",
+    "GIT_CONFIG_GLOBAL": "/nonexistent/synthetic-global",
+    "GIT_CONFIG_SYSTEM": "/nonexistent/synthetic-system",
+    "GIT_DIR": "/nonexistent/synthetic-git-dir",
+    "GIT_WORK_TREE": "/nonexistent/synthetic-work-tree",
+    "GIT_COMMON_DIR": "/nonexistent/synthetic-common-dir",
+    "GIT_INDEX_FILE": "/nonexistent/synthetic-index",
+    "GIT_OBJECT_DIRECTORY": "/nonexistent/synthetic-objects",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES": "/nonexistent/synthetic-alternates",
+    "GIT_NAMESPACE": "synthetic-namespace",
+    "GIT_SHALLOW_FILE": "/nonexistent/synthetic-shallow",
+    "GIT_GRAFT_FILE": "/nonexistent/synthetic-grafts",
+    "GIT_REPLACE_REF_BASE": "refs/synthetic-replacements",
+    "GIT_CEILING_DIRECTORIES": "/nonexistent/synthetic-ceiling",
+    "GIT_DISCOVERY_ACROSS_FILESYSTEM": "1",
+    "GIT_EXEC_PATH": "/nonexistent/synthetic-executables",
+    "GIT_EXTERNAL_DIFF": "synthetic-external-diff",
+    "GIT_DIFF_OPTS": "--synthetic-option",
+    "GIT_ASKPASS": "synthetic-askpass",
+    "SSH_ASKPASS": "synthetic-ssh-askpass",
+    "GIT_SSH": "synthetic-ssh",
+    "GIT_SSH_COMMAND": "synthetic-ssh-command",
+    "GIT_SSH_VARIANT": "synthetic-ssh-variant",
+    "GIT_PAGER": "synthetic-pager",
+    "GIT_TRACE": "/nonexistent/synthetic-trace",
+    "GIT_TRACE2_EVENT": "/nonexistent/synthetic-trace-event",
+}
+
+
+def test_local_git_environment_filters_without_mutating_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    parent = {
+        **_SYNTHETIC_OVERRIDES,
+        "PATH": "/synthetic/bin",
+        "HOME": "/synthetic/home",
+        "LANG": "C.UTF-8",
+        "GIT_OPTIONAL_LOCKS": "1",
+        "GIT_TERMINAL_PROMPT": "1",
+        "GIT_NO_REPLACE_OBJECTS": "0",
+    }
+    monkeypatch.setattr(os, "environ", parent)
+    before = dict(parent)
+
+    assert local_git_environment() == {
+        "PATH": "/synthetic/bin",
+        "HOME": "/synthetic/home",
+        "LANG": "C.UTF-8",
+        "GIT_OPTIONAL_LOCKS": "0",
+        "GIT_TERMINAL_PROMPT": "0",
+        "GIT_NO_REPLACE_OBJECTS": "1",
+    }
+    assert parent == before
+
+
+def test_importer_and_doctor_use_sanitized_git_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    setup_environment = local_git_environment()
+    setup_environment.update(
+        GIT_AUTHOR_NAME="Fixture Author",
+        GIT_AUTHOR_EMAIL="original@example.test",
+        GIT_COMMITTER_NAME="Fixture Committer",
+        GIT_COMMITTER_EMAIL="committer@example.test",
+    )
+
+    def setup(*args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(repository), *args],
+            check=True,
+            capture_output=True,
+            env=setup_environment,
+            shell=False,
+        )
+
+    setup("init", "-q")
+    setup("remote", "add", "origin", "https://example.test/fixture.git")
+    (repository / ".mailmap").write_text(
+        "Canonical Author <canonical@example.test> <original@example.test>\n",
+        encoding="utf-8",
+    )
+    (repository / "fixture.txt").write_text("synthetic content\n", encoding="utf-8")
+    (repository / ".gitattributes").write_text("*.txt diff=fixture\n", encoding="utf-8")
+    setup("config", "diff.fixture.command", "false")
+    setup("config", "diff.fixture.textconv", "false")
+    setup("add", ".")
+    setup("commit", "-q", "-m", "DEMO-1 synthetic change")
+
+    for name, value in _SYNTHETIC_OVERRIDES.items():
+        monkeypatch.setenv(name, value)
+    for name, value in {
+        "GIT_OPTIONAL_LOCKS": "1",
+        "GIT_TERMINAL_PROMPT": "1",
+        "GIT_NO_REPLACE_OBJECTS": "0",
+    }.items():
+        monkeypatch.setenv(name, value)
+
+    run = subprocess.run
+    commands: list[list[str]] = []
+
+    def capture(command: list[str], **kwargs: Any) -> Any:
+        environment = kwargs["env"]
+        assert not (_SYNTHETIC_OVERRIDES.keys() & environment.keys())
+        assert environment["GIT_OPTIONAL_LOCKS"] == "0"
+        assert environment["GIT_TERMINAL_PROMPT"] == "0"
+        assert environment["GIT_NO_REPLACE_OBJECTS"] == "1"
+        assert kwargs["shell"] is False
+        commands.append(command)
+        return run(command, **kwargs)
+
+    monkeypatch.setattr(subprocess, "run", capture)
+    adapter = LocalGitAdapter(
+        LocalGitConfig(
+            repository_path=repository,
+            source_instance="fixture-local",
+            app_id="fixture",
+            email_key=b"synthetic-key",
+            jira_project_keys=("DEMO",),
+        )
+    )
+    pages = list(adapter.iter_pages())
+    commit = next(page.records[0] for page in pages if page.resource_type == "commit")
+    assert commit.payload["subject"] == "DEMO-1 synthetic change"
+    assert any(actor.actor.display_name == "Canonical Author" for actor in commit.participations)
+    assert _git(["rev-parse", "--show-toplevel"], repository).stdout.strip() == str(repository)
+    assert _git(["config", "--get", "remote.origin.url"], repository).stdout.strip() == (
+        "https://example.test/fixture.git"
+    )
+    assert _git(["--version"]).returncode == 0
+    show_commands = [command for command in commands if "show" in command]
+    assert show_commands
+    assert all(
+        "--no-ext-diff" in command and "--no-textconv" in command for command in show_commands
+    )
+    assert os.environ["WORKTRACE_JIRA_API_TOKEN"] == "synthetic-jira-token"

--- a/tests/test_import_readiness.py
+++ b/tests/test_import_readiness.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+from typer.testing import CliRunner
+
+from tests.test_jira_history import JiraFixture, invoke
+from tests.test_jira_history import workspace as workspace
+from worktrace.cli import app
+from worktrace.config import load_config
+from worktrace.db.connection import connect
+from worktrace.db.import_status import legacy_preflight_ids, readiness_contract, source_readiness
+from worktrace.db.queries import source_status
+from worktrace.db.repository import EvidenceRepository, stable_id
+from worktrace.errors import WorkTraceError
+from worktrace.packets.builder import PacketBuilder
+
+
+@pytest.mark.parametrize("command", ["jira", "all"])
+def test_missing_credentials_are_session_preflight_only(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    for name in ("BASE_URL", "EMAIL", "API_TOKEN"):
+        monkeypatch.delenv("WORKTRACE_JIRA_" + name)
+    output = invoke(workspace, "import", command, "sample", success=False)
+    attempt = output["sources"][0] if command == "all" else output
+    assert attempt["status"] == "not_started"
+    assert attempt["reason"] == "credentials_missing"
+    assert attempt["source_instance"] is None
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sync_runs").fetchone()[0] == 0
+        audit = json.loads(
+            connection.execute("SELECT summary_json FROM import_sessions").fetchone()[0]
+        )
+        assert audit["sources"][0]["preflight"]["status"] == "not_started"
+        cli = source_status(connection, "sample")[0]
+        mcp = PacketBuilder(connection, config).source_status("sample")["jira"]
+        assert cli["preflight"] == mcp["preflight"]
+        assert mcp["last_authoritative_snapshots"] == []
+
+
+@pytest.mark.parametrize("failure", ["mismatch", "unauthorized", "invalid_origin"])
+def test_provider_identity_and_origin_are_established_before_run(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch, failure: str
+) -> None:
+    if failure == "invalid_origin":
+        monkeypatch.setenv("WORKTRACE_JIRA_BASE_URL", "http://jira.example")
+    with respx.mock(assert_all_called=False) as mock:
+        route = mock.get("https://jira.example/rest/api/3/myself").mock(
+            return_value=httpx.Response(
+                401 if failure == "unauthorized" else 200, json={"accountId": "other"}
+            )
+        )
+        output = invoke(workspace, "import", "jira", "sample", success=False)
+        assert output["status"] == "not_started"
+        assert output["reason"] in {"origin_invalid", "identity_unverified"}
+        assert route.called == (failure != "invalid_origin")
+    with connect(load_config(workspace).database_path) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM sync_runs").fetchone()[0] == 0
+
+
+def test_later_success_clears_current_preflight_and_retains_audit(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("WORKTRACE_JIRA_API_TOKEN")
+    failed = invoke(workspace, "import", "jira", "sample", success=False)
+    monkeypatch.setenv("WORKTRACE_JIRA_API_TOKEN", "synthetic-fixture-token")
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=JiraFixture())
+        successful = invoke(workspace, "import", "jira", "sample")
+    assert successful["coverage"] == "limited"
+    assert successful["jira_seed_selection"]["omitted_count"] == 0
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        state = source_readiness(connection, "sample")["jira"]
+        assert state["preflight"][0]["status"] == "ready"
+        assert state["preflight"][0]["session_id"] == successful["session_id"]
+        assert state["last_authoritative_snapshots"][0]["run_id"] == successful["run_id"]
+        assert (
+            state["last_authoritative_snapshots"][0]["jira_seed_selection"]
+            == successful["jira_seed_selection"]
+        )
+        old = connection.execute(
+            "SELECT summary_json FROM import_sessions WHERE id=?", (failed["session_id"],)
+        ).fetchone()
+        assert json.loads(old[0])["sources"][0]["status"] == "not_started"
+        # A subsequent preflight failure does not replace the successful source snapshot.
+    monkeypatch.delenv("WORKTRACE_JIRA_API_TOKEN")
+    invoke(workspace, "import", "jira", "sample", success=False)
+    with connect(config.database_path) as connection:
+        state = source_readiness(connection, "sample")["jira"]
+        assert state["preflight"][0]["status"] == "not_started"
+        assert state["last_authoritative_snapshots"][0]["run_id"] == successful["run_id"]
+
+
+def test_all_continues_jira_after_missing_gitlab_preflight(workspace: Path) -> None:
+    text = workspace.read_text().replace(
+        'jira_project_keys = ["DEMO"]', 'jira_project_keys = ["DEMO"]\ngitlab_project_ids = [101]'
+    )
+    workspace.write_text(text)
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=JiraFixture())
+        output = invoke(workspace, "import", "all", "sample", success=False)
+    assert [(item["source"], item["status"]) for item in output["sources"]] == [
+        ("gitlab", "not_started"),
+        ("jira", "complete"),
+    ]
+    with connect(load_config(workspace).database_path) as connection:
+        assert [row[0] for row in connection.execute("SELECT source FROM sync_runs")] == ["jira"]
+        scope = json.loads(connection.execute("SELECT scope_json FROM sync_runs").fetchone()[0])
+        assert scope["seed_input_authority"][0]["status"] == "not_started"
+
+
+def test_legacy_placeholder_recognition_is_exact_and_read_only(workspace: Path) -> None:
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        repository = EvidenceRepository(connection)
+        synthetic = stable_id("source", "sample", "jira", "configured")
+        expected = repository.start_sync_run("sample", "jira", synthetic, {})
+        repository.finish_sync_run(
+            expected, "failed", "source_unavailable", "Jira credentials are not configured"
+        )
+        real = repository.start_sync_run("sample", "jira", "real-jira", {})
+        repository.finish_sync_run(
+            real, "failed", "source_unavailable", "Jira credentials are not configured"
+        )
+        other_error = repository.start_sync_run("sample", "jira", synthetic, {})
+        repository.finish_sync_run(
+            other_error, "failed", "source_unavailable", "Provider request failed"
+        )
+        assert legacy_preflight_ids(connection, "sample") == {expected}
+        state = source_readiness(connection, "sample")["jira"]
+        assert state["legacy_preflight_audit"] == [
+            {"run_id": expected, "reason": "credentials_missing"}
+        ]
+        rows = source_status(connection, "sample")
+        assert {row["source_instance"] for row in rows} == {synthetic, "real-jira"}
+        assert connection.execute("SELECT COUNT(*) FROM sync_runs").fetchone()[0] == 3
+
+
+def test_snapshot_readiness_is_instance_specific_and_legacy_coverage_is_labelled(
+    workspace: Path,
+) -> None:
+    config = load_config(workspace)
+    with connect(config.database_path) as connection:
+        repository = EvidenceRepository(connection)
+        for source, instance in (("gitlab", "project-b"), ("jira", "old-jira")):
+            run = repository.start_sync_run(
+                "sample", source, instance, {"selection_policy_version": 2}
+            )
+            repository.finish_sync_run(run, "complete", "complete_for_scope")
+        other = readiness_contract(
+            connection, "sample", "gitlab", "partial", "partial", source_instance="project-a"
+        )
+        assert other["snapshot_state"] == "unavailable"
+        same = readiness_contract(
+            connection, "sample", "gitlab", "partial", "partial", source_instance="project-b"
+        )
+        assert same["snapshot_state"] == "previous_retained"
+        missing_origin = readiness_contract(
+            connection, "sample", "gitlab", "not_started", "unknown"
+        )
+        assert missing_origin["snapshot_state"] == "unavailable"
+        snapshot = source_readiness(connection, "sample")["jira"]["last_authoritative_snapshots"][0]
+        assert snapshot["selector_policy"] == "legacy"
+        assert snapshot["coverage"] == "unknown"
+        assert source_status(connection, "sample")[1]["authoritative_current"] is True
+
+
+def test_placeholder_like_run_with_observations_remains_real_health(workspace: Path) -> None:
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=JiraFixture())
+        output = invoke(workspace, "import", "jira", "sample")
+    with connect(load_config(workspace).database_path) as connection:
+        connection.execute(
+            "UPDATE sync_runs SET source_instance=?, status='failed', "
+            "completeness='source_unavailable', "
+            "error_summary='Jira credentials are not configured' WHERE id=?",
+            (stable_id("source", "sample", "jira", "configured"), output["run_id"]),
+        )
+        assert legacy_preflight_ids(connection, "sample") == set()
+        assert source_status(connection, "sample")[0]["source_instance"] is not None
+
+
+def test_rebuild_failure_finalizes_session_audit(
+    workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def fail(*args: object) -> None:
+        raise WorkTraceError("synthetic rebuild failure")
+
+    monkeypatch.setattr("worktrace.cli.rebuild_references", fail)
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=JiraFixture())
+        result = CliRunner().invoke(app, ["import", "all", "sample", "--config", str(workspace)])
+        assert result.exit_code != 0
+    with connect(load_config(workspace).database_path) as connection:
+        session = connection.execute("SELECT * FROM import_sessions").fetchone()
+        assert session["status"] == "partial"
+        assert session["completed_at"] is not None
+        audit = json.loads(session["summary_json"])
+        assert audit["sources"][0]["status"] == "complete"
+        assert audit["error"] == "source_or_rebuild_failed"

--- a/tests/test_jira_history.py
+++ b/tests/test_jira_history.py
@@ -97,6 +97,7 @@ def invoke(config: Path, *args: str, success: bool = True) -> dict:
         assert result.exit_code == 0, f"{result.output}\n{result.exception!r}"
     else:
         assert result.exit_code != 0, result.output
+        assert result.stdout, f"{result.output}\n{result.exception!r}"
     return json.loads(result.stdout) if result.stdout else {}
 
 
@@ -295,7 +296,9 @@ def test_interrupted_discovery_retains_previous_authority_and_is_not_reused(
             assert connection.execute("SELECT COUNT(*) FROM jira_import_stage").fetchone()[0] == 1
         fixture.fail_discovery = False
         fixture.issues = [issue(3)]
-        invoke(workspace, "import", "all", "sample")
+        preview = invoke(workspace, "import", "all", "sample", success=False)
+        token = preview["sources"][0]["selector_replacement"]["proposal_token"]
+        invoke(workspace, "import", "all", "sample", "--approve-selector-replacement", token)
     with connect(config.database_path) as connection:
         assert {r["external_id"] for r in search(PacketBuilder(connection, config))["results"]} == {
             "3"

--- a/tests/test_jira_selection.py
+++ b/tests/test_jira_selection.py
@@ -261,3 +261,47 @@ def test_confirmed_noncurrent_record_can_seed_recovery_with_historical_label(sta
     assert result.seeds[0].supporting_observation_ids == (observations["old"],)
     assert "historical_confirmed_observation_not_current" in result.seeds[0].reasons
     assert repository.current_observations("sample") == []
+
+
+@pytest.mark.parametrize("retired", [False, True])
+@pytest.mark.parametrize("kind,field", [("issue", "key"), ("issue_comment", "issue_key")])
+def test_confirmed_jira_structured_key_survives_normal_summary_and_retirement(
+    state, retired, kind, field
+) -> None:
+    repository, config = state
+    item = build_record(
+        source_kind="jira",
+        source_instance="jira",
+        object_type=kind,
+        external_id="10001",
+        app_id="sample",
+        observed_at="2026-02-01T12:00:00Z",
+        source_updated_at="2026-01-10T12:00:00Z",
+        payload={field: "DEMO-7", "summary": "Improve search"},
+        redactor=_REDACTOR,
+    )
+    run = repository.start_sync_run("sample", "jira", "jira", {"selection_policy_version": 2})
+    repository.store_page(run, [record_to_object(item, set())])
+    repository.finish_sync_run(run, "complete", "complete_for_scope")
+    row = repository.current_observations("sample")[0]
+    append_decision(
+        repository.connection,
+        "confirm_candidate",
+        "candidate:jira-history",
+        {
+            "app_id": "sample",
+            "contribution_id": "contribution:jira-history",
+            "members": [str(row["source_object_id"])],
+            "context_members": [],
+        },
+    )
+    if retired:
+        replacement = repository.start_sync_run(
+            "sample", "jira", "jira", {"selection_policy_version": 2}
+        )
+        repository.finish_sync_run(replacement, "complete", "complete_for_scope")
+    selected = select_jira_seeds(repository, config.apps[0], configuration=config)
+    assert selected.keys == ("DEMO-7",)
+    assert selected.seeds[0].supporting_observation_ids == (str(row["id"]),)
+    assert "confirmed_contribution:candidate:jira-history" in selected.seeds[0].reasons
+    assert ("historical_confirmed_observation_not_current" in selected.seeds[0].reasons) is retired

--- a/tests/test_jira_selection.py
+++ b/tests/test_jira_selection.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from worktrace.adapters.base import (
+    NormalizedRecord,
+    Participation,
+    ParticipationRole,
+    Reference,
+    ReferenceStrength,
+)
+from worktrace.candidates.decisions import append_decision, undo_decision
+from worktrace.config import AppConfig, IdentityConfig, WorkTraceConfig
+from worktrace.db.connection import connect
+from worktrace.db.migrations import migrate
+from worktrace.db.repository import EvidenceRepository
+from worktrace.errors import ScopeViolation
+from worktrace.identity import initialize_identity
+from worktrace.importers.jira_selection import select_jira_seeds
+from worktrace.importers.orchestrator import record_to_object
+from worktrace.normalize import actor_identity, build_record
+from worktrace.normalize.redaction import Redactor
+
+_KEY = b"synthetic-selector-key"
+_REDACTOR = Redactor(_KEY)
+
+
+@pytest.fixture
+def state(tmp_path: Path) -> Iterator[tuple[EvidenceRepository, WorkTraceConfig]]:
+    app = AppConfig("sample", "Sample", "", "", ("DEMO",), (), (), (r"DEMO-[0-9]+",), (), (), ())
+    config = WorkTraceConfig(
+        1,
+        tmp_path,
+        date(2026, 1, 1),
+        date(2026, 12, 31),
+        IdentityConfig(
+            "Fixture Engineer", ("self@example.test",), ("Fixture Engineer",), None, None, None
+        ),
+        (app,),
+        tmp_path / "config.toml",
+    )
+    path = tmp_path / "ledger.sqlite3"
+    connection = connect(path)
+    migrate(connection, path)
+    connection.execute("INSERT INTO apps(id,name) VALUES ('sample','Sample')")
+    connection.commit()
+    initialize_identity(connection, config, _KEY)
+    try:
+        yield EvidenceRepository(connection), config
+    finally:
+        connection.close()
+
+
+def record(
+    identifier: str,
+    title: str,
+    *,
+    personal: bool = True,
+    role: ParticipationRole = ParticipationRole.AUTHOR,
+    references: tuple[Reference, ...] = (),
+    kind: str = "commit",
+) -> NormalizedRecord:
+    actor = actor_identity(
+        source_kind="git",
+        source_instance="fixture",
+        redactor=_REDACTOR,
+        provider_actor_id=None,
+        display_name="Fixture Engineer",
+        email="self@example.test" if personal else "colleague@example.test",
+    )
+    return build_record(
+        source_kind="git",
+        source_instance="fixture",
+        object_type=kind,
+        external_id=identifier,
+        app_id="sample",
+        observed_at="2026-02-01T12:00:00Z",
+        source_updated_at="2026-01-10T12:00:00Z",
+        payload={"title": title},
+        redactor=_REDACTOR,
+        participations=(Participation(actor, role),),
+        references=references,
+    )
+
+
+def publish(repository: EvidenceRepository, records: list[NormalizedRecord]) -> dict[str, str]:
+    run = repository.start_sync_run("sample", "git", "fixture", {"mode": "fixture"})
+    repository.store_page(
+        run,
+        [
+            record_to_object(
+                item, {_REDACTOR.hash_email("self@example.test")}, {"Fixture Engineer"}
+            )
+            for item in records
+        ],
+    )
+    repository.finish_sync_run(run, "complete", "complete_for_scope")
+    return {
+        str(row["external_id"]): str(row["id"]) for row in repository.current_observations("sample")
+    }
+
+
+def test_selects_every_personal_key_above_500_with_observation_support(state) -> None:
+    repository, config = state
+    observations = publish(repository, [record(str(i), f"DEMO-{i} change") for i in range(1, 503)])
+    result = select_jira_seeds(repository, config.apps[0], configuration=config)
+    assert set(result.keys) == {f"DEMO-{i}" for i in range(1, 503)}
+    assert result.as_dict()["selected_count"] == result.as_dict()["discovered_count"] == 502
+    assert result.as_dict()["omitted_count"] == 0
+    for seed in result.seeds:
+        assert seed.supporting_observation_ids == (observations[seed.key.removeprefix("DEMO-")],)
+        assert seed.reasons == ("self_role:git_author",)
+
+
+def test_same_name_colleague_excluded_and_role_reasons_union_without_ownership(state) -> None:
+    repository, config = state
+    observations = publish(
+        repository,
+        [
+            record("author", "DEMO-1 change"),
+            record("reviewer", "DEMO-1 review", role=ParticipationRole.REVIEWER),
+            record("committer", "DEMO-2 integrate", role=ParticipationRole.COMMITTER),
+            record("colleague", "DEMO-3 unrelated change", personal=False),
+        ],
+    )
+    result = select_jira_seeds(
+        repository, config.apps[0], configuration=config, explicit_keys=("demo-1",)
+    )
+    assert result.keys == ("DEMO-1", "DEMO-2")
+    assert result.discovered_count == 3
+    first, second = result.seeds
+    assert set(first.supporting_observation_ids) == {
+        observations["author"],
+        observations["reviewer"],
+    }
+    assert set(first.reasons) == {
+        "explicit_user_key",
+        "self_role:git_author",
+        "self_role:git_reviewer",
+    }
+    assert second.reasons == ("self_role:git_committer",)
+    assert result.as_dict()["omitted_count"] == 1
+
+
+@pytest.mark.parametrize("key", ["OTHER-1", "DEMO-1 OR DEMO-2", "DEMO-x", ""])
+def test_explicit_keys_must_be_exact_and_in_scope(state, key: str) -> None:
+    repository, config = state
+    with pytest.raises(ScopeViolation):
+        select_jira_seeds(repository, config.apps[0], configuration=config, explicit_keys=(key,))
+
+
+def test_branch_requires_structural_tie_and_git_parents_are_not_followed(state) -> None:
+    repository, config = state
+
+    def reference(target: str, relationship: str) -> Reference:
+        return Reference(relationship, target, ReferenceStrength.STRUCTURED, "git", "commit")
+
+    observations = publish(
+        repository,
+        [
+            record("root", "DEMO-1 personal", references=(reference("parent", "git_parent"),)),
+            record("parent", "DEMO-2 ancestor", personal=False),
+            record(
+                "branch",
+                "refs/heads/DEMO-3",
+                personal=False,
+                kind="ref",
+                references=(reference("root", "git_ref_target"),),
+            ),
+            record("unrelated-branch", "refs/heads/DEMO-4", personal=False, kind="ref"),
+        ],
+    )
+    result = select_jira_seeds(repository, config.apps[0], configuration=config)
+    assert result.keys == ("DEMO-1", "DEMO-3")
+    assert result.discovered_count == 4
+    assert result.seeds[1].supporting_observation_ids == (observations["branch"],)
+    assert set(result.seeds[1].reasons) == {
+        "related_collaborator_context",
+        "branch_reference_context_not_ownership",
+    }
+
+
+def test_confirmed_lineage_without_suggestion_respects_remove_and_undo(state) -> None:
+    repository, config = state
+    publish(repository, [record("colleague", "DEMO-7 collaborator work", personal=False)])
+    object_id = str(repository.connection.execute("SELECT id FROM source_objects").fetchone()[0])
+    target = "candidate:previous-suggestion"
+    confirmation = append_decision(
+        repository.connection,
+        "confirm_candidate",
+        target,
+        {
+            "contribution_id": "contribution:reviewed",
+            "app_id": "sample",
+            "title": "Reviewed work",
+            "members": [object_id],
+            "context_members": [],
+        },
+    )
+
+    def selected():
+        return select_jira_seeds(repository, config.apps[0], configuration=config)
+
+    assert selected().keys == ("DEMO-7",)
+    assert selected().seeds[0].reasons == ("confirmed_contribution:" + target,)
+    removed = append_decision(
+        repository.connection, "remove_member", target, {"source_object_id": object_id}
+    )
+    assert selected().keys == ()
+    undo_decision(repository.connection, removed)
+    assert selected().keys == ("DEMO-7",)
+    undo_decision(repository.connection, confirmation)
+    assert selected().keys == ()
+    assert repository.connection.execute("SELECT count(*) FROM human_decisions").fetchone()[0] == 4
+
+
+def test_only_current_observations_supply_keys_and_support(state) -> None:
+    repository, config = state
+    previous = publish(repository, [record("commit", "DEMO-1 previous wording")])
+    current = publish(repository, [record("commit", "DEMO-2 current wording")])
+    assert previous["commit"] != current["commit"]
+    result = select_jira_seeds(repository, config.apps[0], configuration=config)
+    assert result.keys == ("DEMO-2",)
+    assert result.seeds[0].supporting_observation_ids == (current["commit"],)
+    assert repository.connection.execute("SELECT count(*) FROM observations").fetchone()[0] == 2
+
+
+def test_explicit_key_needs_no_invented_observation(state) -> None:
+    repository, config = state
+    result = select_jira_seeds(
+        repository, config.apps[0], configuration=config, explicit_keys=(" DEMO-9 ", "demo-9")
+    )
+    assert result.keys == ("DEMO-9",)
+    assert result.seeds[0].supporting_observation_ids == ()
+    assert result.seeds[0].reasons == ("explicit_user_key",)
+    assert result.as_dict()["selected_count"] == result.as_dict()["discovered_count"] == 1
+
+
+def test_confirmed_noncurrent_record_can_seed_recovery_with_historical_label(state) -> None:
+    repository, config = state
+    observations = publish(repository, [record("old", "DEMO-7 confirmed", personal=False)])
+    object_id = str(repository.connection.execute("SELECT id FROM source_objects").fetchone()[0])
+    append_decision(
+        repository.connection,
+        "confirm_candidate",
+        "candidate:history",
+        {
+            "app_id": "sample",
+            "contribution_id": "contribution:history",
+            "members": [object_id],
+            "context_members": [],
+        },
+    )
+    publish(repository, [])
+    result = select_jira_seeds(repository, config.apps[0], configuration=config)
+    assert result.keys == ("DEMO-7",)
+    assert result.seeds[0].supporting_observation_ids == (observations["old"],)
+    assert "historical_confirmed_observation_not_current" in result.seeds[0].reasons
+    assert repository.current_observations("sample") == []

--- a/tests/test_selector_activation.py
+++ b/tests/test_selector_activation.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import respx
+
+from tests.test_jira_history import JiraFixture, invoke, issue, search
+from tests.test_jira_history import workspace as workspace
+from worktrace.config import load_config
+from worktrace.db.connection import connect
+from worktrace.packets.builder import PacketBuilder
+
+
+def test_selector_replacement_requires_exact_reviewed_impact_and_preserves_decisions(
+    workspace: Path,
+) -> None:
+    fixture = JiraFixture([issue(created="2024-01-02T00:00:00Z")])
+    config = load_config(workspace)
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+        with connect(config.database_path) as connection:
+            candidate = str(connection.execute("SELECT id FROM candidate_groups").fetchone()[0])
+            object_id = str(connection.execute("SELECT id FROM source_objects").fetchone()[0])
+        invoke(workspace, "confirm", candidate)
+        with connect(config.database_path) as connection:
+            decisions = list(connection.execute("SELECT id,payload_json FROM human_decisions"))
+        fixture.issues = [issue(2)]
+        preview = invoke(workspace, "import", "all", "sample", success=False)
+        impact = preview["sources"][0]["selector_replacement"]
+        assert impact["removed_object_ids"] == [object_id]
+        assert impact["affected_confirmed_contributions"] == [candidate]
+        with connect(config.database_path) as connection:
+            assert {
+                row["external_id"] for row in search(PacketBuilder(connection, config))["results"]
+            } == {"1"}
+        wrong = invoke(
+            workspace,
+            "import",
+            "all",
+            "sample",
+            "--approve-selector-replacement",
+            "wrong",
+            success=False,
+        )
+        assert (
+            wrong["sources"][0]["selector_replacement"]["proposal_token"]
+            == impact["proposal_token"]
+        )
+        accepted = invoke(
+            workspace,
+            "import",
+            "all",
+            "sample",
+            "--approve-selector-replacement",
+            impact["proposal_token"],
+        )
+        assert accepted["sources"][0]["selector_replacement"]["approved"] is True
+    with connect(config.database_path) as connection:
+        assert {
+            row["external_id"] for row in search(PacketBuilder(connection, config))["results"]
+        } == {"2"}
+        assert [
+            tuple(row) for row in connection.execute("SELECT id,payload_json FROM human_decisions")
+        ] == [tuple(row) for row in decisions]
+        assert (
+            connection.execute(
+                "SELECT COUNT(*) FROM observations WHERE source_object_id=?", (object_id,)
+            ).fetchone()[0]
+            == 1
+        )
+
+
+def test_changed_replacement_invalidates_old_approval(workspace: Path) -> None:
+    fixture = JiraFixture([issue(1), issue(2)])
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+        fixture.issues = [issue(2)]
+        preview = invoke(workspace, "import", "all", "sample", success=False)
+        token = preview["sources"][0]["selector_replacement"]["proposal_token"]
+        fixture.issues = [issue(3)]
+        changed = invoke(
+            workspace,
+            "import",
+            "all",
+            "sample",
+            "--approve-selector-replacement",
+            token,
+            success=False,
+        )
+        assert changed["sources"][0]["selector_replacement"]["proposal_token"] != token
+
+
+def test_replacement_preview_audit_does_not_backfill_old_policy(workspace: Path) -> None:
+    fixture = JiraFixture()
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        invoke(workspace, "import", "all", "sample")
+    with connect(load_config(workspace).database_path) as connection:
+        scope = json.loads(connection.execute("SELECT scope_json FROM sync_runs").fetchone()[0])
+        assert scope["selection_policy_version"] == 3
+        assert scope["jira_seed_selection"]["policy_version"] == 3
+
+
+def test_real_cli_chunks_502_explicit_keys_and_discloses_unreturned_keys(workspace: Path) -> None:
+    fixture = JiraFixture()
+    options = tuple(value for number in range(1, 503) for value in ("--jira-key", f"DEMO-{number}"))
+    with respx.mock() as mock:
+        mock.route().mock(side_effect=fixture)
+        result = invoke(workspace, "import", "all", "sample", *options)
+    exact_queries = [query for query in fixture.queries if "key in (" in query]
+    assert len(exact_queries) == 11
+    assert any('"DEMO-502"' in query for query in exact_queries)
+    source = result["sources"][0]
+    assert source["jira_seed_selection"]["selected_count"] == 502
+    assert source["jira_key_retrieval"]["requested_count"] == 502
+    assert source["jira_key_retrieval"]["unreturned_count"] == 501
+    assert source["coverage"] == "limited"
+    assert any(
+        "deletion or absence of work is not established" in value for value in source["limitations"]
+    )


### PR DESCRIPTION
## Summary

- Replace the silent 500-key slice with auditable personal-role, canonical confirmed-work and explicit-key selection. Process every selected key in bounded provider chunks, preserve supporting observation IDs/reasons, retain related collaborator/branch context and never traverse Git ancestry as personal scope.
- Introduce Jira selector v3 with full-range admission and approval-token-protected replacement. A narrower snapshot first reports removed objects and affected confirmed contributions while retaining previous authority; observations and decisions survive. Canonically confirmed historical records can seed recovery with an explicit noncurrent label.
- Record missing credentials, invalid origins and unverified identities as session preflight results, not invented provider runs. Expose current preparation separately from retained authoritative snapshots, recognize only exact legacy placeholders, and report execution, coverage, snapshot and review readiness independently.
- Share Git environment filtering between importer and doctor, stripping provider/HMAC secrets and hostile overrides while preserving mailmap. Keep external diff/textconv disabled; this is credential minimization, not a sandbox.

Refs #28

AgDR: [AgDR-0007, section C](https://github.com/AmrMohamad/WorkTrace/blob/main/docs/agdr/AgDR-0007-agent-evidence-workflow-migration.md)

## Validation

- Full local suite: **411 passed**, **87% branch-enabled coverage**. Following relocation of the SQLite-only readiness reader into the DB layer, 33 focused readiness/activation/MCP tests passed again. Obsolete coverage data for the moved file is excluded from the final local aggregate; CI runs the exact final tree from scratch.
- Formatting, Ruff, strict mypy (75 source files), sdist and wheel build pass.
- Installed-wheel CLI, status queries and shared Git environment pass in a separate environment outside the checkout. Clean-process status reads do not load importers or provider implementations.
- Tests cover 502 keys and real CLI chunking, unreturned-key limitations, same-name collaborators, role/reason unions, branch context/no-parent traversal, confirmed removal/undo/history, stale replacement tokens, failed preflight then success, retained authority, interrupted session audit and Git subprocess environments.
- Independent review reproduced a missing structured Jira-key recovery path. Fixed issue `key` and subresource `issue_key` extraction; four current/historical regressions and 39 focused integration tests pass. Final tree contains 415 tests; updated-head CI and delta review are required.
- Final exact-head [Quality CI](https://github.com/AmrMohamad/WorkTrace/actions/runs/33986368462) at `2a5e8679da6c9a1b302c758daa354541393497e9`: **415 passed, 87% coverage**, formatting, lint, strict types, package build and installed-wheel smoke all pass. The delta review at this same head is approved.

## Upgrade and boundaries

No schema migration or new dependency. Existing schema-5 ledgers remain readable; old Jira selector coverage is labelled legacy. Full configured-range Jira imports that would remove current records return a preview; inspect its impact before repeating with `--approve-selector-replacement PROPOSAL_TOKEN`. Repeatable `--jira-key` options add explicit in-scope roots.

Known search omissions never prove deletion or absence of work. Failed upstream imports are labelled with actual retained-snapshot provenance or no authoritative input. Six MCP tools and cursor encoding remain unchanged. No live-provider access, private-ledger changes, automatic Git fetch, TUI redesign, or slice-D/E work.

## Review and QA

- [x] [Independent exact-head code/security review approved](https://github.com/AmrMohamad/WorkTrace/pull/35#pullrequestreview-5122664337), including correction of the structured-key recovery finding.
- [x] Exact-head CI green
- [ ] Explicit per-PR human merge approval
- [ ] Post-merge QA

## Glossary

| Term | Meaning |
|---|---|
| Discovery root | An exact, scope-approved starting record or explicit Jira key; not ownership proof. |
| Selector v3 | Personally scoped key selection with auditable omissions and guarded replacement. |
| Preflight | Credential, origin and identity preparation before a real source run starts. |
| Replacement token | Approval bound to previous observations, proposed removals and confirmed membership state. |
| Coverage | Known omissions/limitations, independent of whether execution succeeded. |
