### PR TITLE
feat(#30): explain evidence relationships and memberships

### DIFF
--- a/AGENTS.MCP.md
+++ b/AGENTS.MCP.md
@@ -3,7 +3,7 @@
 Load for MCP server code, tool schemas, limits, configuration, or Codex integration.
 
 - The MCP process opens SQLite read-only and receives no Jira/GitLab credentials.
-- Expose exactly six tools: `list_contribution_candidates`, `get_contribution_summary`, `build_phase4_packet`, `list_evidence_gaps`, `search_evidence`, and `get_evidence_excerpt`.
+- Expose exactly seven tools: `list_contribution_candidates`, `get_contribution_summary`, `build_phase4_packet`, `list_evidence_gaps`, `search_evidence`, `get_evidence_excerpt`, and `get_evidence_context`.
 - Inputs accept stable app/contribution/evidence IDs, filters, cursors, and bounded limits—never paths, commands, URLs to follow, or SQL.
 - Enforce configured app/source scope server-side. A server instruction is guidance, not an access-control boundary.
 - Return redacted structured data with stable evidence IDs, `as_of`, source completeness, staleness, contradictions, and limitations.
@@ -12,5 +12,5 @@ Load for MCP server code, tool schemas, limits, configuration, or Codex integrat
 - Every response uses one short query-only SQLite snapshot. Return a view token and validate optional expected_view_token in that snapshot; tokens certify consistency, not authority or readiness.
 - Candidate/search pages process at most 200 raw matching rows. Advance versioned continuation only past excluded or delivered records; never trim admitted rows after cursor calculation. Legacy offset cursors require restart.
 - Preserve all 30 Phase 4 v2 question identities/statuses and contradiction signals when compacting. Section/question detail retrieval remains within build_phase4_packet, with view-bound continuations.
-- The broader excerpt tool is documented for prompt approval in Codex configuration; the other five tools remain read-only automatic reads.
+- The broader excerpt tool is documented for prompt approval in Codex configuration; the other six tools remain read-only automatic reads.
 - MCP unit tests prove scope, stable-ID validation, read-only behavior, redaction, and output limits. A direct tool call proves only the exercised local database/server path.

--- a/AGENTS.Tooling.md
+++ b/AGENTS.Tooling.md
@@ -15,7 +15,7 @@ Load for Python, CLI, SQLite, adapters, subprocesses, configuration, imports, pa
 ## Read-only human TUI
 
 - The first `worktrace ui` release is structurally read-only. Construct only `ReadOnlyWorkspace`; do not expose provider clients, HTTP/network access, importers, decisions, migrations, maintenance, configuration editing, exports, backups, purge, or a write-capable SQLite connection.
-- Do not call WorkTrace CLI commands as subprocesses, parse CLI JSON as an internal API, or call MCP from the TUI. Keep all six MCP tools and their response limits; MCP uses versioned, view-bound cursors while TUI cursor shapes remain unchanged.
+- Do not call WorkTrace CLI commands as subprocesses, parse CLI JSON as an internal API, or call MCP from the TUI. Keep all seven MCP tools and their response limits; MCP uses versioned, view-bound cursors while TUI cursor shapes remain unchanged.
 - Create every TUI SQLite connection inside its Textual worker with URI `mode=ro`, `PRAGMA query_only=ON`, and a 500 ms busy timeout. Close it in `finally`; never retain a connection while the user is idle or move it across threads.
 - Reuse the shared generation-bound candidate query with caller-owned read snapshots. Preserve TUI command/cursor shapes and scan bounds. Do not add an index without measured evidence.
 - Before importing Textual, scrub the provider credential/HMAC variables and Textual control variables listed in the approved technical design. The TUI never migrates an older database; direct the user to the CLI and reject newer unsupported schemas.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ uv run worktrace status APP_ID
 ```
 
 `import all` rebuilds references and candidates; separate source imports require an explicit
-`worktrace rebuild all APP_ID`. The six-tool MCP contract and cursor encoding are unchanged.
+`worktrace rebuild all APP_ID`. MCP cursors remain opaque and view-bound.
 
 ## Discovery coverage and selector upgrades
 
@@ -189,11 +189,33 @@ without dropping any of the 30 question IDs/statuses or support/contradiction pr
 detail with either `section` (the canonical section name) or `question_id`, then follow
 `detail_cursor`, always carrying `expected_view_token`. Detail entries include stable citation
 IDs and ordered answer/limitation chunks. An explicit size error never advances continuation.
-The TUI keeps its existing navigation and cursor contract; no seventh tool is introduced.
+The TUI keeps its existing navigation and cursor contract.
 
-`worktrace serve-mcp` exposes exactly six bounded, read-only tools over stdio. See
+`worktrace serve-mcp` exposes exactly seven bounded, read-only tools over stdio. `get_evidence_context`
+explains one configured source object through independently paged references and effective memberships;
+it never recursively expands a graph. See
 [`docs/codex-mcp.example.toml`](docs/codex-mcp.example.toml). The server accepts configured app and
 stable evidence/candidate IDs, never filesystem paths or SQL.
+
+`get_evidence_context` starts both `relations` and `memberships` streams when both cursors are
+omitted. To continue only one, send only its cursor; the other is `requested=false`, with
+`items=[]`, `next_cursor=null`, and `complete=null` rather than an empty traversal. Each stream
+scans at most 200 raw rows; one response returns at most 20 items across both streams and shares
+the 20,000-character budget. `complete` describes traversal only: source completeness, identity
+readiness, and availability remain separate coverage facts.
+
+Optional cross-provider SHA links require an explicit correspondence in the owning app:
+
+```toml
+[[apps.gitlab_repository_mappings]]
+repo_path = "/absolute/path/to/your/repository"
+gitlab_project_id = 12345
+```
+
+Without that mapping, matching SHA text creates no Git-to-GitLab relationship. A mapped link is
+explain-only evidence, never ownership or a grouping decision. After an upgrade or mapping change,
+run `worktrace rebuild all APP_ID`; legacy context-role decisions remain inspectable but require
+re-review when canonical membership changes.
 
 ## Verification
 

--- a/docs/codex-mcp.example.toml
+++ b/docs/codex-mcp.example.toml
@@ -19,6 +19,7 @@ enabled_tools = [
     "list_evidence_gaps",
     "search_evidence",
     "get_evidence_excerpt",
+    "get_evidence_context",
 ]
 
 default_tools_approval_mode = "auto"

--- a/docs/product-contract.md
+++ b/docs/product-contract.md
@@ -68,7 +68,7 @@ The authorized v0.1 boundary is:
 - one local SQLite evidence ledger;
 - local Git, Jira Cloud REST v3, and GitLab REST v4 adapters;
 - a CLI that owns every write;
-- a SQLite-only, read-only MCP server with six bounded tools; and
+- a SQLite-only, read-only MCP server with seven bounded tools; and
 - explicit app, project, source-instance, and repository mappings.
 
 The following are out of scope: a cloud backend, web UI, daemon, ORM, embeddings, vector database, embedded LLM, automatic Git fetch, arbitrary filesystem or SQL access through MCP, automatic ownership or impact classification, productivity scoring, and multi-user use.
@@ -81,15 +81,15 @@ writing, and personal career inventory. It is not an employee-evaluation, promot
 seniority, or productivity surface.
 
 This interface does not change the mutation boundary. The CLI continues to own every write, and
-MCP continues to expose exactly six bounded read-only tools. The TUI constructs only a narrow
+MCP continues to expose exactly seven bounded read-only tools. The TUI constructs only a narrow
 read-only workspace over short-lived SQLite URI `mode=ro` connections with
 `PRAGMA query_only = ON`. It receives no provider, credential, network, importer, decision,
 migration, maintenance, export, backup, purge, or configuration-editing capability.
 
 The TUI reuses the packet builder as the canonical claim projection and adds a separate
 generation-bound candidate query for human paging. It does not invoke CLI subprocesses, parse CLI
-JSON, or call MCP internally. MCP's existing schemas, limits, and opaque `offset:` cursor remain
-unchanged.
+JSON, or call MCP internally. MCP's existing schemas and limits remain unchanged; MCP continuations
+are opaque, view-bound cursors and the TUI keeps its separate cursor contract.
 
 The initial executable workflow is limited to application selection, honest latest-attempt source
 status, bounded candidate browsing, contribution review, all canonical Phase 4 questions and gaps,

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -160,7 +160,7 @@ connection creation, file writes, and clipboard calls with failing sentinels and
 journey. A real SQL write attempt through the TUI connection must fail.
 
 The TUI does not call MCP or execute WorkTrace CLI commands. This avoids turning protocol output or
-CLI JSON into an internal capability and leaves MCP's six-tool allowlist and response limits
+CLI JSON into an internal capability and leaves MCP's seven-tool allowlist and response limits
 unchanged.
 
 ### Database version and contention
@@ -209,7 +209,7 @@ Parser failures must never log the raw pre-redacted input. Redaction is versione
 ## MCP enforcement
 
 - Read-only SQLite URI and query-only connection behavior.
-- Exactly six allowlisted tools.
+- Exactly seven allowlisted tools.
 - Maximum 20 records.
 - Default excerpt 1,200 characters; explicit excerpt maximum 4,000.
 - Maximum serialized response text 20,000 characters.

--- a/src/worktrace/candidates/builder.py
+++ b/src/worktrace/candidates/builder.py
@@ -18,7 +18,7 @@ from worktrace.participation import (
     supports_category,
 )
 
-GENERATOR_VERSION = "4"
+GENERATOR_VERSION = "5"
 MAX_DEPTH = 3
 MAX_MEMBERS = 200
 MAX_CONTEXT = 50

--- a/src/worktrace/cli.py
+++ b/src/worktrace/cli.py
@@ -37,7 +37,7 @@ from worktrace.db.import_status import readiness_contract, source_readiness
 from worktrace.db.migrations import backup_database, migrate
 from worktrace.db.queries import search_evidence, source_status
 from worktrace.db.readiness import DatabaseReadinessStatus, database_readiness
-from worktrace.db.repository import EvidenceRepository, stable_id
+from worktrace.db.repository import EvidenceRepository, source_instance_id, stable_id
 from worktrace.doctor import run_doctor
 from worktrace.domain.models import JsonValue
 from worktrace.errors import ConfigurationError, WorkTraceError
@@ -53,6 +53,7 @@ from worktrace.importers.orchestrator import ImportResult, import_snapshot
 from worktrace.linking.builder import rebuild_references
 from worktrace.local_security import email_hmac_key
 from worktrace.normalize.redaction import Redactor
+from worktrace.packets.builder import PacketBuilder
 from worktrace.paths import ensure_private_directory
 from worktrace.services import add_manual_evidence, export_app
 
@@ -249,10 +250,6 @@ def _assert_no_scope_contraction(
             )
 
 
-def _source_instance(app_id: str, source: str, identifier: object) -> str:
-    return stable_id("source", app_id, source, identifier)
-
-
 def _open(
     config_path: Path | None = None,
 ) -> tuple[WorkTraceConfig, sqlite3.Connection, EvidenceRepository]:
@@ -438,7 +435,7 @@ def _verified_repair_identities(
                 JiraConfig(
                     work_timezone=configuration.employment_timezone,
                     base_url=credentials.base_url,
-                    source_instance=_source_instance(app_id, "jira", credentials.base_url),
+                    source_instance=source_instance_id(app_id, "jira", credentials.base_url),
                     app_id=app_id,
                     project_keys=selected.jira_project_keys,
                     account_id=configuration.identity.jira_account_id,
@@ -461,7 +458,7 @@ def _verified_repair_identities(
             gitlab_adapter = GitLabAdapter(
                 GitLabConfig(
                     base_url=credentials_gitlab.base_url,
-                    source_instance=_source_instance(
+                    source_instance=source_instance_id(
                         app_id, "gitlab", selected.gitlab_project_ids[0]
                     ),
                     app_id=app_id,
@@ -647,7 +644,7 @@ def _run_source_import(
     target = (
         str(identifier)
         if source == "gitlab"
-        else (_source_instance(app_id, source, identifier) if source == "git" else "jira")
+        else (source_instance_id(app_id, source, identifier) if source == "git" else "jira")
     )
     reason = "identity_policy_unready"
     started = False
@@ -679,7 +676,7 @@ def _run_source_import(
             if source == "git":
                 assert isinstance(identifier, Path)
                 scoped_repo = configured_app.assert_repo_scope(identifier)
-                source_instance = _source_instance(app_id, source, scoped_repo)
+                source_instance = source_instance_id(app_id, source, scoped_repo)
                 adapter = LocalGitAdapter(
                     LocalGitConfig(
                         repository_path=scoped_repo,
@@ -695,7 +692,7 @@ def _run_source_import(
                 scope["selection_reasons"] = ["configured repository read-only snapshot"]
             elif source == "gitlab":
                 assert credentials is not None and isinstance(identifier, int)
-                source_instance = _source_instance(app_id, source, identifier)
+                source_instance = source_instance_id(app_id, source, identifier)
                 seeds = _relevant_git_commit_shas(repository, app_id)
                 counts = {
                     "relevant_local_commit_shas": len(seeds.values),
@@ -746,7 +743,7 @@ def _run_source_import(
                     explicit_keys=explicit_jira_keys,
                 )
                 counts = {"exact_jira_keys": len(selection.keys)}
-                source_instance = _source_instance(app_id, source, credentials.base_url)
+                source_instance = source_instance_id(app_id, source, credentials.base_url)
                 reason = "origin_invalid"
                 # This branch has JiraCredentials; keep the union's narrowing explicit.
                 jira_auth = jira_credentials()
@@ -800,7 +797,7 @@ def _run_source_import(
                     expected_instance = item.get("source_instance") or (
                         item.get("target")
                         if previous_source == "git"
-                        else _source_instance(app_id, "gitlab", item.get("target"))
+                        else source_instance_id(app_id, "gitlab", item.get("target"))
                     )
                     known = retained.get(previous_source, {}).get(
                         "last_authoritative_snapshots", []
@@ -1246,29 +1243,38 @@ def remove_member(candidate_id: str, source_object_id: str, config: ConfigOption
 
 @app.command()
 def merge(candidate_id: str, other_candidate_ids: list[str], config: ConfigOption = None) -> None:
-    _, connection, _ = _open(config)
+    configuration, connection, _ = _open(config)
     try:
-        views = [
-            project_candidate(connection, value) for value in [candidate_id, *other_candidate_ids]
+        requested_ids = [candidate_id, *other_candidate_ids]
+        builder = PacketBuilder(connection, configuration)
+        views = [builder.resolve_contribution(value) for value in requested_ids]
+        canonical_ids = [
+            view.candidate_id if isinstance(view.candidate_id, str) and view.candidate_id else value
+            for value, view in zip(requested_ids, views, strict=True)
         ]
+        if len(set(canonical_ids)) < 2:
+            raise WorkTraceError("merge requires at least two distinct effective contributions")
         app_ids = {view.app_id for view in views}
         if len(app_ids) != 1:
             raise WorkTraceError("merged candidates must belong to one app")
-        member_ids = sorted(
-            {str(member["source_object_id"]) for view in views for member in view.members}
-        )
-        contribution_id = stable_id("contribution", candidate_id, *sorted(other_candidate_ids))
+        material_ids = set().union(*(view.member_ids for view in views))
+        context_ids = set().union(*(view.context_ids for view in views)) - material_ids
+        # The creation snapshot records every effective member; role is carried
+        # separately by context_members so a later projector need not infer it.
+        member_ids = sorted(material_ids) + sorted(context_ids)
+        contribution_id = stable_id("contribution", *sorted(canonical_ids))
         decision_id = append_decision(
             connection,
             "merge_contributions",
-            candidate_id,
+            canonical_ids[0],
             {
                 "contribution_id": contribution_id,
-                "candidate_ids": other_candidate_ids,
+                "candidate_ids": canonical_ids[1:],
                 "app_id": views[0].app_id,
                 "title": views[0].title,
                 "type": views[0].contribution_type,
-                "members": member_ids,
+                "members": sorted(set(member_ids) | context_ids),
+                "context_members": sorted(context_ids),
             },
         )
         _emit({"decision_id": decision_id, "contribution_id": contribution_id})
@@ -1280,18 +1286,42 @@ def merge(candidate_id: str, other_candidate_ids: list[str], config: ConfigOptio
 def split(
     candidate_id: str, keep_source_object_ids: list[str], config: ConfigOption = None
 ) -> None:
-    candidate = candidate_id
-    contribution_id = stable_id("contribution", candidate, *sorted(keep_source_object_ids))
-    _decision(
-        "split_contribution",
-        candidate,
-        {
-            "contribution_id": contribution_id,
-            "keep_source_object_ids": keep_source_object_ids,
-            "members": keep_source_object_ids,
-        },
-        config,
-    )
+    configuration, connection, _ = _open(config)
+    try:
+        view = PacketBuilder(connection, configuration).resolve_contribution(candidate_id)
+        canonical_id = (
+            view.candidate_id
+            if isinstance(view.candidate_id, str) and view.candidate_id
+            else candidate_id
+        )
+        keep_ids = set(keep_source_object_ids)
+        effective_ids = view.member_ids | view.context_ids
+        if not keep_ids:
+            raise WorkTraceError(
+                "split requires a nonempty subset of effective contribution members"
+            )
+        if not keep_ids <= effective_ids:
+            raise WorkTraceError("split members must belong to the effective contribution")
+        material_ids = view.member_ids & keep_ids
+        context_ids = (view.context_ids & keep_ids) - material_ids
+        contribution_id = stable_id("contribution", canonical_id, *sorted(keep_ids))
+        decision_id = append_decision(
+            connection,
+            "split_contribution",
+            canonical_id,
+            {
+                "contribution_id": contribution_id,
+                "app_id": view.app_id,
+                "title": view.title,
+                "type": view.contribution_type,
+                "keep_source_object_ids": sorted(keep_ids),
+                "members": sorted(material_ids | context_ids),
+                "context_members": sorted(context_ids),
+            },
+        )
+        _emit({"decision_id": decision_id, "contribution_id": contribution_id})
+    finally:
+        connection.close()
 
 
 @app.command()

--- a/src/worktrace/config.py
+++ b/src/worktrace/config.py
@@ -56,6 +56,14 @@ class ModuleRule:
 
 
 @dataclass(frozen=True)
+class GitLabRepositoryMapping:
+    """One explicitly configured GitLab project to local repository correspondence."""
+
+    repo_path: Path
+    gitlab_project_id: int
+
+
+@dataclass(frozen=True)
 class IdentityConfig:
     display_name: str
     git_author_emails: tuple[str, ...]
@@ -80,6 +88,7 @@ class AppConfig:
     ignored_paths: tuple[str, ...]
     module_rules: tuple[ModuleRule, ...] = field(default_factory=tuple)
     jira_custom_fields: dict[str, str] = field(default_factory=dict)
+    gitlab_repository_mappings: tuple[GitLabRepositoryMapping, ...] = field(default_factory=tuple)
 
     def assert_repo_scope(self, candidate: Path) -> Path:
         resolved = candidate.expanduser().resolve()
@@ -167,6 +176,52 @@ def _parse_app(raw: object, index: int) -> AppConfig:
     ):
         raise ConfigurationError("Jira custom field mappings must be strings")
 
+    raw_mappings = table.get("gitlab_repository_mappings", [])
+    if not isinstance(raw_mappings, list):
+        raise ConfigurationError(
+            f"apps[{index}].gitlab_repository_mappings must be an array of tables"
+        )
+    mappings: list[GitLabRepositoryMapping] = []
+    seen_mapping_pairs: set[tuple[Path, int]] = set()
+    for mapping_index, raw_mapping in enumerate(raw_mappings):
+        mapping = _require_table(
+            raw_mapping, f"apps[{index}].gitlab_repository_mappings[{mapping_index}]"
+        )
+        raw_repo_path = mapping.get("repo_path")
+        if not isinstance(raw_repo_path, str) or not raw_repo_path.strip():
+            raise ConfigurationError(
+                f"apps[{index}].gitlab_repository_mappings[{mapping_index}].repo_path "
+                "must be a nonblank string"
+            )
+        repo_path = Path(raw_repo_path).expanduser().resolve()
+        raw_project_id = mapping.get("gitlab_project_id")
+        if (
+            isinstance(raw_project_id, bool)
+            or not isinstance(raw_project_id, int)
+            or raw_project_id < 1
+        ):
+            raise ConfigurationError(
+                f"apps[{index}].gitlab_repository_mappings[{mapping_index}].gitlab_project_id "
+                "must be a positive integer"
+            )
+        if repo_path not in repo_paths:
+            raise ConfigurationError(
+                f"apps[{index}].gitlab_repository_mappings[{mapping_index}].repo_path "
+                "is not configured for this app"
+            )
+        if raw_project_id not in gitlab_ids:
+            raise ConfigurationError(
+                f"apps[{index}].gitlab_repository_mappings[{mapping_index}].gitlab_project_id "
+                "is not configured for this app"
+            )
+        pair = (repo_path, raw_project_id)
+        if pair in seen_mapping_pairs:
+            raise ConfigurationError("duplicate GitLab repository mapping")
+        seen_mapping_pairs.add(pair)
+        mappings.append(
+            GitLabRepositoryMapping(repo_path=repo_path, gitlab_project_id=raw_project_id)
+        )
+
     return AppConfig(
         id=app_id,
         name=name,
@@ -185,6 +240,9 @@ def _parse_app(raw: object, index: int) -> AppConfig:
         ignored_paths=_strings(table.get("ignored_paths"), f"apps[{index}].ignored_paths"),
         module_rules=tuple(rules),
         jira_custom_fields={str(key): str(value) for key, value in custom_fields.items()},
+        gitlab_repository_mappings=tuple(
+            sorted(mappings, key=lambda item: (str(item.repo_path), item.gitlab_project_id))
+        ),
     )
 
 

--- a/src/worktrace/db/read_state.py
+++ b/src/worktrace/db/read_state.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from worktrace.errors import DatabaseError
 
 READ_PROTOCOL_VERSION = 1
-READ_MODEL_VERSION = 1
+READ_MODEL_VERSION = 2
 
 
 def mark_read_state_changed(connection: sqlite3.Connection, app_id: str) -> None:

--- a/src/worktrace/db/repository.py
+++ b/src/worktrace/db/repository.py
@@ -44,6 +44,12 @@ def stable_id(prefix: str, *parts: object) -> str:
     return f"{prefix}:{hashlib.sha256(raw.encode('utf-8')).hexdigest()[:24]}"
 
 
+def source_instance_id(app_id: str, source: str, identifier: object) -> str:
+    """Return the established opaque source-instance identifier without changing it."""
+
+    return stable_id("source", app_id, source, identifier)
+
+
 def payload_hash(title: str | None, body: str | None, data: dict[str, JsonValue]) -> str:
     payload = json.dumps(
         {"title": title, "body": body, "data": data},

--- a/src/worktrace/linking/builder.py
+++ b/src/worktrace/linking/builder.py
@@ -7,7 +7,13 @@ from dataclasses import dataclass
 from worktrace.config import AppConfig
 from worktrace.db.read_state import mark_read_states_changed
 from worktrace.db.repository import EvidenceRepository, stable_id
-from worktrace.linking.extractors import extract_commit_shas, extract_jira_keys, extract_mr_iids
+from worktrace.linking.extractors import (
+    extract_commit_shas,
+    extract_full_commit_shas,
+    extract_jira_keys,
+    extract_mr_iids,
+)
+from worktrace.linking.mappings import mapped_commit_sha_allowed
 
 
 @dataclass(frozen=True)
@@ -78,18 +84,22 @@ def _insert(
 def rebuild_references(app: AppConfig, repository: EvidenceRepository) -> int:
     connection = repository.connection
     objects = _objects(repository, app.id)
-    by_source_kind_external: dict[tuple[str, str, str], CurrentObject] = {
-        (item.source, item.kind, item.external_id): item for item in objects
-    }
+    by_source_kind_external: dict[tuple[str, str, str], list[CurrentObject]] = {}
+    for item in objects:
+        by_source_kind_external.setdefault((item.source, item.kind, item.external_id), []).append(
+            item
+        )
     for item in objects:
         if item.kind == "jira_issue" and isinstance(item.data.get("key"), str):
-            by_source_kind_external[("jira", "jira_issue", str(item.data["key"]))] = item
+            alias_key = ("jira", "jira_issue", str(item.data["key"]))
+            if alias_key != (item.source, item.kind, item.external_id):
+                by_source_kind_external.setdefault(alias_key, []).append(item)
     jira = {
         str(item.data.get("key", item.external_id)).upper(): item
         for item in objects
         if item.kind == "jira_issue"
     }
-    commits = {item.external_id.lower(): item for item in objects if item.kind == "git_commit"}
+    commits = [item for item in objects if item.kind == "git_commit"]
     mrs_by_iid: dict[str, list[CurrentObject]] = {}
     for item in objects:
         if item.kind == "gitlab_mr":
@@ -107,17 +117,48 @@ def rebuild_references(app: AppConfig, repository: EvidenceRepository) -> int:
                     )
 
             for prefix in sorted(extract_commit_shas(text)):
-                matches = [commit for sha, commit in commits.items() if sha.startswith(prefix)]
+                matches = [
+                    commit for commit in commits if commit.external_id.lower().startswith(prefix)
+                ]
                 if len(matches) == 1 and matches[0].object_id != item.object_id:
+                    target = matches[0]
+                    if (
+                        item.source == target.source
+                        and item.source_instance != target.source_instance
+                    ):
+                        continue
+                    if item.source == "gitlab" and target.source == "git":
+                        # Cross-provider SHA matches require a full, explicit mapping.
+                        continue
                     _insert(
                         connection,
                         app.id,
                         item,
-                        matches[0],
+                        target,
                         "mentions_commit_sha",
                         "exact_text",
                         prefix,
                     )
+
+            if item.source == "gitlab":
+                for sha in sorted(extract_full_commit_shas(text)):
+                    matches = [
+                        commit
+                        for commit in commits
+                        if commit.external_id.casefold() == sha
+                        and commit.object_id != item.object_id
+                    ]
+                    for target in matches:
+                        if mapped_commit_sha_allowed(app, item, target, sha):
+                            _insert(
+                                connection,
+                                app.id,
+                                item,
+                                target,
+                                "mapped_commit_sha",
+                                "explicit_repo_project_full_sha:textual_reference",
+                                sha,
+                            )
 
             for iid in sorted(extract_mr_iids(text)):
                 matches = mrs_by_iid.get(iid, [])
@@ -137,8 +178,48 @@ def rebuild_references(app: AppConfig, repository: EvidenceRepository) -> int:
                         str(raw.get("target_kind", "")),
                         str(raw.get("target_external_id", "")),
                     )
-                    target = by_source_kind_external.get(target_key)
-                    if target and target.object_id != item.object_id:
+                    targets = (
+                        [
+                            commit
+                            for commit in commits
+                            if commit.external_id.casefold()
+                            == str(raw.get("target_external_id", "")).casefold()
+                        ]
+                        if target_key[:2] == ("git", "git_commit")
+                        else by_source_kind_external.get(target_key, [])
+                    )
+                    exact_value = (
+                        str(raw["exact_value"]) if raw.get("exact_value") is not None else None
+                    )
+                    for target in targets:
+                        if target.object_id == item.object_id:
+                            continue
+                        if (
+                            item.source == target.source
+                            and item.source_instance != target.source_instance
+                        ):
+                            continue
+                        if item.source == "gitlab" and target.source == "git":
+                            if target.kind != "git_commit" or exact_value is None:
+                                continue
+                            if mapped_commit_sha_allowed(app, item, target, exact_value):
+                                field = {
+                                    "gitlab_source_head": "source_head",
+                                    "gitlab_merge_commit": "merge_commit_sha",
+                                    "gitlab_squash_commit": "squash_commit_sha",
+                                    "gitlab_release_commit": "commit_record",
+                                    "gitlab_deployment_commit": "deployment",
+                                }.get(str(raw.get("relationship_type")), "pending_reference")
+                                _insert(
+                                    connection,
+                                    app.id,
+                                    item,
+                                    target,
+                                    "mapped_commit_sha",
+                                    f"explicit_repo_project_full_sha:{field}",
+                                    exact_value.casefold(),
+                                )
+                            continue
                         _insert(
                             connection,
                             app.id,
@@ -146,30 +227,59 @@ def rebuild_references(app: AppConfig, repository: EvidenceRepository) -> int:
                             target,
                             str(raw.get("relationship_type", "related_to")),
                             str(raw.get("extraction_method", "source_metadata")),
-                            str(raw["exact_value"]) if raw.get("exact_value") is not None else None,
+                            exact_value,
                         )
 
             structural: list[tuple[str, str, str]] = []
             if item.kind == "gitlab_mr":
                 commit_shas = item.data.get("commit_shas")
                 if isinstance(commit_shas, list):
-                    for sha in commit_shas:
-                        structural.append(("git_commit", str(sha), "mr_contains_commit"))
+                    for commit_sha in commit_shas:
+                        structural.append(("git_commit", str(commit_sha), "mr_contains_commit"))
                 for field in ("merge_commit_sha", "squash_commit_sha"):
-                    sha = item.data.get(field)
-                    if isinstance(sha, str) and sha:
-                        structural.append(("git_commit", sha, "commit_introduced_by_mr"))
+                    field_sha = item.data.get(field)
+                    if isinstance(field_sha, str) and field_sha:
+                        structural.append(("git_commit", field_sha, "commit_introduced_by_mr"))
+            elif item.kind == "gitlab_merge_request_commit":
+                commit_sha = item.data.get("sha")
+                if isinstance(commit_sha, str):
+                    structural.append(("git_commit", commit_sha, "commit_record"))
             elif item.kind == "git_deployment":
-                sha = item.data.get("sha")
-                if isinstance(sha, str):
-                    structural.append(("git_commit", sha, "deployment_contains_sha"))
+                deployment_sha = item.data.get("sha")
+                if isinstance(deployment_sha, str):
+                    structural.append(("git_commit", deployment_sha, "deployment_contains_sha"))
             elif item.kind == "git_tag":
-                sha = item.data.get("target_commit_sha")
-                if isinstance(sha, str):
-                    structural.append(("git_commit", sha, "tag_points_to_commit"))
+                target_sha = item.data.get("target_commit_sha")
+                if isinstance(target_sha, str):
+                    structural.append(("git_commit", target_sha, "tag_points_to_commit"))
             for kind, external_id, relationship in structural:
-                target = by_source_kind_external.get(("git", kind, external_id))
-                if target:
+                targets = (
+                    [
+                        commit
+                        for commit in commits
+                        if commit.external_id.casefold() == external_id.casefold()
+                    ]
+                    if kind == "git_commit"
+                    else by_source_kind_external.get(("git", kind, external_id), [])
+                )
+                for target in targets:
+                    if (
+                        item.source == target.source
+                        and item.source_instance != target.source_instance
+                    ):
+                        continue
+                    if item.source == "gitlab" and target.source == "git":
+                        if mapped_commit_sha_allowed(app, item, target, external_id):
+                            _insert(
+                                connection,
+                                app.id,
+                                item,
+                                target,
+                                "mapped_commit_sha",
+                                f"explicit_repo_project_full_sha:{relationship}",
+                                external_id.casefold(),
+                            )
+                        continue
                     _insert(
                         connection,
                         app.id,

--- a/src/worktrace/linking/extractors.py
+++ b/src/worktrace/linking/extractors.py
@@ -5,6 +5,7 @@ import re
 from worktrace.config import AppConfig
 
 SHA_RE = re.compile(r"(?<![0-9a-f])([0-9a-f]{7,40})(?![0-9a-f])", re.IGNORECASE)
+FULL_SHA_RE = re.compile(r"(?<![0-9a-f])([0-9a-f]{40}|[0-9a-f]{64})(?![0-9a-f])", re.IGNORECASE)
 MR_RE = re.compile(r"(?<![A-Za-z0-9])!(?P<iid>[1-9][0-9]*)")
 
 
@@ -17,6 +18,12 @@ def extract_jira_keys(text: str, app: AppConfig) -> set[str]:
 
 def extract_commit_shas(text: str) -> set[str]:
     return {match.lower() for match in SHA_RE.findall(text)}
+
+
+def extract_full_commit_shas(text: str) -> set[str]:
+    """Extract only unambiguous full Git object identifiers for cross-provider mapping."""
+
+    return {match.lower() for match in FULL_SHA_RE.findall(text)}
 
 
 def extract_mr_iids(text: str) -> set[str]:

--- a/src/worktrace/linking/mappings.py
+++ b/src/worktrace/linking/mappings.py
@@ -1,0 +1,91 @@
+"""Explicit GitLab-project to local-repository SHA mapping guards.
+
+The opaque source-instance identities are the only correspondence used here.
+Neither app co-membership nor Git remote metadata establishes a mapping.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from worktrace.config import AppConfig
+from worktrace.db.repository import source_instance_id
+
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$|^[0-9a-f]{64}$", re.IGNORECASE)
+_METHOD_PREFIX = "explicit_repo_project_full_sha:"
+
+
+def _field(value: object, name: str) -> object | None:
+    if isinstance(value, Mapping):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _full_sha(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.casefold()
+    return normalized if _FULL_SHA_RE.fullmatch(normalized) else None
+
+
+def mapped_source_instance_pairs(app: AppConfig) -> frozenset[tuple[str, str]]:
+    """Return configured `(gitlab, git)` opaque source-instance pairs."""
+
+    return frozenset(
+        (
+            source_instance_id(app.id, "gitlab", mapping.gitlab_project_id),
+            source_instance_id(app.id, "git", mapping.repo_path),
+        )
+        for mapping in app.gitlab_repository_mappings
+    )
+
+
+def mapped_commit_sha_allowed(
+    app: AppConfig,
+    from_object: object,
+    to_object: object,
+    exact_value: object,
+) -> bool:
+    """Check one proposed GitLab-to-Git SHA link against live explicit mapping."""
+
+    sha = _full_sha(exact_value)
+    target_sha = _full_sha(_field(to_object, "external_id"))
+    if sha is None or target_sha is None or sha != target_sha or len(sha) != len(target_sha):
+        return False
+    if (
+        _field(from_object, "source") != "gitlab"
+        or _field(to_object, "source") != "git"
+        or _field(to_object, "kind") != "git_commit"
+    ):
+        return False
+    for object_value in (from_object, to_object):
+        object_app = _field(object_value, "app_id")
+        if object_app is not None and object_app != app.id:
+            return False
+    source_pair = (_field(from_object, "source_instance"), _field(to_object, "source_instance"))
+    return (
+        isinstance(source_pair[0], str)
+        and isinstance(source_pair[1], str)
+        and source_pair in mapped_source_instance_pairs(app)
+    )
+
+
+def reference_mapping_allowed(
+    app: AppConfig,
+    reference: object,
+    from_object: object,
+    to_object: object,
+) -> bool:
+    """Fail closed unless a stored mapped-SHA reference remains currently valid.
+
+    This is intentionally suitable for context reads: malformed legacy rows and
+    removed mappings are simply not admissible and never cause a read failure.
+    """
+
+    if _field(reference, "relationship_type") != "mapped_commit_sha":
+        return False
+    method = _field(reference, "extraction_method")
+    if not isinstance(method, str) or not method.startswith(_METHOD_PREFIX):
+        return False
+    return mapped_commit_sha_allowed(app, from_object, to_object, _field(reference, "exact_value"))

--- a/src/worktrace/mcp_server/limits.py
+++ b/src/worktrace/mcp_server/limits.py
@@ -141,7 +141,13 @@ def _redact_string(value: str) -> str:
 def _is_structured_identifier(value: str, field_name: str | None) -> bool:
     if field_name in {"view_token", "expected_view_token"}:
         return re.fullmatch(r"view:1:[0-9a-f]{64}", value) is not None
-    if field_name in {"cursor", "next_cursor", "detail_cursor"}:
+    if field_name in {
+        "cursor",
+        "next_cursor",
+        "detail_cursor",
+        "relation_cursor",
+        "membership_cursor",
+    }:
         return len(value) <= 2048 and re.fullmatch(r"wtc1:[A-Za-z0-9_-]+", value) is not None
     if field_name is None or _STABLE_IDENTIFIER.fullmatch(value) is None:
         return False

--- a/src/worktrace/mcp_server/protocol.py
+++ b/src/worktrace/mcp_server/protocol.py
@@ -21,6 +21,8 @@ _POSITIONS = {
     "candidates": {"candidate_id"},
     "evidence": {"sort_time", "observation_id"},
     "packet_details": {"question_id", "kind", "ordinal"},
+    "context_relations": {"phase", "key"},
+    "context_memberships": {"phase", "key"},
 }
 
 
@@ -106,7 +108,13 @@ def _unique_object(pairs: list[tuple[str, object]]) -> dict[str, object]:
 
 
 def decode_cursor(
-    value: str | None, *, collection: str, app_id: str, view: str, filters: str
+    value: str | None,
+    *,
+    collection: str,
+    app_id: str,
+    view: str,
+    filters: str,
+    object_fingerprint: str | None = None,
 ) -> dict[str, object] | None:
     if value is None:
         return None
@@ -123,7 +131,7 @@ def decode_cursor(
             raise ValueError("bad alphabet")
         raw = base64.b64decode(encoded + "=" * (-len(encoded) % 4), altchars=b"-_", validate=True)
         payload = json.loads(raw, object_pairs_hook=_unique_object)
-        if not isinstance(payload, dict) or set(payload) != {
+        base_fields = {
             "v",
             "collection",
             "app",
@@ -131,12 +139,21 @@ def decode_cursor(
             "filters",
             "generation",
             "position",
-        }:
+        }
+        if not isinstance(payload, dict) or (
+            set(payload) != base_fields and set(payload) != base_fields | {"object_fingerprint"}
+        ):
             raise ValueError("bad fields")
         if type(payload["v"]) is not int or payload["v"] != 1:
             raise ValueError("bad version")
         if not all(isinstance(payload[k], str) for k in ("collection", "app", "view", "filters")):
             raise ValueError("bad types")
+        context_fingerprint = payload.get("object_fingerprint")
+        if context_fingerprint is not None and (
+            not isinstance(context_fingerprint, str)
+            or re.fullmatch(r"[0-9a-f]{64}", context_fingerprint) is None
+        ):
+            raise ValueError("bad object fingerprint")
         if (
             _TOKEN.fullmatch(payload["view"]) is None
             or re.fullmatch(r"[0-9a-f]{64}", payload["filters"]) is None
@@ -157,8 +174,34 @@ def decode_cursor(
             not isinstance(generation, str) or re.fullmatch(r"[0-9a-f]{64}", generation) is None
         ):
             raise ValueError("bad generation")
-        if payload["collection"] != "candidates" and generation is not None:
+        if (
+            payload["collection"] not in {"candidates", "context_memberships"}
+            and generation is not None
+        ):
             raise ValueError("unexpected generation")
+        if payload["collection"] in {"context_relations", "context_memberships"}:
+            if context_fingerprint is None:
+                raise ValueError("missing object fingerprint")
+            if position["phase"] not in {"start", "after"}:
+                raise ValueError("bad context phase")
+            if position["phase"] == "start" and position["key"] != "-":
+                raise ValueError("bad context start")
+            if position["phase"] == "after" and not re.fullmatch(
+                r"[A-Za-z][A-Za-z0-9_-]{1,127}(?::[A-Za-z0-9._-]{1,128})*", position["key"]
+            ):
+                raise ValueError("bad context key")
+            if (
+                position["phase"] == "after"
+                and payload["collection"] == "context_relations"
+                and not position["key"].startswith("ref:")
+            ):
+                raise ValueError("bad relation key")
+            if (
+                position["phase"] == "after"
+                and payload["collection"] == "context_memberships"
+                and not position["key"].startswith(("candidate:", "contribution:"))
+            ):
+                raise ValueError("bad membership key")
         if (
             payload["collection"] == "evidence"
             and datetime.fromisoformat(position["sort_time"].replace("Z", "+00:00")).tzinfo is None
@@ -183,6 +226,10 @@ def decode_cursor(
         )
     if payload["filters"] != filters:
         raise ProtocolError("cursor_filter_mismatch", "Filters changed; restart without a cursor.")
+    if context_fingerprint != object_fingerprint:
+        raise ProtocolError(
+            "cursor_scope_mismatch", "Cursor belongs to a different context object."
+        )
     check_expected(payload["view"], view)
     return payload
 
@@ -195,8 +242,9 @@ def encode_cursor(
     filters: str,
     position: dict[str, str],
     generation: str | None = None,
+    object_fingerprint: str | None = None,
 ) -> str:
-    payload = {
+    payload: dict[str, object] = {
         "v": 1,
         "collection": collection,
         "app": app_id,
@@ -205,6 +253,8 @@ def encode_cursor(
         "generation": generation,
         "position": position,
     }
+    if object_fingerprint is not None:
+        payload["object_fingerprint"] = object_fingerprint
     raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     result = _CURSOR_PREFIX + base64.urlsafe_b64encode(raw).decode().rstrip("=")
     if len(result) > 2048:

--- a/src/worktrace/mcp_server/responses.py
+++ b/src/worktrace/mcp_server/responses.py
@@ -114,6 +114,18 @@ def _minimal_item(item: dict[str, object]) -> dict[str, object]:
         "chunk_count",
     }
     result = {key: value for key, value in item.items() if key in retained}
+    for key, value in tuple(result.items()):
+        if isinstance(value, str) and key not in {
+            "reference_id",
+            "from_object_id",
+            "to_object_id",
+            "object_id",
+            "candidate_id",
+            "contribution_id",
+        }:
+            result[key] = value[:192]
+            if len(value) > 192:
+                result[f"{key}_truncated"] = True
     for key in ("title", "text"):
         if isinstance(item.get(key), str):
             value = str(item[key])
@@ -127,6 +139,47 @@ def _minimal_item(item: dict[str, object]) -> dict[str, object]:
     result["has_limitations"] = bool(
         item.get("limitations") or item.get("warnings") or item.get("title_limitations")
     )
+    result["item_compacted"] = True
+    return result
+
+
+def _minimal_context_item(item: dict[str, object]) -> dict[str, object]:
+    retained = {
+        "reference_id",
+        "direction",
+        "from_object_id",
+        "to_object_id",
+        "relationship_type",
+        "relationship_interpretation",
+        "extraction_method",
+        "exact_value",
+        "supporting_observation_id",
+        "from_endpoint",
+        "to_endpoint",
+        "object_id",
+        "candidate_id",
+        "contribution_id",
+        "role",
+        "basis",
+        "status",
+        "evidence_state",
+        "citations",
+        "citations_truncated",
+        "limitations",
+    }
+    result = {key: value for key, value in item.items() if key in retained}
+    for key, value in tuple(result.items()):
+        if isinstance(value, str) and key not in {
+            "reference_id",
+            "from_object_id",
+            "to_object_id",
+            "object_id",
+            "candidate_id",
+            "contribution_id",
+        }:
+            result[key] = value[:192]
+            if len(value) > 192:
+                result[f"{key}_truncated"] = True
     result["item_compacted"] = True
     return result
 
@@ -175,6 +228,117 @@ def admit_page(
         result = trial
         if len(items) == limit:
             break
+    return result if serialized_size(result) <= MAX_RESPONSE_CHARS else _error(result)
+
+
+def _unrequested_context_stream() -> dict[str, object]:
+    return {"requested": False, "items": [], "next_cursor": None, "complete": None}
+
+
+def admit_context(
+    envelope: dict[str, object],
+    *,
+    relation_rows: Iterable[ScannedRow] | None,
+    membership_rows: Iterable[ScannedRow] | None,
+    limit: int,
+    relation_initial: dict[str, str] | None,
+    membership_initial: dict[str, str] | None,
+    relation_cursor: CursorFactory,
+    membership_cursor: CursorFactory,
+) -> dict[str, object]:
+    """Round-robin two independent streams without advancing an unsent item."""
+    result = _clean(envelope)
+    streams: dict[str, dict[str, object]] = {
+        "relations": _unrequested_context_stream(),
+        "memberships": _unrequested_context_stream(),
+    }
+    sources = {
+        "relations": (
+            iter(relation_rows) if relation_rows is not None else None,
+            relation_initial,
+            relation_cursor,
+        ),
+        "memberships": (
+            iter(membership_rows) if membership_rows is not None else None,
+            membership_initial,
+            membership_cursor,
+        ),
+    }
+    for name, (rows, initial, factory) in sources.items():
+        if rows is not None:
+            streams[name] = {
+                "requested": True,
+                "items": [],
+                "next_cursor": factory(initial or {"phase": "start", "key": "-"}),
+                "complete": False,
+            }
+    result.update(streams)
+    # Cursor reservation keeps a blocked stream restartable after the other advances.
+    if serialized_size(result) + 4096 > MAX_RESPONSE_CHARS:
+        result = _small_envelope(result)
+        result.update(streams)
+    accepted: dict[str, dict[str, str] | None] = {
+        "relations": relation_initial,
+        "memberships": membership_initial,
+    }
+    exhausted = {name: rows is None for name, (rows, _, _) in sources.items()}
+    seen = {"relations": False, "memberships": False}
+    while sum(len(cast(list[object], streams[name]["items"])) for name in streams) < 20:
+        moved = False
+        for name in ("relations", "memberships"):
+            rows, _, factory = sources[name]
+            if (
+                rows is None
+                or exhausted[name]
+                or len(cast(list[object], streams[name]["items"])) >= limit
+            ):
+                continue
+            try:
+                position, raw, has_more = next(rows)
+            except StopIteration:
+                exhausted[name] = True
+                if not seen[name] or streams[name]["next_cursor"] is None:
+                    streams[name]["complete"] = True
+                    streams[name]["next_cursor"] = None
+                continue
+            moved = True
+            seen[name] = True
+            if raw is None:
+                accepted[name] = position
+                streams[name]["next_cursor"] = factory(position) if has_more else None
+                streams[name]["complete"] = not has_more
+                continue
+            item = _clean(raw)
+            next_cursor = factory(position) if has_more else None
+            trial = dict(result)
+            trial_streams = dict(streams)
+            trial_stream = dict(streams[name])
+            trial_stream["items"] = [*cast(list[object], trial_stream["items"]), item]
+            trial_stream["next_cursor"] = next_cursor
+            trial_stream["complete"] = not has_more
+            trial_streams[name] = trial_stream
+            trial.update(trial_streams)
+            if serialized_size(trial) > MAX_RESPONSE_CHARS:
+                compact = _minimal_context_item(item)
+                trial_stream["items"] = [*cast(list[object], streams[name]["items"]), compact]
+                if serialized_size(trial) > MAX_RESPONSE_CHARS:
+                    # Do not consume this row: the old cursor remains intact.
+                    exhausted[name] = True
+                    continue
+            streams[name] = trial_stream
+            result = trial
+            accepted[name] = position
+        if not moved:
+            break
+    for name, (rows, _, factory) in sources.items():
+        if rows is not None and streams[name]["complete"] is False:
+            accepted_position = accepted[name]
+            streams[name]["next_cursor"] = (
+                factory(accepted_position)
+                if accepted_position is not None
+                else streams[name]["next_cursor"]
+            )
+    result.update(streams)
     return result if serialized_size(result) <= MAX_RESPONSE_CHARS else _error(result)
 
 

--- a/src/worktrace/mcp_server/server.py
+++ b/src/worktrace/mcp_server/server.py
@@ -155,6 +155,26 @@ def build_mcp_server(
             expected_view_token=expected_view_token,
         )
 
+    @server.tool(annotations=_READ_ONLY_ANNOTATIONS, structured_output=True)
+    def get_evidence_context(
+        app_id: str,
+        object_id: str,
+        relation_cursor: str | None = None,
+        membership_cursor: str | None = None,
+        limit: int = 10,
+        expected_view_token: str | None = None,
+    ) -> dict[str, object]:
+        """Explain one source object's bounded references and effective memberships."""
+
+        return service.get_evidence_context(
+            app_id=app_id,
+            object_id=object_id,
+            relation_cursor=relation_cursor,
+            membership_cursor=membership_cursor,
+            limit=limit,
+            expected_view_token=expected_view_token,
+        )
+
     return server
 
 

--- a/src/worktrace/mcp_server/tools.py
+++ b/src/worktrace/mcp_server/tools.py
@@ -24,7 +24,7 @@ from worktrace.mcp_server.protocol import (
     fingerprint,
     view_token,
 )
-from worktrace.mcp_server.responses import admit_page, bounded_response, shape_packet
+from worktrace.mcp_server.responses import admit_context, admit_page, bounded_response, shape_packet
 from worktrace.mcp_server.schemas import app_id as validate_app_id
 from worktrace.mcp_server.schemas import (
     bounded_limit,
@@ -38,6 +38,12 @@ from worktrace.mcp_server.schemas import source_types as validate_source_types
 from worktrace.packets.builder import PacketBuilder
 from worktrace.packets.schema import PHASE4_QUESTIONS
 from worktrace.read_models.agent_pages import scan_candidates, scan_evidence
+from worktrace.read_models.evidence_context import (
+    context_readiness,
+    describe_object,
+    scan_memberships,
+    scan_relations,
+)
 
 
 def _protocol_result[**P](
@@ -69,7 +75,7 @@ def _ascii_lower(value: str | None) -> str | None:
 
 
 class WorkTraceTools:
-    """Six SQLite-only operations with short snapshots and bound continuations."""
+    """Seven SQLite-only operations with short snapshots and bound continuations."""
 
     def __init__(
         self,
@@ -350,6 +356,116 @@ class WorkTraceTools:
                     view=view,
                     filters=filters,
                     position=p,
+                ),
+            )
+
+    @_protocol_result
+    def get_evidence_context(
+        self,
+        *,
+        app_id: str,
+        object_id: str,
+        relation_cursor: str | None = None,
+        membership_cursor: str | None = None,
+        limit: int = 10,
+        expected_view_token: str | None = None,
+    ) -> dict[str, object]:
+        app_id, object_id, limit = (
+            validate_app_id(app_id),
+            stable_id(object_id, "object_id"),
+            bounded_limit(limit),
+        )
+        if len(object_id) > 256:
+            raise ScopeViolation("object_id is limited to 256 characters")
+        object_binding = fingerprint({"app_id": app_id, "object_id": object_id})
+        filters = fingerprint({"object_id": object_id})
+        with self._builder() as builder:
+            object_description = describe_object(builder, app_id, object_id)
+            meta = self._metadata(builder, app_id, expected_view_token)
+            view = str(meta["view_token"])
+            relation = decode_cursor(
+                relation_cursor,
+                collection="context_relations",
+                app_id=app_id,
+                view=view,
+                filters=filters,
+                object_fingerprint=object_binding,
+            )
+            membership = decode_cursor(
+                membership_cursor,
+                collection="context_memberships",
+                app_id=app_id,
+                view=view,
+                filters=filters,
+                object_fingerprint=object_binding,
+            )
+            relation_position = cast(dict[str, str], relation["position"]) if relation else None
+            membership_position = (
+                cast(dict[str, str], membership["position"]) if membership else None
+            )
+            relation_rows = (
+                scan_relations(
+                    builder,
+                    app_id,
+                    object_id,
+                    after=(
+                        relation_position["key"]
+                        if relation_position and relation_position["phase"] == "after"
+                        else None
+                    ),
+                )
+                if relation is not None or membership is None
+                else None
+            )
+            if membership is not None or relation is None:
+                generation, membership_rows = scan_memberships(
+                    builder,
+                    app_id,
+                    object_id,
+                    after=(
+                        membership_position["key"]
+                        if membership_position and membership_position["phase"] == "after"
+                        else None
+                    ),
+                )
+            else:
+                generation, membership_rows = None, None
+            if membership is not None and membership["generation"] != generation:
+                raise ProtocolError(
+                    "evidence_changed",
+                    "Membership generation changed; restart the investigation.",
+                    view_token=view,
+                )
+
+            def cursor(
+                collection: str,
+                position: dict[str, str] | None,
+                generation_token: str | None = None,
+            ) -> str:
+                return encode_cursor(
+                    collection=collection,
+                    app_id=app_id,
+                    view=view,
+                    filters=filters,
+                    object_fingerprint=object_binding,
+                    generation=generation_token,
+                    position=position or {"phase": "start", "key": "-"},
+                )
+
+            return admit_context(
+                {
+                    **self._page_envelope(builder, meta, None, None),
+                    "object": object_description,
+                    "context_readiness": context_readiness(builder, app_id),
+                },
+                relation_rows=relation_rows,
+                membership_rows=membership_rows,
+                limit=limit,
+                relation_initial=relation_position,
+                membership_initial=membership_position,
+                relation_cursor=lambda position: cursor("context_relations", position),
+                membership_cursor=lambda position: cursor(
+                    "context_memberships", position, generation
                 ),
             )
 

--- a/src/worktrace/packets/builder.py
+++ b/src/worktrace/packets/builder.py
@@ -360,7 +360,14 @@ class PacketBuilder:
             title_source_object_id=projected.metadata_source_object_id,
         )
 
-    def _resolve_contribution(self, identifier: str) -> ContributionView:
+    def resolve_contribution(self, identifier: str) -> ContributionView:
+        """Return the canonical effective contribution view for an identifier.
+
+        This is the supported read interface for consumers which need the
+        decision-projected material and context membership sets.  In
+        particular, callers must not replay decision events or substitute
+        generated candidate membership for this result.
+        """
         lineage = (
             self._decision_projection.resolve_lineage(identifier)
             if self._decision_projection is not None
@@ -516,6 +523,11 @@ class PacketBuilder:
                 )
         self._app(state.app_id)
         return state
+
+    def _resolve_contribution(self, identifier: str) -> ContributionView:
+        """Compatibility alias for pre-context internal callers."""
+
+        return self.resolve_contribution(identifier)
 
     def _record_for_object(self, object_id: str, context_only: bool) -> EvidenceRecord | None:
         if self._authority_context is not None:
@@ -2089,13 +2101,51 @@ class PacketBuilder:
         reference = self.connection.execute(
             f"""
             WITH {authoritative_current_reference_ctes()}
-            SELECT * FROM authoritative_current_references WHERE id=?
+            SELECT reference.*, from_object.source AS from_source,
+                   from_object.source_instance AS from_source_instance,
+                   from_object.kind AS from_kind,
+                   from_object.external_id AS from_external_id,
+                   to_object.source AS to_source,
+                   to_object.source_instance AS to_source_instance,
+                   to_object.kind AS to_kind,
+                   to_object.external_id AS to_external_id
+            FROM authoritative_current_references reference
+            JOIN source_objects from_object ON from_object.id=reference.from_object_id
+            JOIN source_objects to_object ON to_object.id=reference.to_object_id
+            WHERE reference.id=?
             """,
             (evidence_id,),
         ).fetchone()
         if reference is not None:
+            reference_fields = dict(reference)
             app_id = str(reference["app_id"])
             self._app(app_id)
+            if str(reference["relationship_type"]) == "mapped_commit_sha":
+                try:
+                    from worktrace.linking.mappings import reference_mapping_allowed
+                except ImportError:
+                    raise NotFound(f"evidence not found: {evidence_id}") from None
+                if not reference_mapping_allowed(
+                    self.config.app(app_id),
+                    reference_fields,
+                    {
+                        "id": reference["from_object_id"],
+                        "app_id": app_id,
+                        "source": reference["from_source"],
+                        "source_instance": reference["from_source_instance"],
+                        "kind": reference["from_kind"],
+                        "external_id": reference["from_external_id"],
+                    },
+                    {
+                        "id": reference["to_object_id"],
+                        "app_id": app_id,
+                        "source": reference["to_source"],
+                        "source_instance": reference["to_source_instance"],
+                        "kind": reference["to_kind"],
+                        "external_id": reference["to_external_id"],
+                    },
+                ):
+                    raise NotFound(f"evidence not found: {evidence_id}")
             return {
                 "evidence_id": evidence_id,
                 "app_id": app_id,

--- a/src/worktrace/read_models/evidence_context.py
+++ b/src/worktrace/read_models/evidence_context.py
@@ -448,9 +448,7 @@ def _endpoint(row: sqlite3.Row, prefix: str, object_id: str) -> dict[str, object
     }
 
 
-def _reference_is_allowed(
-    app: AppConfig, connection: sqlite3.Connection, row: sqlite3.Row
-) -> bool:
+def _reference_is_allowed(app: AppConfig, connection: sqlite3.Connection, row: sqlite3.Row) -> bool:
     if not _object_in_scope(
         app,
         connection=connection,

--- a/src/worktrace/read_models/evidence_context.py
+++ b/src/worktrace/read_models/evidence_context.py
@@ -54,27 +54,69 @@ def _source_instances(app: AppConfig, source: str) -> frozenset[str]:
     return frozenset()
 
 
-def _metadata_identifiers(external_id: str, metadata: Mapping[str, object]) -> set[str]:
-    result = {external_id}
-    for key in (
-        "key",
-        "issue_key",
-        "project_key",
-        "parent_key",
-        "parent_issue_key",
-        "parent_identifier",
-    ):
-        value = metadata.get(key)
-        if isinstance(value, str) and value:
-            result.add(value)
-    return result
+_JIRA_ROOT_KINDS = frozenset({"jira_issue"})
+_JIRA_SUBRESOURCE_KINDS = frozenset(
+    {"issue_comment", "issue_changelog", "jira_comment", "jira_changelog"}
+)
+
+
+def _configured_jira_issue_key(app: AppConfig, value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and bool(_JIRA_ISSUE_KEY.fullmatch(value.upper()))
+        and app.allows_jira_key(value.upper())
+    )
+
+
+def _jira_root_in_scope(app: AppConfig, external_id: str, metadata: Mapping[str, object]) -> bool:
+    """Validate a root issue from its own identity, never its parent metadata."""
+
+    key = metadata.get("key")
+    if key is not None:
+        return _configured_jira_issue_key(app, key)
+    issue_key = metadata.get("issue_key")
+    if issue_key is not None:
+        return _configured_jira_issue_key(app, issue_key)
+    # Some older normalized root records kept only the textual Jira key as the
+    # external identifier.  Numeric Jira IDs cannot establish project scope.
+    return _configured_jira_issue_key(app, external_id)
+
+
+def _jira_parent_binding_in_scope(
+    connection: sqlite3.Connection,
+    app: AppConfig,
+    *,
+    source_instance: str,
+    issue_id: object,
+) -> bool:
+    if not isinstance(issue_id, str) or not issue_id:
+        return False
+    row = connection.execute(
+        f"""
+        WITH {authoritative_current_observation_ctes()}
+        SELECT parent.external_id,
+               {_scope_metadata_json("current", "parent")} AS metadata_json
+        FROM source_objects parent
+        LEFT JOIN authoritative_current_observations current
+          ON current.source_object_id=parent.id
+        WHERE parent.app_id=? AND parent.source='jira'
+          AND parent.source_instance=? AND parent.kind='jira_issue'
+          AND parent.external_id=?
+        """,
+        (app.id, source_instance, issue_id),
+    ).fetchone()
+    return row is not None and _jira_root_in_scope(
+        app, str(row["external_id"]), _json_object(row["metadata_json"])
+    )
 
 
 def _object_in_scope(
     app: AppConfig,
     *,
+    connection: sqlite3.Connection,
     source: str,
     source_instance: str,
+    kind: str,
     external_id: str,
     metadata_json: object,
 ) -> bool:
@@ -99,12 +141,20 @@ def _object_in_scope(
             return int(project_id) in app.gitlab_project_ids
         return False
     if source == "jira":
-        # A comment/changelog/subresource can be scoped by an exact parent
-        # issue key.  Never infer scope from a URL or a substring.
-        return any(
-            bool(_JIRA_ISSUE_KEY.fullmatch(identifier.upper()))
-            and app.allows_jira_key(identifier.upper())
-            for identifier in _metadata_identifiers(external_id, metadata)
+        if kind in _JIRA_ROOT_KINDS:
+            return _jira_root_in_scope(app, external_id, metadata)
+        if kind not in _JIRA_SUBRESOURCE_KINDS:
+            return False
+        owning_key = metadata.get("issue_key")
+        if owning_key is not None:
+            return _configured_jira_issue_key(app, owning_key)
+        # A parent key is only a fallback for an actual Jira subresource with
+        # no own issue identity and an exact stored parent-object binding.
+        return _jira_parent_binding_in_scope(
+            connection,
+            app,
+            source_instance=source_instance,
+            issue_id=metadata.get("issue_id"),
         )
     return False
 
@@ -138,6 +188,7 @@ def _scope_metadata_json(current_alias: str, object_alias: str) -> str:
         "parent_key",
         "parent_issue_key",
         "parent_identifier",
+        "issue_id",
         "project_id",
     )
     current_fields = ", ".join(
@@ -216,8 +267,10 @@ def describe_object(builder: PacketBuilder, app_id: str, object_id: str) -> dict
         raise NotFound("source object not found")
     if not _object_in_scope(
         app,
+        connection=builder.connection,
         source=str(row["source"]),
         source_instance=str(row["source_instance"]),
+        kind=str(row["kind"]),
         external_id=str(row["external_id"]),
         metadata_json=row["metadata_json"],
     ):
@@ -395,17 +448,23 @@ def _endpoint(row: sqlite3.Row, prefix: str, object_id: str) -> dict[str, object
     }
 
 
-def _reference_is_allowed(app: AppConfig, row: sqlite3.Row) -> bool:
+def _reference_is_allowed(
+    app: AppConfig, connection: sqlite3.Connection, row: sqlite3.Row
+) -> bool:
     if not _object_in_scope(
         app,
+        connection=connection,
         source=str(row["from_source"]),
         source_instance=str(row["from_source_instance"]),
+        kind=str(row["from_kind"]),
         external_id=str(row["from_external_id"]),
         metadata_json=row["from_metadata_json"],
     ) or not _object_in_scope(
         app,
+        connection=connection,
         source=str(row["to_source"]),
         source_instance=str(row["to_source_instance"]),
+        kind=str(row["to_kind"]),
         external_id=str(row["to_external_id"]),
         metadata_json=row["to_metadata_json"],
     ):
@@ -488,7 +547,7 @@ def scan_relations(
     )
 
     def project(row: sqlite3.Row) -> dict[str, object] | None:
-        if not _reference_is_allowed(app, row):
+        if not _reference_is_allowed(app, builder.connection, row):
             return None
         from_id, to_id = str(row["from_object_id"]), str(row["to_object_id"])
         relationship_type = str(row["relationship_type"])

--- a/src/worktrace/read_models/evidence_context.py
+++ b/src/worktrace/read_models/evidence_context.py
@@ -1,0 +1,678 @@
+"""Bounded, canonical context rows for one configured source object.
+
+This module deliberately stops before MCP cursor serialization and response
+budget admission.  Its streams retain excluded positions so the transport can
+advance a continuation only after an excluded or delivered row.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from typing import cast
+
+from worktrace.candidates.builder import GENERATOR_VERSION
+from worktrace.candidates.decisions import CREATION_ACTIONS, snapshot_member_ids
+from worktrace.config import AppConfig
+from worktrace.db.authority import (
+    authoritative_availability_event_ctes,
+    authoritative_current_observation_ctes,
+    authoritative_current_reference_ctes,
+    authoritative_run_sql,
+)
+from worktrace.db.repository import source_instance_id
+from worktrace.errors import NotFound, ScopeViolation
+from worktrace.packets.builder import PacketBuilder
+from worktrace.read_models.candidates import _active_generation
+
+MAX_CONTEXT_SCAN_BUDGET = 200
+type ScannedRow = tuple[dict[str, str], dict[str, object] | None, bool]
+_JIRA_ISSUE_KEY = re.compile(r"^[A-Z][A-Z0-9_]*-[1-9][0-9]*$")
+
+
+def _json_object(value: object) -> dict[str, object]:
+    if not isinstance(value, str):
+        return {}
+    try:
+        parsed = json.loads(value)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return dict(parsed) if isinstance(parsed, dict) else {}
+
+
+def _source_instances(app: AppConfig, source: str) -> frozenset[str]:
+    if source == "git":
+        return frozenset(source_instance_id(app.id, "git", path) for path in app.repo_paths)
+    if source == "gitlab":
+        return frozenset(
+            source_instance_id(app.id, "gitlab", project_id)
+            for project_id in app.gitlab_project_ids
+        )
+    return frozenset()
+
+
+def _metadata_identifiers(external_id: str, metadata: Mapping[str, object]) -> set[str]:
+    result = {external_id}
+    for key in (
+        "key",
+        "issue_key",
+        "project_key",
+        "parent_key",
+        "parent_issue_key",
+        "parent_identifier",
+    ):
+        value = metadata.get(key)
+        if isinstance(value, str) and value:
+            result.add(value)
+    return result
+
+
+def _object_in_scope(
+    app: AppConfig,
+    *,
+    source: str,
+    source_instance: str,
+    external_id: str,
+    metadata_json: object,
+) -> bool:
+    """Validate configured source scope without following source-controlled URLs."""
+
+    metadata = _json_object(metadata_json)
+    if source == "manual":
+        return True
+    if source == "git":
+        return source_instance in _source_instances(app, source)
+    if source == "gitlab":
+        if source_instance not in _source_instances(app, source):
+            return False
+        project_id = metadata.get("project_id")
+        if project_id is None:
+            return True
+        if isinstance(project_id, bool):
+            return False
+        if isinstance(project_id, int):
+            return project_id in app.gitlab_project_ids
+        if isinstance(project_id, str) and project_id.isascii() and project_id.isdecimal():
+            return int(project_id) in app.gitlab_project_ids
+        return False
+    if source == "jira":
+        # A comment/changelog/subresource can be scoped by an exact parent
+        # issue key.  Never infer scope from a URL or a substring.
+        return any(
+            bool(_JIRA_ISSUE_KEY.fullmatch(identifier.upper()))
+            and app.allows_jira_key(identifier.upper())
+            for identifier in _metadata_identifiers(external_id, metadata)
+        )
+    return False
+
+
+def _availability(row: Mapping[str, object], prefix: str = "") -> dict[str, object]:
+    event_id = row[f"{prefix}availability_event_id"]
+    return {
+        "state": str(row[f"{prefix}availability"]) if event_id is not None else "unknown",
+        "current": event_id is not None,
+        "evidence_id": str(event_id) if event_id is not None else None,
+        "reason": (
+            str(row[f"{prefix}availability_reason"])
+            if event_id is not None and row[f"{prefix}availability_reason"] is not None
+            else None
+        ),
+        "observed_at": (
+            str(row[f"{prefix}availability_observed_at"])
+            if event_id is not None and row[f"{prefix}availability_observed_at"] is not None
+            else None
+        ),
+    }
+
+
+def _scope_metadata_json(current_alias: str, object_alias: str) -> str:
+    """Select only scope keys from authoritative-origin metadata, never a body."""
+
+    fields = (
+        "key",
+        "issue_key",
+        "project_key",
+        "parent_key",
+        "parent_issue_key",
+        "parent_identifier",
+        "project_id",
+    )
+    current_fields = ", ".join(
+        f"'{field}', json_extract({current_alias}.data_json, '$.{field}')" for field in fields
+    )
+    historical_fields = ", ".join(
+        f"'{field}', json_extract(historical.data_json, '$.{field}')" for field in fields
+    )
+    return f"""
+        CASE WHEN {current_alias}.id IS NOT NULL
+             THEN json_object({current_fields})
+             ELSE (
+                 SELECT json_object({historical_fields})
+                 FROM observations historical
+                 JOIN sync_runs historical_run ON historical_run.id=historical.sync_run_id
+                 WHERE historical.source_object_id={object_alias}.id
+                   AND historical_run.app_id={object_alias}.app_id
+                   AND historical_run.source={object_alias}.source
+                   AND historical_run.source_instance={object_alias}.source_instance
+                   AND {authoritative_run_sql("historical_run")}
+                 ORDER BY historical.fetched_at DESC, historical.id DESC
+                 LIMIT 1
+             )
+        END
+    """
+
+
+def _object_metadata_row(
+    builder: PacketBuilder,
+    app_id: str,
+    object_id: str,
+) -> sqlite3.Row | None:
+    return cast(
+        sqlite3.Row | None,
+        builder.connection.execute(
+            f"""
+        WITH {authoritative_current_observation_ctes()},
+             {authoritative_availability_event_ctes()}
+        SELECT object.id AS object_id, object.app_id, object.source,
+               object.source_instance, object.kind, object.external_id,
+               object.availability, object.availability_reason,
+               object.availability_observed_at,
+               current.id AS current_observation_id,
+               event.id AS availability_event_id,
+               {_scope_metadata_json("current", "object")} AS metadata_json
+        FROM source_objects object
+        LEFT JOIN authoritative_current_observations current
+          ON current.source_object_id=object.id
+        LEFT JOIN authoritative_current_availability_events event
+          ON event.source_object_id=object.id
+        WHERE object.id=? AND object.app_id=?
+        """,
+            (object_id, app_id),
+        ).fetchone(),
+    )
+
+
+def describe_object(builder: PacketBuilder, app_id: str, object_id: str) -> dict[str, object]:
+    """Return bounded identity/currentness metadata for one configured object.
+
+    This intentionally requires a stored ``source_objects`` identifier.  An
+    observation, reference, decision, participation, or candidate identifier
+    cannot be translated into a source object here.
+    """
+
+    app = builder.config.app(app_id)
+    if not isinstance(object_id, str) or not object_id.startswith("obj:"):
+        raise ScopeViolation("object_id must be a source-object identifier")
+    row = _object_metadata_row(builder, app_id, object_id)
+    if row is None:
+        foreign = builder.connection.execute(
+            "SELECT 1 FROM source_objects WHERE id=?", (object_id,)
+        ).fetchone()
+        if foreign is not None:
+            raise ScopeViolation("object belongs to another configured application")
+        raise NotFound("source object not found")
+    if not _object_in_scope(
+        app,
+        source=str(row["source"]),
+        source_instance=str(row["source_instance"]),
+        external_id=str(row["external_id"]),
+        metadata_json=row["metadata_json"],
+    ):
+        raise ScopeViolation("source object is outside current configured source scope")
+    availability_row = {
+        "availability": row["availability"],
+        "availability_reason": row["availability_reason"],
+        "availability_observed_at": row["availability_observed_at"],
+        "availability_event_id": row["availability_event_id"],
+    }
+    return {
+        "app_id": app_id,
+        "object_id": str(row["object_id"]),
+        "source": str(row["source"]),
+        "kind": str(row["kind"]),
+        "external_id": str(row["external_id"]),
+        "current_observation_id": (
+            str(row["current_observation_id"])
+            if row["current_observation_id"] is not None
+            else None
+        ),
+        "availability": _availability(availability_row),
+        "limitations": (
+            []
+            if row["current_observation_id"] is not None
+            else [
+                "No authoritative current observation is available; historical metadata "
+                "establishes scope only."
+            ]
+        ),
+    }
+
+
+def _legacy_role_snapshot_limitations(builder: PacketBuilder, app_id: str) -> list[str]:
+    context = builder._decision_projection
+    if context is None:
+        # Building this projection is deliberate: contexts must use precisely
+        # the canonical decision stream that contribution resolution uses.
+        builder = builder.page_projection_builder(app_id)
+        context = builder._decision_projection
+    assert context is not None
+    for decision in context.active_decisions:
+        if context.decision_scopes.get(decision.id) != app_id:
+            continue
+        if decision.action in {"merge", "split", "merge_contributions", "split_contribution"} and (
+            "context_members" not in decision.payload
+        ):
+            return [
+                "A historical merge/split snapshot lacks context-role metadata; "
+                "human re-review is required before treating roles as complete."
+            ]
+    return []
+
+
+def context_readiness(builder: PacketBuilder, app_id: str) -> dict[str, object]:
+    """Return context-specific derived-state limitations without claiming coverage."""
+
+    builder.config.app(app_id)
+    rows = list(
+        builder.connection.execute(
+            "SELECT DISTINCT generator_version FROM candidate_groups WHERE app_id=?",
+            (app_id,),
+        )
+    )
+    versions = {str(row["generator_version"]) for row in rows}
+    requires_rebuild = bool(versions and versions != {GENERATOR_VERSION})
+    limitations: list[str] = []
+    if requires_rebuild:
+        limitations.append(
+            "Generated memberships use a legacy generator; run explicitly authorized "
+            "`rebuild all` before treating them as current."
+        )
+    limitations.extend(_legacy_role_snapshot_limitations(builder, app_id))
+    return {"requires_rebuild": requires_rebuild, "limitations": limitations}
+
+
+@dataclass(slots=True)
+class _LazyRows(Iterator[ScannedRow]):
+    rows: tuple[sqlite3.Row, ...]
+    has_more_after_last: bool
+    project: object
+    _index: int = 0
+
+    def __next__(self) -> ScannedRow:
+        if self._index >= len(self.rows):
+            raise StopIteration
+        row = self.rows[self._index]
+        self._index += 1
+        project = self.project
+        assert callable(project)
+        return (
+            {"phase": "after", "key": str(row["scan_key"])},
+            project(row),
+            self._index < len(self.rows) or self.has_more_after_last,
+        )
+
+
+def _relation_rows(
+    builder: PacketBuilder,
+    app_id: str,
+    object_id: str,
+    after: str,
+    limit: int,
+) -> list[sqlite3.Row]:
+    return list(
+        builder.connection.execute(
+            f"""
+            WITH {authoritative_current_reference_ctes()},
+                 {authoritative_availability_event_ctes()}
+            SELECT reference.id AS scan_key, reference.id AS reference_id,
+                   reference.from_object_id, reference.to_object_id,
+                   reference.relationship_type, reference.extraction_method,
+                   reference.exact_value, reference.supporting_observation_id,
+                   from_object.source AS from_source,
+                   from_object.source_instance AS from_source_instance,
+                   from_object.kind AS from_kind,
+                   from_object.external_id AS from_external_id,
+                   from_object.availability AS from_availability,
+                   from_object.availability_reason AS from_availability_reason,
+                   from_object.availability_observed_at AS from_availability_observed_at,
+                   from_current.id AS from_current_observation_id,
+                   from_event.id AS from_availability_event_id,
+                   {_scope_metadata_json("from_current", "from_object")} AS from_metadata_json,
+                   to_object.source AS to_source,
+                   to_object.source_instance AS to_source_instance,
+                   to_object.kind AS to_kind,
+                   to_object.external_id AS to_external_id,
+                   to_object.availability AS to_availability,
+                   to_object.availability_reason AS to_availability_reason,
+                   to_object.availability_observed_at AS to_availability_observed_at,
+                   to_current.id AS to_current_observation_id,
+                   to_event.id AS to_availability_event_id,
+                   {_scope_metadata_json("to_current", "to_object")} AS to_metadata_json
+            FROM authoritative_current_references reference
+            JOIN source_objects from_object ON from_object.id=reference.from_object_id
+            JOIN source_objects to_object ON to_object.id=reference.to_object_id
+            LEFT JOIN authoritative_current_observations from_current
+              ON from_current.source_object_id=from_object.id
+            LEFT JOIN authoritative_current_observations to_current
+              ON to_current.source_object_id=to_object.id
+            LEFT JOIN authoritative_current_availability_events from_event
+              ON from_event.source_object_id=from_object.id
+            LEFT JOIN authoritative_current_availability_events to_event
+              ON to_event.source_object_id=to_object.id
+            WHERE reference.app_id=?
+              AND (reference.from_object_id=? OR reference.to_object_id=?)
+              AND reference.id>?
+            ORDER BY reference.id
+            LIMIT ?
+            """,
+            (app_id, object_id, object_id, after, limit),
+        )
+    )
+
+
+def _has_relation_after(builder: PacketBuilder, app_id: str, object_id: str, after: str) -> bool:
+    return bool(_relation_rows(builder, app_id, object_id, after, 1))
+
+
+def _endpoint(row: sqlite3.Row, prefix: str, object_id: str) -> dict[str, object]:
+    availability_row = {
+        "availability": row[f"{prefix}availability"],
+        "availability_reason": row[f"{prefix}availability_reason"],
+        "availability_observed_at": row[f"{prefix}availability_observed_at"],
+        "availability_event_id": row[f"{prefix}availability_event_id"],
+    }
+    return {
+        "object_id": object_id,
+        "current_observation_id": (
+            str(row[f"{prefix}current_observation_id"])
+            if row[f"{prefix}current_observation_id"] is not None
+            else None
+        ),
+        "availability": _availability(availability_row),
+    }
+
+
+def _reference_is_allowed(app: AppConfig, row: sqlite3.Row) -> bool:
+    if not _object_in_scope(
+        app,
+        source=str(row["from_source"]),
+        source_instance=str(row["from_source_instance"]),
+        external_id=str(row["from_external_id"]),
+        metadata_json=row["from_metadata_json"],
+    ) or not _object_in_scope(
+        app,
+        source=str(row["to_source"]),
+        source_instance=str(row["to_source_instance"]),
+        external_id=str(row["to_external_id"]),
+        metadata_json=row["to_metadata_json"],
+    ):
+        return False
+    relationship_type = str(row["relationship_type"])
+    if relationship_type != "mapped_commit_sha":
+        # Every GitLab-to-local-Git SHA family predating the explicit mapping
+        # rule is historical derived state, not an admissible current link.
+        return not (row["from_source"] == "gitlab" and row["to_source"] == "git")
+    try:
+        from worktrace.linking.mappings import reference_mapping_allowed
+    except ImportError:
+        return False
+    return reference_mapping_allowed(
+        app,
+        dict(row),
+        {
+            "id": row["from_object_id"],
+            "app_id": app.id,
+            "source": row["from_source"],
+            "source_instance": row["from_source_instance"],
+            "kind": row["from_kind"],
+            "external_id": row["from_external_id"],
+        },
+        {
+            "id": row["to_object_id"],
+            "app_id": app.id,
+            "source": row["to_source"],
+            "source_instance": row["to_source_instance"],
+            "kind": row["to_kind"],
+            "external_id": row["to_external_id"],
+        },
+    )
+
+
+def _relationship_interpretation(relationship_type: str) -> str:
+    if relationship_type == "mapped_commit_sha":
+        return "explicitly_mapped_sha_reference"
+    if relationship_type.startswith("mentions_") or relationship_type in {
+        "contains_explicit_url",
+        "jira_links_to_issue",
+        "jira_hierarchy_context",
+    }:
+        return "textual_mention"
+    if relationship_type in {
+        "mr_contains_commit",
+        "commit_introduced_by_mr",
+        "mr_uses_source_branch",
+        "jira_subtask_of",
+        "git_reverts_commit",
+        "git_cherry_picks_commit",
+        "deployment_contains_sha",
+        "tag_points_to_commit",
+        "gitlab_mr_commit",
+        "gitlab_mr_discussion",
+        "gitlab_mr_changed_paths",
+        "jira_comment_issue",
+        "jira_changelog_issue",
+    }:
+        return "recorded_structural_relationship"
+    return "unspecified_recorded_relationship"
+
+
+def scan_relations(
+    builder: PacketBuilder,
+    app_id: str,
+    object_id: str,
+    *,
+    after: str | None = None,
+) -> Iterator[ScannedRow]:
+    """Yield up to 200 authoritative incoming/outgoing reference positions."""
+
+    describe_object(builder, app_id, object_id)
+    app = builder.config.app(app_id)
+    rows = _relation_rows(builder, app_id, object_id, after or "", MAX_CONTEXT_SCAN_BUDGET)
+    has_more = (
+        bool(rows)
+        and len(rows) == MAX_CONTEXT_SCAN_BUDGET
+        and _has_relation_after(builder, app_id, object_id, str(rows[-1]["reference_id"]))
+    )
+
+    def project(row: sqlite3.Row) -> dict[str, object] | None:
+        if not _reference_is_allowed(app, row):
+            return None
+        from_id, to_id = str(row["from_object_id"]), str(row["to_object_id"])
+        relationship_type = str(row["relationship_type"])
+        return {
+            "reference_id": str(row["reference_id"]),
+            "direction": "outgoing" if from_id == object_id else "incoming",
+            "from_object_id": from_id,
+            "to_object_id": to_id,
+            "relationship_type": relationship_type,
+            "relationship_interpretation": _relationship_interpretation(relationship_type),
+            "extraction_method": str(row["extraction_method"]),
+            "exact_value": str(row["exact_value"]) if row["exact_value"] is not None else None,
+            "supporting_observation_id": str(row["supporting_observation_id"]),
+            "from_endpoint": _endpoint(row, "from_", from_id),
+            "to_endpoint": _endpoint(row, "to_", to_id),
+            "limitations": [
+                "This relationship does not itself establish personal ownership, feature "
+                "identity, deployment, or impact."
+            ],
+        }
+
+    return _LazyRows(tuple(rows), has_more, project)
+
+
+def _decision_mentions_object(action: str, payload: Mapping[str, object], object_id: str) -> bool:
+    """Use only the canonical membership fields accepted for each action."""
+
+    if action in CREATION_ACTIONS or action in {"confirm", "merge", "split"}:
+        return object_id in snapshot_member_ids(payload)
+    if action in {"add_member", "remove_member", "mark_context_only"}:
+        return any(
+            payload.get(key) == object_id
+            for key in ("member_id", "source_object_id", "evidence_object_id")
+        )
+    return False
+
+
+def _membership_locator_ids(builder: PacketBuilder, app_id: str, object_id: str) -> set[str]:
+    result = {
+        str(row["candidate_id"])
+        for row in builder.connection.execute(
+            """
+            SELECT member.candidate_id
+            FROM candidate_members member
+            JOIN candidate_groups candidate ON candidate.id=member.candidate_id
+            WHERE candidate.app_id=? AND member.source_object_id=?
+            """,
+            (app_id, object_id),
+        )
+    }
+    context_builder = builder.page_projection_builder(app_id)
+    context = context_builder._decision_projection
+    assert context is not None
+    for decision in context.active_decisions:
+        if context.decision_scopes.get(decision.id) == app_id and _decision_mentions_object(
+            decision.action, decision.payload, object_id
+        ):
+            result.add(decision.target_id)
+    return result
+
+
+def _lineage_identity(
+    builder: PacketBuilder, app_id: str, identifier: str
+) -> tuple[str, str | None, str, bool]:
+    context_builder = builder.page_projection_builder(app_id)
+    context = context_builder._decision_projection
+    assert context is not None
+    lineage = context.resolve_lineage(identifier, app_id=app_id)
+    if lineage is None:
+        confirmed = any(
+            decision.target_id == identifier
+            and decision.action in {"confirm", "confirm_candidate"}
+            and context.decision_scopes.get(decision.id) == app_id
+            for decision in context.active_decisions
+        )
+        return identifier, None, identifier, confirmed
+    creation = next(
+        (
+            decision
+            for decision in reversed(lineage.decisions)
+            if decision.action in CREATION_ACTIONS
+            and isinstance(decision.payload.get("contribution_id"), str)
+            and bool(decision.payload["contribution_id"])
+        ),
+        None,
+    )
+    if creation is None:
+        return lineage.canonical_candidate_id, None, lineage.canonical_candidate_id, False
+    contribution_id = str(creation.payload["contribution_id"])
+    return contribution_id, contribution_id, lineage.canonical_candidate_id, True
+
+
+def scan_memberships(
+    builder: PacketBuilder,
+    app_id: str,
+    object_id: str,
+    *,
+    after: str | None = None,
+) -> tuple[str | None, Iterator[ScannedRow]]:
+    """Yield canonical effective membership groups, deduplicated before paging."""
+
+    describe_object(builder, app_id, object_id)
+    generation = _active_generation(builder.connection, app_id)
+    generation_token = generation.token if generation is not None else None
+    legacy_generated = generation is not None and generation.generator_version != GENERATOR_VERSION
+    context_builder = builder.page_projection_builder(app_id)
+    locator_ids = _membership_locator_ids(context_builder, app_id, object_id)
+    by_key: dict[str, tuple[str, str | None, str, bool]] = {}
+    for identifier in sorted(locator_ids):
+        try:
+            key, contribution_id, candidate_id, confirmed = _lineage_identity(
+                context_builder, app_id, identifier
+            )
+        except ScopeViolation:
+            continue
+        existing = by_key.get(key)
+        if existing is None or (confirmed and not existing[3]):
+            by_key[key] = (identifier, contribution_id, candidate_id, confirmed)
+
+    object_description = describe_object(context_builder, app_id, object_id)
+    object_has_current = object_description["current_observation_id"] is not None
+    entries = [(key, *value) for key, value in sorted(by_key.items()) if key > (after or "")][
+        :MAX_CONTEXT_SCAN_BUDGET
+    ]
+    has_more = len([key for key in by_key if key > (after or "")]) > len(entries)
+
+    class _MembershipRows(Iterator[ScannedRow]):
+        def __init__(self) -> None:
+            self.index = 0
+
+        def __next__(self) -> ScannedRow:
+            if self.index >= len(entries):
+                raise StopIteration
+            key, identifier, contribution_id, candidate_id, confirmed = entries[self.index]
+            self.index += 1
+            item: dict[str, object] | None = None
+            # Old generated rows are not newly validated by an upgrade.  A
+            # human-confirmed lineage remains inspectable despite that gap.
+            if not (legacy_generated and not confirmed):
+                try:
+                    contribution = context_builder.resolve_contribution(identifier)
+                except (NotFound, ScopeViolation):
+                    contribution = None
+                if contribution is not None:
+                    role = (
+                        "material"
+                        if object_id in contribution.member_ids
+                        else "context"
+                        if object_id in contribution.context_ids
+                        else None
+                    )
+                    if role is not None:
+                        citations = sorted(contribution.decision_evidence_ids) if confirmed else []
+                        if not citations and object_has_current:
+                            citations = [str(object_description["current_observation_id"])]
+                        raw_limitations = object_description["limitations"]
+                        limitations = (
+                            list(raw_limitations) if isinstance(raw_limitations, list) else []
+                        )
+                        if legacy_generated and confirmed:
+                            limitations.append(
+                                "Generated locator coverage is legacy; this row persists because "
+                                "a human-confirmed decision lineage remains effective."
+                            )
+                        item = {
+                            "object_id": object_id,
+                            "candidate_id": candidate_id,
+                            "contribution_id": contribution_id,
+                            "role": role,
+                            "basis": "confirmed" if confirmed else "suggestion",
+                            "status": "confirmed" if confirmed else "suggestion",
+                            "evidence_state": (
+                                "authoritative_current"
+                                if object_has_current
+                                else "current_evidence_unavailable"
+                            ),
+                            "citations": citations[:20],
+                            "citations_truncated": len(citations) > 20,
+                            "limitations": limitations,
+                        }
+            return (
+                {"phase": "after", "key": key},
+                item,
+                self.index < len(entries) or has_more,
+            )
+
+    return generation_token, _MembershipRows()

--- a/tests/test_acceptance_recovery.py
+++ b/tests/test_acceptance_recovery.py
@@ -481,12 +481,40 @@ def test_cli_git_only_journey_reaches_packet_gaps_and_mcp_entrypoint(
     assert sum(len(questions) for questions in packet_payload["sections"].values()) == 30
     assert isinstance(json.loads(gaps.stdout), dict)
 
+    ignored = runner.invoke(
+        app, ["ignore", candidate_id, "--reason", "fixture reason", "--config", str(config)]
+    )
+    assert ignored.exit_code == 0, ignored.stdout
+    rejected_ignored = runner.invoke(
+        app, ["split", candidate_id, object_id, "--config", str(config)]
+    )
+    assert rejected_ignored.exit_code != 0
+    restored_ignore = runner.invoke(
+        app, ["undo", json.loads(ignored.stdout)["decision_id"], "--config", str(config)]
+    )
+    assert restored_ignore.exit_code == 0, restored_ignore.stdout
+
     decision_commands = (
-        ["ignore", candidate_id, "--reason", "fixture reason", "--config", str(config)],
         ["rename", candidate_id, "Checkout contribution", "--config", str(config)],
         ["add-member", candidate_id, object_id, "--config", str(config)],
         ["remove-member", candidate_id, object_id, "--config", str(config)],
-        ["split", candidate_id, object_id, "--config", str(config)],
+    )
+    decision_ids: list[str] = []
+    for command in decision_commands:
+        result = runner.invoke(app, command)
+        assert result.exit_code == 0, f"{command}: {result.stdout} {result.stderr}"
+        decision_ids.append(json.loads(result.stdout)["decision_id"])
+    rejected_removed = runner.invoke(
+        app, ["split", candidate_id, object_id, "--config", str(config)]
+    )
+    assert rejected_removed.exit_code != 0
+    restored_remove = runner.invoke(app, ["undo", decision_ids[-1], "--config", str(config)])
+    assert restored_remove.exit_code == 0, restored_remove.stdout
+    split = runner.invoke(app, ["split", candidate_id, object_id, "--config", str(config)])
+    assert split.exit_code == 0, split.stdout
+    decision_ids.append(json.loads(split.stdout)["decision_id"])
+    attested = runner.invoke(
+        app,
         [
             "attest",
             contribution_id,
@@ -496,11 +524,8 @@ def test_cli_git_only_journey_reaches_packet_gaps_and_mcp_entrypoint(
             str(config),
         ],
     )
-    decision_ids: list[str] = []
-    for command in decision_commands:
-        result = runner.invoke(app, command)
-        assert result.exit_code == 0, f"{command}: {result.stdout} {result.stderr}"
-        decision_ids.append(json.loads(result.stdout)["decision_id"])
+    assert attested.exit_code == 0, attested.stdout
+    decision_ids.append(json.loads(attested.stdout)["decision_id"])
     undone = runner.invoke(app, ["undo", decision_ids[-1], "--config", str(config)])
     assert undone.exit_code == 0, undone.stdout
 
@@ -632,7 +657,7 @@ def test_import_all_uses_git_then_gitlab_then_jira_discovery(
 
 
 @pytest.mark.asyncio
-async def test_mcp_stdio_initializes_and_lists_exactly_six_read_only_tools(
+async def test_mcp_stdio_initializes_and_lists_exactly_seven_read_only_tools(
     tmp_path: Path,
 ) -> None:
     repository = tmp_path / "repository"
@@ -661,6 +686,7 @@ async def test_mcp_stdio_initializes_and_lists_exactly_six_read_only_tools(
         "list_evidence_gaps",
         "search_evidence",
         "get_evidence_excerpt",
+        "get_evidence_context",
     }
 
 

--- a/tests/test_cli_context_roles.py
+++ b/tests/test_cli_context_roles.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from worktrace.candidates.builder import rebuild_candidates
+from worktrace.cli import app
+from worktrace.config import load_config
+from worktrace.db.connection import connect
+from worktrace.db.repository import EvidenceRepository
+from worktrace.domain.enums import Completeness
+from worktrace.domain.models import (
+    ActorObservation,
+    NormalizedObject,
+    ParticipationObservation,
+    SourceIdentity,
+)
+from worktrace.packets.builder import PacketBuilder
+
+
+def _config(tmp_path: Path) -> Path:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        f"""schema_version = 1
+
+[data]
+directory = {str(tmp_path / "data")!r}
+
+[employment]
+from = "2024-01-01"
+to = "2026-08-26"
+
+[identity]
+display_name = "Fixture Engineer"
+git_author_emails = ["fixture@example.test"]
+git_author_names = ["Fixture Engineer"]
+
+[[apps]]
+id = "sample"
+name = "Sample"
+repo_paths = [{str(tmp_path / "repo")!r}]
+gitlab_project_ids = []
+jira_project_keys = []
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _object(sha: str) -> NormalizedObject:
+    actor = ActorObservation("git", "fixture-repository", "self", "Fixture", is_self=True)
+    return NormalizedObject(
+        identity=SourceIdentity("git", "fixture-repository", "git_commit", sha),
+        app_id="sample",
+        title=sha,
+        body_text="fixture",
+        source_updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        actors=(actor,),
+        participations=(ParticipationObservation("self", "git_author"),),
+        pending_references=(),
+        data={"sha": sha},
+        completeness=Completeness.COMPLETE,
+    )
+
+
+def test_cli_merge_split_undo_and_rebuild_preserve_context_roles(tmp_path: Path) -> None:
+    config_path = _config(tmp_path)
+    runner = CliRunner()
+    initialized = runner.invoke(app, ["init", "--config", str(config_path)])
+    assert initialized.exit_code == 0, initialized.output
+    configuration = load_config(config_path)
+    connection = connect(configuration.database_path)
+    try:
+        repository = EvidenceRepository(connection)
+        run = repository.start_sync_run("sample", "git", "fixture-repository", {"mode": "fixture"})
+        repository.store_page(run, [_object("a" * 40), _object("b" * 40), _object("c" * 40)])
+        repository.finish_sync_run(run, "complete", "complete_for_scope")
+        rebuild_candidates("sample", repository)
+        candidates = {
+            str(row["external_id"]): str(row["id"])
+            for row in connection.execute(
+                "SELECT candidate.id, object.external_id FROM candidate_groups candidate "
+                "JOIN source_objects object ON object.id=candidate.seed_object_id"
+            )
+        }
+        objects = {
+            str(row["external_id"]): str(row["id"])
+            for row in connection.execute("SELECT id, external_id FROM source_objects")
+        }
+        first, second, context_object = (
+            candidates["a" * 40],
+            candidates["b" * 40],
+            objects["c" * 40],
+        )
+        material_first, material_second = objects["a" * 40], objects["b" * 40]
+        # Add fixture context to the first generated suggestion without making it material.
+        connection.execute(
+            "INSERT OR REPLACE INTO candidate_members("
+            "candidate_id, source_object_id, membership_reason, context_only) "
+            "VALUES (?, ?, 'fixture_context', 1)",
+            (first, context_object),
+        )
+        connection.commit()
+        first_view = PacketBuilder(connection, configuration).resolve_contribution(first)
+        assert context_object in first_view.context_ids
+    finally:
+        connection.close()
+
+    merged = runner.invoke(app, ["merge", first, second, "--config", str(config_path)])
+    assert merged.exit_code == 0, merged.output
+    merge_result = json.loads(merged.output)
+    contribution_id = str(merge_result["contribution_id"])
+
+    connection = connect(configuration.database_path)
+    try:
+        payload = json.loads(
+            str(
+                connection.execute(
+                    "SELECT payload_json FROM human_decisions WHERE id=?",
+                    (merge_result["decision_id"],),
+                ).fetchone()[0]
+            )
+        )
+        assert payload["context_members"] == [context_object]
+        assert set(payload["members"]) == {material_first, material_second, context_object}
+    finally:
+        connection.close()
+
+    split = runner.invoke(
+        app,
+        ["split", contribution_id, material_second, context_object, "--config", str(config_path)],
+    )
+    assert split.exit_code == 0, split.output
+    split_result = json.loads(split.output)
+    connection = connect(configuration.database_path)
+    try:
+        split_payload = json.loads(
+            str(
+                connection.execute(
+                    "SELECT payload_json FROM human_decisions WHERE id=?",
+                    (split_result["decision_id"],),
+                ).fetchone()[0]
+            )
+        )
+        assert set(split_payload["members"]) == {material_second, context_object}
+        assert split_payload["context_members"] == [context_object]
+    finally:
+        connection.close()
+
+    undone = runner.invoke(
+        app, ["undo", str(split_result["decision_id"]), "--config", str(config_path)]
+    )
+    assert undone.exit_code == 0, undone.output
+    rebuilt = runner.invoke(app, ["rebuild", "candidates", "sample", "--config", str(config_path)])
+    assert rebuilt.exit_code == 0, rebuilt.output
+    connection = connect(configuration.database_path)
+    try:
+        view = PacketBuilder(connection, configuration).resolve_contribution(contribution_id)
+        assert view.member_ids == {material_first, material_second}
+        assert view.context_ids == {context_object}
+    finally:
+        connection.close()

--- a/tests/test_context_budget.py
+++ b/tests/test_context_budget.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import json
+
+from worktrace.constants import MAX_RESPONSE_CHARS
+from worktrace.mcp_server.responses import admit_context
+
+
+def _rows(name: str, count: int, *, excluded: bool = False, has_more_last: bool = False):
+    for index in range(count):
+        key = f"{name}:{index + 10}"
+        item = None if excluded else {"reference_id" if name == "ref" else "candidate_id": key}
+        yield ({"phase": "after", "key": key}, item, index + 1 < count or has_more_last)
+
+
+def _cursor(prefix: str):
+    return lambda position: f"wtc1:{prefix}:{position['key'] if position else '-'}"
+
+
+def _admit(relations, memberships, limit: int = 10):
+    return admit_context(
+        {"app_id": "sample_store", "view_token": "view:1:" + "a" * 64},
+        relation_rows=relations,
+        membership_rows=memberships,
+        limit=limit,
+        relation_initial=None,
+        membership_initial=None,
+        relation_cursor=_cursor("r"),
+        membership_cursor=_cursor("m"),
+    )
+
+
+def test_empty_requested_streams_are_successful_and_complete() -> None:
+    result = _admit([], [])
+    assert result["relations"] == {
+        "requested": True,
+        "items": [],
+        "next_cursor": None,
+        "complete": True,
+    }
+    assert result["memberships"] == {
+        "requested": True,
+        "items": [],
+        "next_cursor": None,
+        "complete": True,
+    }
+
+
+def test_initial_streams_get_start_cursors_and_each_limit_is_bounded() -> None:
+    result = _admit(_rows("ref", 20), _rows("candidate", 20), limit=1)
+    assert len(result["relations"]["items"]) == len(result["memberships"]["items"]) == 1
+    assert result["relations"]["next_cursor"].endswith("ref:10")
+    assert result["memberships"]["next_cursor"].endswith("candidate:10")
+
+
+def test_excluded_scan_rows_preserve_continuation_after_two_hundred_rows() -> None:
+    result = _admit(_rows("ref", 200, excluded=True, has_more_last=True), [], limit=20)
+    assert result["relations"]["items"] == []
+    assert result["relations"]["complete"] is False
+    assert result["relations"]["next_cursor"].endswith("ref:209")
+
+
+def test_combined_cap_is_twenty_even_when_each_stream_allows_twenty() -> None:
+    result = _admit(_rows("ref", 30), _rows("candidate", 30), limit=20)
+    assert len(result["relations"]["items"]) + len(result["memberships"]["items"]) == 20
+
+
+def test_context_compaction_preserves_required_relation_and_membership_fields() -> None:
+    relation = {
+        "reference_id": "ref:one",
+        "direction": "outgoing",
+        "from_object_id": "obj:a",
+        "to_object_id": "obj:b",
+        "relationship_type": "relates_to",
+        "exact_value": "x" * 40_000,
+        "from_endpoint": {"object_id": "obj:a"},
+        "to_endpoint": {"object_id": "obj:b"},
+    }
+    membership = {
+        "object_id": "obj:a",
+        "candidate_id": "candidate:one",
+        "role": "material",
+        "basis": "confirmed",
+        "status": "confirmed",
+        "citations": ["obs:one"],
+    }
+    result = _admit(
+        iter([({"phase": "after", "key": "ref:one"}, relation, False)]),
+        iter([({"phase": "after", "key": "candidate:one"}, membership, False)]),
+    )
+    assert {
+        "reference_id",
+        "from_object_id",
+        "to_object_id",
+        "relationship_type",
+        "from_endpoint",
+        "to_endpoint",
+    } <= set(result["relations"]["items"][0])
+    assert {"object_id", "candidate_id", "role", "basis", "status"} <= set(
+        result["memberships"]["items"][0]
+    )
+
+
+def test_unicode_budget_never_skips_eligible_row() -> None:
+    huge = {
+        "reference_id": "ref:unicode",
+        "exact_value": "é" * 19_000,
+        "relationship_type": "exact",
+    }
+    result = _admit(iter([({"phase": "after", "key": "ref:unicode"}, huge, True)]), [])
+    assert result["relations"]["items"][0]["reference_id"] == "ref:unicode"
+    assert result["relations"]["next_cursor"].endswith("ref:unicode")
+    assert len(json.dumps(result, ensure_ascii=True, separators=(",", ":"))) <= MAX_RESPONSE_CHARS

--- a/tests/test_context_protocol.py
+++ b/tests/test_context_protocol.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.test_mcp_security import _mcp_state
+from worktrace.errors import ScopeViolation
+from worktrace.mcp_server import tools as tool_module
+
+
+def _rows(prefix: str, count: int, *, excluded: bool = False):
+    for index in range(count):
+        key = f"{prefix}:{index + 10}"
+        item = None if excluded else {"reference_id" if prefix == "ref" else "candidate_id": key}
+        yield {"phase": "after", "key": key}, item, index + 1 < count
+
+
+def _install_streams(
+    monkeypatch: pytest.MonkeyPatch, *, relations, memberships, generation: str = "a" * 64
+) -> None:
+    monkeypatch.setattr(tool_module, "scan_relations", lambda *args, **kwargs: iter(relations))
+    monkeypatch.setattr(
+        tool_module, "scan_memberships", lambda *args, **kwargs: (generation, iter(memberships))
+    )
+
+
+def test_context_uses_source_object_ids_and_starts_both_streams(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, _, tools = _mcp_state(tmp_path)
+    _install_streams(
+        monkeypatch, relations=list(_rows("ref", 1)), memberships=list(_rows("candidate", 1))
+    )
+    result = tools.get_evidence_context(app_id="sample_store", object_id="obj:manual_1")
+    assert result["object"]["object_id"] == "obj:manual_1"
+    assert result["relations"]["requested"] is result["memberships"]["requested"] is True
+    with pytest.raises(ScopeViolation):
+        tools.get_evidence_context(app_id="sample_store", object_id="obs:manual_1")
+    with pytest.raises(ScopeViolation):
+        tools.get_evidence_context(app_id="other_app", object_id="obj:manual_1")
+
+
+def test_context_continuations_are_independent_and_bound(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, _, tools = _mcp_state(tmp_path)
+    _install_streams(
+        monkeypatch, relations=list(_rows("ref", 2)), memberships=list(_rows("candidate", 2))
+    )
+    first = tools.get_evidence_context(app_id="sample_store", object_id="obj:manual_1", limit=1)
+    continued = tools.get_evidence_context(
+        app_id="sample_store",
+        object_id="obj:manual_1",
+        relation_cursor=first["relations"]["next_cursor"],
+        expected_view_token=first["view_token"],
+    )
+    assert continued["relations"]["requested"] is True
+    assert continued["memberships"] == {
+        "requested": False,
+        "items": [],
+        "next_cursor": None,
+        "complete": None,
+    }
+    for cursor in (
+        first["relation_cursor"]
+        if "relation_cursor" in first
+        else first["relations"]["next_cursor"],
+        "offset:0",
+    ):
+        bad = tools.get_evidence_context(
+            app_id="sample_store", object_id="obj:manual_2", relation_cursor=cursor
+        )
+        assert "error" in bad
+
+
+def test_context_excluded_scan_and_confirmed_namespace_keep_cursor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, _, tools = _mcp_state(tmp_path)
+    excluded = list(_rows("ref", 200, excluded=True))
+    excluded[-1] = (excluded[-1][0], excluded[-1][1], True)
+    _install_streams(
+        monkeypatch,
+        relations=excluded,
+        memberships=[
+            (
+                {"phase": "after", "key": "contribution:confirmed_1"},
+                {"contribution_id": "contribution:confirmed_1", "role": "material"},
+                True,
+            )
+        ],
+    )
+    result = tools.get_evidence_context(app_id="sample_store", object_id="obj:manual_1")
+    assert result["relations"]["items"] == []
+    assert result["relations"]["next_cursor"]
+    assert result["memberships"]["next_cursor"]
+
+
+def test_context_stale_and_collection_cursors_fail_explicitly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _, _, tools = _mcp_state(tmp_path)
+    _install_streams(monkeypatch, relations=list(_rows("ref", 2)), memberships=[])
+    first = tools.get_evidence_context(app_id="sample_store", object_id="obj:manual_1", limit=1)
+    stale = tools.get_evidence_context(
+        app_id="sample_store", object_id="obj:manual_1", expected_view_token="view:1:" + "b" * 64
+    )
+    assert stale["error"]["code"] == "evidence_changed"
+    wrong_collection = tools.get_evidence_context(
+        app_id="sample_store",
+        object_id="obj:manual_1",
+        membership_cursor=first["relations"]["next_cursor"],
+    )
+    assert wrong_collection["error"]["code"] == "cursor_scope_mismatch"

--- a/tests/test_context_workflow.py
+++ b/tests/test_context_workflow.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from worktrace.cli import app
+from worktrace.mcp_server.tools import WorkTraceTools
+
+
+def _git(repository: Path, *arguments: str, environment: dict[str, str]) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repository), *arguments],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=environment,
+    )
+    return result.stdout.strip()
+
+
+def _config(tmp_path: Path, repository: Path) -> Path:
+    path = tmp_path / "config.toml"
+    path.write_text(
+        f"""schema_version = 1
+
+[data]
+directory = {str(tmp_path / "data")!r}
+
+[employment]
+from = "2026-01-01"
+to = "2026-12-31"
+
+[identity]
+display_name = "Fixture Engineer"
+git_author_emails = ["fixture@example.test"]
+git_author_names = ["Fixture Engineer"]
+
+[[apps]]
+id = "sample"
+name = "Sample"
+repo_paths = [{str(repository)!r}]
+gitlab_project_ids = []
+jira_project_keys = []
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_public_search_context_summary_then_cli_correction_workflow(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repository)], check=True)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "GIT_AUTHOR_NAME": "Fixture Engineer",
+            "GIT_AUTHOR_EMAIL": "fixture@example.test",
+            "GIT_COMMITTER_NAME": "Fixture Engineer",
+            "GIT_COMMITTER_EMAIL": "fixture@example.test",
+            "GIT_AUTHOR_DATE": "2026-04-01T12:00:00Z",
+            "GIT_COMMITTER_DATE": "2026-04-01T12:00:00Z",
+        }
+    )
+    (repository / "first.txt").write_text("first\n", encoding="utf-8")
+    _git(repository, "add", "first.txt", environment=environment)
+    _git(repository, "commit", "-m", "first implementation", environment=environment)
+    first_sha = _git(repository, "rev-parse", "HEAD", environment=environment)
+    (repository / "second.txt").write_text("second\n", encoding="utf-8")
+    _git(repository, "add", "second.txt", environment=environment)
+    _git(
+        repository,
+        "commit",
+        "-m",
+        f"second discovery references {first_sha}",
+        environment=environment,
+    )
+
+    config_path = _config(tmp_path, repository)
+    runner = CliRunner()
+    initialized = runner.invoke(app, ["init", "--config", str(config_path)])
+    assert initialized.exit_code == 0, initialized.output
+    imported = runner.invoke(app, ["import", "all", "sample", "--config", str(config_path)])
+    assert imported.exit_code == 0, imported.output
+    rebuilt = runner.invoke(app, ["rebuild", "all", "sample", "--config", str(config_path)])
+    assert rebuilt.exit_code == 0, rebuilt.output
+
+    tools = WorkTraceTools(config_path=config_path)
+    found = tools.search_evidence(app_id="sample", query="second discovery", limit=10)
+    assert "error" not in found
+    result = next(item for item in found["results"] if item["external_id"] != first_sha)
+    object_id = str(result["object_id"])
+    initial_token = str(found["view_token"])
+
+    context = tools.get_evidence_context(
+        app_id="sample", object_id=object_id, expected_view_token=initial_token
+    )
+    relation_items = context["relations"]["items"]
+    assert any(item["relationship_type"] == "mentions_commit_sha" for item in relation_items)
+    membership_items = context["memberships"]["items"]
+    assert membership_items and membership_items[0]["basis"] == "suggestion"
+    candidate_id = str(membership_items[0]["candidate_id"])
+    summary = tools.get_contribution_summary(
+        contribution_id=candidate_id, expected_view_token=str(context["view_token"])
+    )
+    assert summary["contribution"]["candidate_id"] == candidate_id
+
+    confirmed = runner.invoke(app, ["confirm", candidate_id, "--config", str(config_path)])
+    assert confirmed.exit_code == 0, confirmed.output
+    confirmed_context = tools.get_evidence_context(app_id="sample", object_id=object_id)
+    assert confirmed_context["view_token"] != context["view_token"]
+    assert any(
+        item["basis"] == "confirmed" and item["candidate_id"] == candidate_id
+        for item in confirmed_context["memberships"]["items"]
+    )
+
+    removed = runner.invoke(
+        app, ["remove-member", candidate_id, object_id, "--config", str(config_path)]
+    )
+    assert removed.exit_code == 0, removed.output
+    removed_context = tools.get_evidence_context(app_id="sample", object_id=object_id)
+    assert removed_context["view_token"] != confirmed_context["view_token"]
+    assert not any(
+        item["basis"] == "confirmed" and item["candidate_id"] == candidate_id
+        for item in removed_context["memberships"]["items"]
+    )
+
+    remove_decision_id = str(json.loads(removed.output)["decision_id"])
+    undone = runner.invoke(app, ["undo", remove_decision_id, "--config", str(config_path)])
+    assert undone.exit_code == 0, undone.output
+    restored = tools.get_evidence_context(app_id="sample", object_id=object_id)
+    assert restored["view_token"] != removed_context["view_token"]
+    assert any(
+        item["basis"] == "confirmed" and item["candidate_id"] == candidate_id
+        for item in restored["memberships"]["items"]
+    )

--- a/tests/test_docs_fixtures.py
+++ b/tests/test_docs_fixtures.py
@@ -16,6 +16,7 @@ MCP_TOOLS = {
     "list_evidence_gaps",
     "search_evidence",
     "get_evidence_excerpt",
+    "get_evidence_context",
 }
 
 

--- a/tests/test_evidence_context.py
+++ b/tests/test_evidence_context.py
@@ -223,11 +223,14 @@ def test_public_context_uses_jira_owning_identity_before_parent_metadata(
     assert {"ref:jira-out", "ref:jira-in", "ref:jira-fallback"} <= relation_ids
     # A foreign explicit issue_key and a missing parent binding both fail
     # closed even when source-controlled parent_key says DEMO-1.
-    assert not {
-        "ref:jira-conflict-out",
-        "ref:jira-conflict-in",
-        "ref:jira-missing",
-    } & relation_ids
+    assert (
+        not {
+            "ref:jira-conflict-out",
+            "ref:jira-conflict-in",
+            "ref:jira-missing",
+        }
+        & relation_ids
+    )
 
 
 def test_confirmed_rowless_context_membership_survives_legacy_generated_state(

--- a/tests/test_evidence_context.py
+++ b/tests/test_evidence_context.py
@@ -1,0 +1,429 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.test_mapped_references import _app, _object, _worktrace_config
+from tests.test_mcp_security import _mcp_state
+from worktrace.candidates.builder import GENERATOR_VERSION
+from worktrace.candidates.decisions import append_decision, undo_decision
+from worktrace.db.connection import connect
+from worktrace.db.migrations import migrate
+from worktrace.db.repository import EvidenceRepository, source_instance_id
+from worktrace.errors import ScopeViolation
+from worktrace.packets.builder import PacketBuilder
+from worktrace.read_models.evidence_context import (
+    _decision_mentions_object,
+    context_readiness,
+    describe_object,
+    scan_memberships,
+    scan_relations,
+)
+
+
+def test_context_requires_a_scoped_source_object_and_keeps_endpoint_availability_separate(
+    tmp_path: Path,
+) -> None:
+    database, _, tools = _mcp_state(tmp_path)
+    writer = connect(database)
+    try:
+        writer.execute(
+            """
+            INSERT INTO "references"(
+                id, app_id, from_object_id, to_object_id, relationship_type,
+                extraction_method, exact_value, supporting_observation_id, derived
+            ) VALUES (
+                'ref:manual-context', 'sample_store', 'obj:manual_1', 'obj:manual_2',
+                'mentions_jira_key', 'fixture', 'DEMO-1', 'obs:manual_1', 1
+            )
+            """
+        )
+        writer.commit()
+    finally:
+        writer.close()
+
+    with tools._builder() as builder:
+        described = describe_object(builder, "sample_store", "obj:manual_1")
+        assert described["current_observation_id"] == "obs:manual_1"
+        assert described["availability"]["state"] == "unknown"
+        with pytest.raises(ScopeViolation, match="source-object"):
+            describe_object(builder, "sample_store", "obs:manual_1")
+
+        rows = list(scan_relations(builder, "sample_store", "obj:manual_1"))
+        assert len(rows) == 1
+        _, relation, has_more = rows[0]
+        assert has_more is False
+        assert relation is not None
+        assert relation["direction"] == "outgoing"
+        assert relation["relationship_interpretation"] == "textual_mention"
+        assert relation["to_endpoint"] == {
+            "object_id": "obj:manual_2",
+            "current_observation_id": "obs:manual_2",
+            "availability": {
+                "state": "unknown",
+                "current": False,
+                "evidence_id": None,
+                "reason": None,
+                "observed_at": None,
+            },
+        }
+
+
+def test_confirmed_rowless_context_membership_survives_legacy_generated_state(
+    tmp_path: Path,
+) -> None:
+    database, _, tools = _mcp_state(tmp_path)
+    writer = connect(database)
+    try:
+        append_decision(
+            writer,
+            "confirm_candidate",
+            "candidate:manual_1",
+            {
+                "app_id": "sample_store",
+                "contribution_id": "contribution:manual-context",
+                "members": ["obj:manual_2"],
+                "context_members": ["obj:manual_1"],
+                "title": "Human-approved context",
+            },
+        )
+        writer.execute("DELETE FROM candidate_groups WHERE id='candidate:manual_1'")
+        writer.commit()
+    finally:
+        writer.close()
+
+    with tools._builder() as builder:
+        generation, rows = scan_memberships(builder, "sample_store", "obj:manual_1")
+        assert generation is not None
+        scanned = list(rows)
+
+    assert len(scanned) == 1
+    _, membership, has_more = scanned[0]
+    assert has_more is False
+    assert membership is not None
+    assert membership["contribution_id"] == "contribution:manual-context"
+    assert membership["role"] == "context"
+    assert membership["basis"] == "confirmed"
+    assert membership["evidence_state"] == "authoritative_current"
+
+
+def test_membership_locator_uses_accepted_fields_not_unrelated_decision_prose() -> None:
+    object_id = "obj:manual_1"
+    assert _decision_mentions_object(
+        "confirm_candidate",
+        {"members": [object_id], "context_members": []},
+        object_id,
+    )
+    assert _decision_mentions_object("add_member", {"source_object_id": object_id}, object_id)
+    assert not _decision_mentions_object(
+        "attest_claim",
+        {"statement": f"Please inspect {object_id}", "members": [object_id]},
+        object_id,
+    )
+
+
+def test_mapped_reference_excerpt_requires_and_accepts_live_explicit_mapping(
+    tmp_path: Path,
+) -> None:
+    repo_a, repo_b = (tmp_path / "repo-a").resolve(), (tmp_path / "repo-b").resolve()
+    app = _app(repo_a, repo_b, mapped=True)
+    config = _worktrace_config(app, tmp_path)
+    sha = "a" * 40
+    connection = connect(tmp_path / "ledger.sqlite3")
+    try:
+        migrate(connection, tmp_path / "ledger.sqlite3")
+        repository = EvidenceRepository(connection)
+        repository.ensure_apps(config)
+        git_instance = source_instance_id(app.id, "git", repo_a)
+        gitlab_instance = source_instance_id(app.id, "gitlab", 101)
+        git_run = repository.start_sync_run(app.id, "git", git_instance, {"mode": "fixture"})
+        repository.store_page(
+            git_run,
+            [_object("git", git_instance, "git_commit", sha)],
+        )
+        repository.finish_sync_run(git_run, "complete", "complete_for_scope")
+        gitlab_run = repository.start_sync_run(
+            app.id,
+            "gitlab",
+            gitlab_instance,
+            {"mode": "fixture", "selection_policy_version": 2},
+        )
+        repository.store_page(
+            gitlab_run,
+            [
+                _object(
+                    "gitlab",
+                    gitlab_instance,
+                    "gitlab_mr",
+                    "101:1",
+                    data={"project_id": "101"},
+                )
+            ],
+        )
+        repository.finish_sync_run(gitlab_run, "complete", "complete_for_scope")
+        source = connection.execute(
+            "SELECT id FROM source_objects WHERE source='gitlab'"
+        ).fetchone()
+        target = connection.execute("SELECT id FROM source_objects WHERE source='git'").fetchone()
+        observation = connection.execute(
+            "SELECT id FROM observations WHERE source_object_id=?", (str(source["id"]),)
+        ).fetchone()
+        connection.execute(
+            """
+            INSERT INTO "references"(
+                id, app_id, from_object_id, to_object_id, relationship_type,
+                extraction_method, exact_value, supporting_observation_id, derived
+            ) VALUES (?, ?, ?, ?, 'mapped_commit_sha',
+                      'explicit_repo_project_full_sha:commit_record', ?, ?, 1)
+            """,
+            ("ref:mapped", app.id, source["id"], target["id"], sha, observation["id"]),
+        )
+        connection.commit()
+
+        builder = PacketBuilder(connection, config)
+        excerpt = builder.evidence_excerpt("ref:mapped", 100)
+        assert excerpt["content_type"] == "typed_reference_evidence"
+        assert excerpt["relationship_type"] == "mapped_commit_sha"
+        relation_rows = list(scan_relations(builder, app.id, str(source["id"])))
+        assert relation_rows[0][1] is not None
+        assert relation_rows[0][1]["relationship_interpretation"] == (
+            "explicitly_mapped_sha_reference"
+        )
+    finally:
+        connection.close()
+
+
+def test_removed_rowless_member_returns_after_undo_without_replaying_decisions(
+    tmp_path: Path,
+) -> None:
+    database, _, tools = _mcp_state(tmp_path)
+    writer = connect(database)
+    try:
+        append_decision(
+            writer,
+            "confirm_candidate",
+            "candidate:manual_1",
+            {
+                "app_id": "sample_store",
+                "contribution_id": "contribution:rowless",
+                "members": ["obj:manual_1", "obj:manual_2"],
+            },
+        )
+        removed = append_decision(
+            writer,
+            "remove_member",
+            "candidate:manual_1",
+            {"source_object_id": "obj:manual_1"},
+        )
+        writer.execute("DELETE FROM candidate_groups WHERE id='candidate:manual_1'")
+        writer.commit()
+
+        with tools._builder() as builder:
+            assert list(scan_memberships(builder, "sample_store", "obj:manual_1")[1]) == [
+                ({"phase": "after", "key": "contribution:rowless"}, None, False)
+            ]
+
+        undo_decision(writer, removed)
+        with tools._builder() as builder:
+            restored = list(scan_memberships(builder, "sample_store", "obj:manual_1")[1])
+        assert restored[0][1] is not None
+        assert restored[0][1]["role"] == "material"
+    finally:
+        writer.close()
+
+
+def test_merge_split_aliases_deduplicate_to_latest_confirmed_contribution(
+    tmp_path: Path,
+) -> None:
+    database, _, tools = _mcp_state(tmp_path)
+    writer = connect(database)
+    try:
+        # Two generated aliases both locate the queried object.  The canonical
+        # decision lineage must collapse them before keyset continuation.
+        writer.execute(
+            "INSERT INTO candidate_members VALUES "
+            "('candidate:manual_2', 'obj:manual_1', 'fixture', 0)"
+        )
+        append_decision(
+            writer,
+            "merge_contributions",
+            "candidate:manual_1",
+            {
+                "app_id": "sample_store",
+                "candidate_ids": ["candidate:manual_1", "candidate:manual_2"],
+                "contribution_id": "contribution:merged",
+                "members": ["obj:manual_1", "obj:manual_2"],
+            },
+        )
+        append_decision(
+            writer,
+            "split_contribution",
+            "candidate:manual_1",
+            {
+                "app_id": "sample_store",
+                "candidate_ids": ["candidate:manual_1", "candidate:manual_2"],
+                "contribution_id": "contribution:split",
+                "members": ["obj:manual_1"],
+                "context_members": [],
+            },
+        )
+        writer.commit()
+    finally:
+        writer.close()
+
+    with tools._builder() as builder:
+        _, rows = scan_memberships(builder, "sample_store", "obj:manual_1")
+        memberships = [item for _, item, _ in rows if item is not None]
+
+    assert len(memberships) == 1
+    assert memberships[0]["contribution_id"] == "contribution:split"
+    assert memberships[0]["candidate_id"] == "candidate:manual_1"
+
+
+def test_legacy_generated_memberships_are_suppressed_but_readiness_requires_rebuild(
+    tmp_path: Path,
+) -> None:
+    _, _, tools = _mcp_state(tmp_path)
+    with tools._builder() as builder:
+        readiness = context_readiness(builder, "sample_store")
+        _, rows = scan_memberships(builder, "sample_store", "obj:manual_1")
+        scanned = list(rows)
+
+    assert readiness["requires_rebuild"] is True
+    assert readiness["limitations"]
+    assert scanned == [({"phase": "after", "key": "candidate:manual_1"}, None, False)]
+
+
+def test_relation_keeps_unavailable_target_but_rejects_noncurrent_declaring_authority(
+    tmp_path: Path,
+) -> None:
+    database, _, tools = _mcp_state(tmp_path)
+    writer = connect(database)
+    try:
+        writer.execute(
+            "UPDATE source_objects SET availability='unavailable', availability_reason='fixture', "
+            "availability_observed_at='2026-08-26T12:00:00+00:00' WHERE id='obj:manual_2'"
+        )
+        writer.execute(
+            """
+            INSERT INTO source_object_availability_events(
+                id, source_object_id, sync_run_id, state, reason, observed_at
+            ) VALUES ('availability:manual-2', 'obj:manual_2', 'run:manual_new',
+                      'unavailable', 'fixture', '2026-08-26T12:00:00+00:00')
+            """
+        )
+        writer.execute("DELETE FROM observations WHERE source_object_id='obj:manual_2'")
+        writer.execute(
+            """
+            INSERT INTO "references"(
+                id, app_id, from_object_id, to_object_id, relationship_type,
+                extraction_method, supporting_observation_id, derived
+            ) VALUES ('ref:available-declarer', 'sample_store', 'obj:manual_1', 'obj:manual_2',
+                      'mentions_jira_key', 'fixture', 'obs:manual_1', 1)
+            """
+        )
+        writer.execute(
+            """
+            INSERT INTO sync_runs(
+                id, app_id, source, source_instance, status, started_at, completed_at,
+                adapter_version, scope_json, completeness
+            ) VALUES ('run:failed-declarer', 'sample_store', 'manual', 'local', 'failed',
+                      '2026-08-27T12:00:00+00:00', '2026-08-27T12:00:00+00:00',
+                      'fixture', '{}', 'unknown')
+            """
+        )
+        writer.execute(
+            """
+            INSERT INTO observations(
+                id, source_object_id, sync_run_id, source_updated_at, fetched_at,
+                payload_hash, title, body_text, data_json, completeness,
+                adapter_version, normalization_version, redaction_version
+            ) VALUES ('obs:failed-declarer', 'obj:manual_0', 'run:failed-declarer',
+                      '2026-08-27T12:00:00+00:00', '2026-08-27T12:00:00+00:00',
+                      'failed-hash', 'Failed', NULL, '{}', 'unknown', 'fixture', '1', '1')
+            """
+        )
+        writer.execute(
+            """
+            INSERT INTO "references"(
+                id, app_id, from_object_id, to_object_id, relationship_type,
+                extraction_method, supporting_observation_id, derived
+            ) VALUES ('ref:old-declarer', 'sample_store', 'obj:manual_0', 'obj:manual_1',
+                      'mentions_jira_key', 'fixture', 'obs:failed-declarer', 1)
+            """
+        )
+        writer.commit()
+    finally:
+        writer.close()
+
+    with tools._builder() as builder:
+        relations = list(scan_relations(builder, "sample_store", "obj:manual_1"))
+    assert len(relations) == 1
+    item = relations[0][1]
+    assert item is not None
+    assert item["reference_id"] == "ref:available-declarer"
+    assert item["to_endpoint"]["current_observation_id"] is None
+    assert item["to_endpoint"]["availability"]["state"] == "unavailable"
+    assert item["to_endpoint"]["availability"]["evidence_id"] == "availability:manual-2"
+
+
+def test_membership_locator_scan_is_lossless_across_more_than_two_hundred_groups(
+    tmp_path: Path,
+) -> None:
+    database, _, tools = _mcp_state(tmp_path)
+    writer = connect(database)
+    try:
+        generated_at = "2026-08-26T12:00:00+00:00"
+        writer.execute(
+            "UPDATE candidate_groups SET generator_version=?, generated_at=?",
+            (GENERATOR_VERSION, generated_at),
+        )
+        writer.executemany(
+            """
+            INSERT INTO source_objects(
+                id, app_id, source, source_instance, kind, external_id,
+                first_seen_run_id, last_seen_run_id
+            ) VALUES (?, 'sample_store', 'manual', 'local', 'manual_evidence', ?,
+                      'run:manual_new', 'run:manual_new')
+            """,
+            [(f"obj:fanout-{index:03d}", f"fanout-{index:03d}") for index in range(205)],
+        )
+        writer.executemany(
+            """
+            INSERT INTO candidate_groups(
+                id, app_id, seed_object_id, generator_version, suggested_title,
+                suggested_type, generated_at
+            ) VALUES (?, 'sample_store', ?, ?, 'Fanout', 'unknown', ?)
+            """,
+            [
+                (
+                    f"candidate:fanout-{index:03d}",
+                    f"obj:fanout-{index:03d}",
+                    GENERATOR_VERSION,
+                    generated_at,
+                )
+                for index in range(205)
+            ],
+        )
+        writer.executemany(
+            "INSERT INTO candidate_members VALUES (?, 'obj:manual_1', 'fixture', 0)",
+            [(f"candidate:fanout-{index:03d}",) for index in range(205)],
+        )
+        writer.commit()
+    finally:
+        writer.close()
+
+    seen: list[str] = []
+    after: str | None = None
+    while True:
+        with tools._builder() as builder:
+            _, rows = scan_memberships(builder, "sample_store", "obj:manual_1", after=after)
+            page = list(rows)
+        seen.extend(position["key"] for position, item, _ in page if item is not None)
+        if not page or not page[-1][2]:
+            break
+        after = page[-1][0]["key"]
+
+    assert len(seen) == 206
+    assert len(seen) == len(set(seen))

--- a/tests/test_evidence_context.py
+++ b/tests/test_evidence_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import UTC, date, datetime
 from pathlib import Path
 
 import pytest
@@ -8,10 +9,14 @@ from tests.test_mapped_references import _app, _object, _worktrace_config
 from tests.test_mcp_security import _mcp_state
 from worktrace.candidates.builder import GENERATOR_VERSION
 from worktrace.candidates.decisions import append_decision, undo_decision
+from worktrace.config import AppConfig, IdentityConfig, WorkTraceConfig
 from worktrace.db.connection import connect
 from worktrace.db.migrations import migrate
 from worktrace.db.repository import EvidenceRepository, source_instance_id
+from worktrace.domain.enums import Completeness
+from worktrace.domain.models import NormalizedObject, SourceIdentity
 from worktrace.errors import ScopeViolation
+from worktrace.mcp_server.tools import WorkTraceTools
 from worktrace.packets.builder import PacketBuilder
 from worktrace.read_models.evidence_context import (
     _decision_mentions_object,
@@ -20,6 +25,135 @@ from worktrace.read_models.evidence_context import (
     scan_memberships,
     scan_relations,
 )
+
+
+def _jira_context_tools(
+    tmp_path: Path,
+) -> tuple[WorkTraceTools, dict[str, str], Path]:
+    database = tmp_path / "jira-context.sqlite3"
+    app = AppConfig(
+        id="sample_jira",
+        name="Sample Jira",
+        market="",
+        business_type="fixture",
+        jira_project_keys=("DEMO",),
+        gitlab_project_ids=(),
+        repo_paths=(),
+        jira_key_patterns=(),
+        production_environments=(),
+        release_tag_patterns=(),
+        ignored_paths=(),
+    )
+    config = WorkTraceConfig(
+        schema_version=1,
+        data_directory=tmp_path,
+        employment_from=date(2024, 1, 1),
+        employment_to=date(2026, 12, 31),
+        identity=IdentityConfig("Fixture", (), (), None, None, None),
+        apps=(app,),
+        config_path=tmp_path / "jira.toml",
+    )
+    connection = connect(database)
+    try:
+        migrate(connection, database)
+        repository = EvidenceRepository(connection)
+        repository.ensure_apps(config)
+        instance = "jira-fixture"
+        run = repository.start_sync_run(
+            app.id,
+            "jira",
+            instance,
+            {"mode": "fixture", "selection_policy_version": 2},
+        )
+
+        def record(kind: str, external_id: str, data: dict[str, object]) -> NormalizedObject:
+            return NormalizedObject(
+                identity=SourceIdentity("jira", instance, kind, external_id),
+                app_id=app.id,
+                title=external_id,
+                body_text=None,
+                source_updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+                actors=(),
+                participations=(),
+                pending_references=(),
+                data=data,  # type: ignore[arg-type]
+                completeness=Completeness.COMPLETE,
+            )
+
+        repository.store_page(
+            run,
+            [
+                record("jira_issue", "100", {"key": "DEMO-1"}),
+                record(
+                    "jira_issue",
+                    "200",
+                    {"key": "OTHER-1", "parent_key": "DEMO-1"},
+                ),
+                record("jira_issue", "DEMO-9", {}),
+                record(
+                    "issue_comment",
+                    "100:out",
+                    {"issue_id": "100", "issue_key": "DEMO-1"},
+                ),
+                record(
+                    "issue_changelog",
+                    "100:in",
+                    {"issue_id": "100", "issue_key": "DEMO-1"},
+                ),
+                record(
+                    "issue_comment",
+                    "100:conflict",
+                    {
+                        "issue_id": "100",
+                        "issue_key": "OTHER-1",
+                        "parent_key": "DEMO-1",
+                    },
+                ),
+                record(
+                    "issue_changelog",
+                    "100:fallback",
+                    {"issue_id": "100", "parent_key": "DEMO-1"},
+                ),
+                record(
+                    "issue_comment",
+                    "999:missing",
+                    {"issue_id": "999", "parent_key": "DEMO-1"},
+                ),
+            ],
+        )
+        repository.finish_sync_run(run, "complete", "complete_for_scope")
+        objects = {
+            str(row["external_id"]): str(row["id"])
+            for row in connection.execute("SELECT id, external_id FROM source_objects")
+        }
+        observations = {
+            str(row["source_object_id"]): str(row["id"])
+            for row in connection.execute("SELECT id, source_object_id FROM observations")
+        }
+        references = (
+            ("ref:jira-out", objects["100"], objects["100:out"]),
+            ("ref:jira-in", objects["100:in"], objects["100"]),
+            ("ref:jira-conflict-out", objects["100"], objects["100:conflict"]),
+            ("ref:jira-conflict-in", objects["100:conflict"], objects["100"]),
+            ("ref:jira-fallback", objects["100"], objects["100:fallback"]),
+            ("ref:jira-missing", objects["100"], objects["999:missing"]),
+        )
+        connection.executemany(
+            """
+            INSERT INTO "references"(
+                id, app_id, from_object_id, to_object_id, relationship_type,
+                extraction_method, supporting_observation_id, derived
+            ) VALUES (?, 'sample_jira', ?, ?, 'jira_comment_issue', 'fixture', ?, 1)
+            """,
+            [
+                (reference_id, from_id, to_id, observations[from_id])
+                for reference_id, from_id, to_id in references
+            ],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    return WorkTraceTools(config=config, database_path=database), objects, database
 
 
 def test_context_requires_a_scoped_source_object_and_keeps_endpoint_availability_separate(
@@ -68,6 +202,32 @@ def test_context_requires_a_scoped_source_object_and_keeps_endpoint_availability
                 "observed_at": None,
             },
         }
+
+
+def test_public_context_uses_jira_owning_identity_before_parent_metadata(
+    tmp_path: Path,
+) -> None:
+    tools, objects, _ = _jira_context_tools(tmp_path)
+
+    # A root issue must not borrow an in-scope parent key when its own key is
+    # foreign, and the legacy textual external-key fallback remains bounded.
+    with pytest.raises(ScopeViolation, match="outside current configured source scope"):
+        tools.get_evidence_context(app_id="sample_jira", object_id=objects["200"])
+    legacy = tools.get_evidence_context(app_id="sample_jira", object_id=objects["DEMO-9"])
+    assert legacy["object"]["object_id"] == objects["DEMO-9"]
+
+    context = tools.get_evidence_context(app_id="sample_jira", object_id=objects["100"])
+    relation_ids = {item["reference_id"] for item in context["relations"]["items"]}
+    # Explicit owning issue_key supports both directions.  A subresource can
+    # fall back only through the exact same-source parent ID binding.
+    assert {"ref:jira-out", "ref:jira-in", "ref:jira-fallback"} <= relation_ids
+    # A foreign explicit issue_key and a missing parent binding both fail
+    # closed even when source-controlled parent_key says DEMO-1.
+    assert not {
+        "ref:jira-conflict-out",
+        "ref:jira-conflict-in",
+        "ref:jira-missing",
+    } & relation_ids
 
 
 def test_confirmed_rowless_context_membership_survives_legacy_generated_state(

--- a/tests/test_golden_end_to_end.py
+++ b/tests/test_golden_end_to_end.py
@@ -24,7 +24,7 @@ from worktrace.candidates.projector import project_candidate
 from worktrace.config import AppConfig, IdentityConfig, ModuleRule, WorkTraceConfig
 from worktrace.db.connection import connect
 from worktrace.db.migrations import migrate
-from worktrace.db.repository import EvidenceRepository
+from worktrace.db.repository import EvidenceRepository, stable_id
 from worktrace.importers.orchestrator import import_snapshot
 from worktrace.linking.builder import rebuild_references
 from worktrace.mcp_server.tools import WorkTraceTools
@@ -1381,16 +1381,18 @@ def test_production_adapters_feed_import_packet_and_mcp_authority(
         assert candidate_row is not None
         candidate_id = str(candidate_row["id"])
 
-        material_external_ids = {"10001", "101:7", "101:7:changed-paths"}
+        material_external_ids = {"10001", "101:7", "101:7:changed-paths", commit_sha}
+        material_object_ids: list[str] = []
         for row in connection.execute(
             """
             SELECT id, external_id FROM source_objects
-            WHERE app_id=? AND external_id IN ('10001', '101:7', '101:7:changed-paths')
+            WHERE app_id=? AND external_id IN (?, '10001', '101:7', '101:7:changed-paths')
             ORDER BY external_id
             """,
-            (app.id,),
+            (app.id, commit_sha),
         ):
             material_external_ids.discard(str(row["external_id"]))
+            material_object_ids.append(str(row["id"]))
             append_decision(
                 connection,
                 "add_member",
@@ -1398,7 +1400,26 @@ def test_production_adapters_feed_import_packet_and_mcp_authority(
                 {"source_object_id": str(row["id"])},
             )
         assert not material_external_ids
-        append_decision(connection, "confirm", candidate_id)
+        release_row = connection.execute(
+            "SELECT id FROM source_objects WHERE app_id=? AND source='gitlab' "
+            "AND kind='gitlab_release'",
+            (app.id,),
+        ).fetchone()
+        assert release_row is not None
+        release_id = str(release_row["id"])
+        append_decision(
+            connection,
+            "confirm_candidate",
+            candidate_id,
+            {
+                "contribution_id": stable_id("contribution", candidate_id),
+                "app_id": app.id,
+                "title": "Explicit synthetic production grouping",
+                "type": "feature",
+                "members": sorted(material_object_ids),
+                "context_members": [release_id],
+            },
+        )
 
         projected = project_candidate(connection, candidate_id)
         assert projected.status == "confirmed"

--- a/tests/test_mapped_references.py
+++ b/tests/test_mapped_references.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from worktrace.config import (
+    AppConfig,
+    GitLabRepositoryMapping,
+    IdentityConfig,
+    WorkTraceConfig,
+    load_config,
+)
+from worktrace.db.connection import connect
+from worktrace.db.migrations import migrate
+from worktrace.db.repository import EvidenceRepository, source_instance_id
+from worktrace.domain.enums import Completeness
+from worktrace.domain.models import NormalizedObject, PendingReference, SourceIdentity
+from worktrace.errors import ConfigurationError
+from worktrace.linking.builder import _objects, rebuild_references
+from worktrace.linking.mappings import mapped_commit_sha_allowed, mapped_source_instance_pairs
+
+
+def _config(apps: str, directory: Path) -> Path:
+    path = directory / "config.toml"
+    path.write_text(
+        f"""schema_version = 1
+
+[data]
+directory = {str(directory / "data")!r}
+
+[employment]
+from = "2024-01-01"
+to = "2026-08-26"
+
+[identity]
+display_name = "Fixture Engineer"
+
+{apps}
+""",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_repository_mappings_are_scoped_strict_and_normalized(tmp_path: Path) -> None:
+    repo_a = (tmp_path / "a").resolve()
+    repo_b = (tmp_path / "b").resolve()
+    apps = f"""[[apps]]
+id = "sample"
+name = "Sample"
+repo_paths = [{str(repo_a)!r}, {str(repo_b)!r}]
+gitlab_project_ids = [101, 202]
+jira_project_keys = []
+
+[[apps.gitlab_repository_mappings]]
+repo_path = {str(repo_b)!r}
+gitlab_project_id = 202
+
+[[apps.gitlab_repository_mappings]]
+repo_path = {str(repo_a)!r}
+gitlab_project_id = 101
+"""
+    app = load_config(_config(apps, tmp_path)).app("sample")
+
+    assert [
+        (item.repo_path, item.gitlab_project_id) for item in app.gitlab_repository_mappings
+    ] == [
+        (repo_a, 101),
+        (repo_b, 202),
+    ]
+    assert mapped_source_instance_pairs(app) == {
+        (source_instance_id("sample", "gitlab", 101), source_instance_id("sample", "git", repo_a)),
+        (source_instance_id("sample", "gitlab", 202), source_instance_id("sample", "git", repo_b)),
+    }
+
+
+@pytest.mark.parametrize(
+    "mapping, message",
+    [
+        ('repo_path = ""\ngitlab_project_id = 101', "repo_path"),
+        ('repo_path = "{repo}"\ngitlab_project_id = true', "positive integer"),
+        ('repo_path = "{repo}"\ngitlab_project_id = 0', "positive integer"),
+        ('repo_path = "{repo}"\ngitlab_project_id = 999', "not configured"),
+    ],
+)
+def test_repository_mapping_rejects_invalid_values(
+    tmp_path: Path, mapping: str, message: str
+) -> None:
+    repo = (tmp_path / "repo").resolve()
+    app = f"""[[apps]]
+id = "sample"
+name = "Sample"
+repo_paths = [{str(repo)!r}]
+gitlab_project_ids = [101]
+jira_project_keys = []
+
+[[apps.gitlab_repository_mappings]]
+{mapping.format(repo=repo)}
+"""
+    with pytest.raises(ConfigurationError, match=message):
+        load_config(_config(app, tmp_path))
+
+
+def _app(repo_a: Path, repo_b: Path, *, mapped: bool) -> AppConfig:
+    return AppConfig(
+        id="sample",
+        name="Sample",
+        market="",
+        business_type="",
+        jira_project_keys=(),
+        gitlab_project_ids=(101,),
+        repo_paths=(repo_a, repo_b),
+        jira_key_patterns=(),
+        production_environments=(),
+        release_tag_patterns=(),
+        ignored_paths=(),
+        gitlab_repository_mappings=((GitLabRepositoryMapping(repo_a, 101),) if mapped else ()),
+    )
+
+
+def _worktrace_config(app: AppConfig, directory: Path) -> WorkTraceConfig:
+    return WorkTraceConfig(
+        schema_version=1,
+        data_directory=directory,
+        employment_from=date(2024, 1, 1),
+        employment_to=date(2026, 8, 26),
+        identity=IdentityConfig("Fixture", (), (), None, None, None),
+        apps=(app,),
+        config_path=directory / "config.toml",
+    )
+
+
+def _object(
+    source: str,
+    instance: str,
+    kind: str,
+    external_id: str,
+    *,
+    title: str = "",
+    data: dict[str, object] | None = None,
+    pending: tuple[PendingReference, ...] = (),
+) -> NormalizedObject:
+    return NormalizedObject(
+        identity=SourceIdentity(source, instance, kind, external_id),
+        app_id="sample",
+        title=title,
+        body_text="",
+        source_updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        actors=(),
+        participations=(),
+        pending_references=pending,
+        data=data or {},  # type: ignore[arg-type]
+        completeness=Completeness.COMPLETE,
+    )
+
+
+@pytest.mark.parametrize("sha", ["a" * 40, "b" * 64])
+def test_mapped_sha_paths_are_explicit_and_do_not_join_decoy_repositories(
+    tmp_path: Path, sha: str
+) -> None:
+    repo_a, repo_b = (tmp_path / "a").resolve(), (tmp_path / "b").resolve()
+    app = _app(repo_a, repo_b, mapped=True)
+    connection = connect(tmp_path / "ledger.sqlite3")
+    try:
+        migrate(connection, tmp_path / "ledger.sqlite3")
+        repository = EvidenceRepository(connection)
+        repository.ensure_apps(_worktrace_config(app, tmp_path))
+        git_a = source_instance_id("sample", "git", repo_a)
+        git_b = source_instance_id("sample", "git", repo_b)
+        gitlab = source_instance_id("sample", "gitlab", 101)
+        run = repository.start_sync_run("sample", "git", git_a, {"mode": "fixture"})
+        repository.store_page(run, [_object("git", git_a, "git_commit", sha)])
+        repository.finish_sync_run(run, "complete", "complete_for_scope")
+        run = repository.start_sync_run("sample", "git", git_b, {"mode": "fixture"})
+        repository.store_page(run, [_object("git", git_b, "git_commit", sha)])
+        repository.finish_sync_run(run, "complete", "complete_for_scope")
+        run = repository.start_sync_run(
+            "sample", "gitlab", gitlab, {"mode": "fixture", "selection_policy_version": 2}
+        )
+        repository.store_page(
+            run,
+            [
+                _object(
+                    "gitlab",
+                    gitlab,
+                    "gitlab_mr",
+                    "101:1",
+                    title=sha,
+                    data={"commit_shas": [sha]},
+                    pending=(
+                        PendingReference(
+                            "git",
+                            "git_commit",
+                            sha,
+                            "gitlab_source_head",
+                            "structured",
+                            sha,
+                        ),
+                    ),
+                ),
+                _object(
+                    "gitlab",
+                    gitlab,
+                    "gitlab_merge_request_commit",
+                    f"101:1:{sha}",
+                    data={"sha": sha},
+                ),
+            ],
+        )
+        repository.finish_sync_run(run, "complete", "complete_for_scope")
+
+        current = _objects(repository, "sample")
+        gitlab_object = next(item for item in current if item.source == "gitlab")
+        git_object = next(item for item in current if item.source_instance == git_a)
+        assert mapped_commit_sha_allowed(app, gitlab_object, git_object, sha)
+        rebuild_references(app, repository)
+        rows = list(
+            connection.execute(
+                'SELECT relationship_type, extraction_method, to_object_id FROM "references" '
+                "ORDER BY extraction_method"
+            )
+        )
+        assert {str(row["relationship_type"]) for row in rows} == {"mapped_commit_sha"}
+        assert {str(row["to_object_id"]) for row in rows} == {
+            str(
+                connection.execute(
+                    "SELECT id FROM source_objects WHERE source_instance=?", (git_a,)
+                ).fetchone()[0]
+            )
+        }
+        assert {str(row["extraction_method"]) for row in rows} == {
+            "explicit_repo_project_full_sha:textual_reference",
+            "explicit_repo_project_full_sha:mr_contains_commit",
+            "explicit_repo_project_full_sha:source_head",
+            "explicit_repo_project_full_sha:commit_record",
+        }
+    finally:
+        connection.close()
+
+
+def test_mapping_guard_rejects_abbreviated_or_removed_mapping(tmp_path: Path) -> None:
+    repo_a, repo_b = (tmp_path / "a").resolve(), (tmp_path / "b").resolve()
+    sha = "a" * 40
+    app = _app(repo_a, repo_b, mapped=True)
+    source = {
+        "app_id": "sample",
+        "source": "gitlab",
+        "source_instance": source_instance_id("sample", "gitlab", 101),
+    }
+    target = {
+        "app_id": "sample",
+        "source": "git",
+        "source_instance": source_instance_id("sample", "git", repo_a),
+        "kind": "git_commit",
+        "external_id": sha,
+    }
+    assert mapped_commit_sha_allowed(app, source, target, sha)
+    assert not mapped_commit_sha_allowed(app, source, target, sha[:12])
+    assert not mapped_commit_sha_allowed(_app(repo_a, repo_b, mapped=False), source, target, sha)

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -188,7 +188,7 @@ def _mcp_state(tmp_path: Path) -> tuple[Path, WorkTraceConfig, WorkTraceTools]:
     return database_path, config, WorkTraceTools(config=config, database_path=database_path)
 
 
-def test_server_registers_exactly_six_read_only_closed_world_tools() -> None:
+def test_server_registers_exactly_seven_read_only_closed_world_tools() -> None:
     server = build_mcp_server()
     registered = asyncio.run(server.list_tools())
 
@@ -199,6 +199,7 @@ def test_server_registers_exactly_six_read_only_closed_world_tools() -> None:
         "list_evidence_gaps",
         "search_evidence",
         "get_evidence_excerpt",
+        "get_evidence_context",
     ]
     assert all(tool.annotations is not None for tool in registered)
     assert all(tool.annotations.read_only_hint is True for tool in registered)

--- a/tests/test_read_state.py
+++ b/tests/test_read_state.py
@@ -35,7 +35,7 @@ def test_read_snapshot_owns_and_rolls_back_on_success_and_failure(tmp_path: Path
     path = _database(tmp_path)
     connection = connect_read_only(path)
     try:
-        assert (READ_PROTOCOL_VERSION, READ_MODEL_VERSION) == (1, 1)
+        assert (READ_PROTOCOL_VERSION, READ_MODEL_VERSION) == (1, 2)
         with read_snapshot(connection):
             assert connection.in_transaction
         assert not connection.in_transaction

--- a/tests/test_stdio_read_protocol.py
+++ b/tests/test_stdio_read_protocol.py
@@ -159,6 +159,7 @@ async def test_stdio_read_protocol_binds_tokens_paging_mutation_and_restart(tmp_
             "list_evidence_gaps",
             "search_evidence",
             "get_evidence_excerpt",
+            "get_evidence_context",
         }
         for tool in listed.tools:
             assert "expected_view_token" in tool.input_schema["properties"]
@@ -170,6 +171,32 @@ async def test_stdio_read_protocol_binds_tokens_paging_mutation_and_restart(tmp_
         )
         token = cast(str, search["view_token"])
         assert isinstance(search["next_cursor"], str)
+        context = _payload(
+            await session.call_tool(
+                "get_evidence_context",
+                {
+                    "app_id": "sample_store",
+                    "object_id": "obj:stdio:0",
+                    "limit": 1,
+                    "expected_view_token": token,
+                },
+            )
+        )
+        assert context["view_token"] == token
+        relation_cursor = context["relations"]["next_cursor"]
+        if isinstance(relation_cursor, str):
+            relation_page = _payload(
+                await session.call_tool(
+                    "get_evidence_context",
+                    {
+                        "app_id": "sample_store",
+                        "object_id": "obj:stdio:0",
+                        "relation_cursor": relation_cursor,
+                        "expected_view_token": token,
+                    },
+                )
+            )
+            assert relation_page["memberships"]["requested"] is False
         continued = _payload(
             await session.call_tool(
                 "search_evidence",


### PR DESCRIPTION
## Summary

- Adds the seventh read-only MCP tool, `get_evidence_context`, so an investigation can explain a configured source object's authoritative references and effective memberships before grouping; it stays bounded, query-only, and explain-only.
- Binds independent context cursors to the app, view, object, filters, and membership generation, so a caller can continue one stream without silently treating the other as empty or current.
- Preserves material/context roles through corrections and explicit Git/GitLab repository mappings, so an SHA match is linked only when configured and never becomes an ownership or release claim.
- Documents the seven-tool contract and adds protocol, budget, STDIO, CLI, mapping, and public workflow coverage so reviewers can verify the new reader boundary without provider credentials or a private ledger.

## Validation

- Historical pre-final local `uv run coverage run -m pytest && uv run coverage report` — 474 passed, 87% branch-enabled coverage. Merged-main validation is recorded in Delivery below.
- `uv run ruff format --check . && uv run ruff check .` — passed.
- `uv run mypy src` — passed for 81 source files.
- `uv build` — source distribution and wheel built.
- Installed-wheel STDIO smoke passed with an isolated Python environment outside the checkout.

## Scope and limits

- Context returns at most 20 total rows across both streams, scans at most 200 rows per stream, and shares the 20,000-character escaped JSON budget.
- Traversal completion is distinct from source coverage, readiness, availability, and evidence authority. No provider was contacted and no private ledger was used.
- Schema remains 6; no migration, dependency, or index was added.
- Review, CI, human approval, and post-merge QA are complete; the merged delivery record is below.

## Glossary

| Term | Definition |
|---|---|
| View token | Snapshot consistency marker, not an access grant or readiness claim. |
| Effective membership | Canonical material or context role after active human decisions and lineage projection. |
| Pending-only continuation | A call that continues one context stream while the other is explicitly not requested. |
| Explicit mapping | Configured Git repository to GitLab project correspondence required before full-SHA linking. |

Refs #30

Architecture: [`AgDR-0007`](https://github.com/AmrMohamad/WorkTrace/blob/main/docs/agdr/AgDR-0007-agent-evidence-workflow-migration.md)

## Delivery

- [x] Squash merged as [`8cc35b412566f6982e8767f03cf3f29c28a38c9e`](https://github.com/AmrMohamad/WorkTrace/commit/8cc35b412566f6982e8767f03cf3f29c28a38c9e).
- [x] Merged-main [Quality CI](https://github.com/AmrMohamad/WorkTrace/actions/runs/33998050672) passed: 475 tests and 87% branch coverage.
- [x] Independent post-merge QA [sign-off](https://github.com/AmrMohamad/WorkTrace/issues/30#issuecomment-5555444212): 55 focused checks passed.
- [x] Issue #30 closed as completed after separately authorized acceptance readback.
