### PR TITLE
feat(#22): add bounded TUI evidence discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,15 @@ uv run worktrace ui --app sample_store_b2c --candidate candidate:stable-id
 
 The UI reviews source-attempt status, bounded candidate pages, contribution evidence,
 participation, seven independent delivery states, Phase 4 questions and gaps, and bounded source
-excerpts. It does not import evidence, contact providers, write decisions, rebuild data, or perform
-maintenance; those operations remain explicit CLI commands.
+excerpts. From a settled candidate page, press `/` to open evidence search. Enter a literal query
+and optional source, module text, and activity-date filters, then press Enter or Search. Result
+Enter opens a bounded excerpt; contribution-link Enter opens its review; `n`/`p` page only outside
+an editable field. A short or empty evidence page may still continue, and incomplete canonical
+links explicitly report the projection-budget or display-cap limitation.
+
+The UI does not import evidence, contact providers, write decisions, rebuild data, or perform
+maintenance; those operations remain explicit CLI commands. TUI evidence continuations are local
+and separate from candidate-browser and MCP cursor formats.
 
 ## MCP
 
@@ -197,7 +204,8 @@ without dropping any of the 30 question IDs/statuses or support/contradiction pr
 detail with either `section` (the canonical section name) or `question_id`, then follow
 `detail_cursor`, always carrying `expected_view_token`. Detail entries include stable citation
 IDs and ordered answer/limitation chunks. An explicit size error never advances continuation.
-The TUI keeps its existing navigation and cursor contract.
+The TUI candidate browser keeps its existing navigation and cursor contract; evidence search uses
+its own in-memory continuation and does not alter MCP cursors.
 
 `worktrace serve-mcp` exposes exactly seven bounded, read-only tools over stdio. `get_evidence_context`
 explains one configured source object through independently paged references and effective memberships;

--- a/docs/prds/worktrace-read-only-human-tui.md
+++ b/docs/prds/worktrace-read-only-human-tui.md
@@ -27,8 +27,9 @@ The original product and implementation sequence is complete:
 The current MCP surface is seven bounded read-only tools with view-bound `wtc1:` candidate and
 evidence cursors. References to six tools and `offset:` cursors below describe the original PRD
 baseline; [AgDR-0007](../agdr/AgDR-0007-agent-evidence-workflow-migration.md) supersedes only
-those historical MCP constraints. This addendum approves the #22 discovery contract; it does not
-claim that search is implemented. The representative private-ledger measurement remains deferred,
+those historical MCP constraints. This addendum approves the #22 discovery contract. Its
+implementation is pending PR merge and independent acceptance QA; the representative private-ledger
+measurement remains deferred,
 so the later parent feature remains open.
 
 ## Overview
@@ -235,7 +236,7 @@ At 80x24, the workflow uses a single primary pane and drill-down navigation. At 
 
 No dashboard-only shell is part of this release. The first executable UI must ship the complete journey.
 
-## Evidence discovery addendum — accepted contract for [#22](https://github.com/AmrMohamad/WorkTrace/issues/22), not implemented
+## Evidence discovery addendum — accepted contract for [#22](https://github.com/AmrMohamad/WorkTrace/issues/22)
 
 This addendum adds a bounded evidence-search journey above the delivered candidate browser. It is
 not a replacement browser mode and does not make a search match evidence of contribution ownership

--- a/docs/technical-designs/worktrace-read-only-human-tui.md
+++ b/docs/technical-designs/worktrace-read-only-human-tui.md
@@ -12,8 +12,8 @@
 
 **Delivery**: The design merged in [PR #13](https://github.com/AmrMohamad/WorkTrace/pull/13) and
 the complete original vertical slice merged in [PR #16](https://github.com/AmrMohamad/WorkTrace/pull/16).
-The #22 evidence-search addendum below is an accepted implementation contract, not a statement that
-search has shipped.
+The #22 evidence-search addendum below is the accepted implementation contract. Its implementation
+is pending PR merge and independent acceptance QA; this document does not claim shipped delivery.
 
 ## Overview
 
@@ -450,7 +450,7 @@ UI state remains in memory and contains only the current app, screen, selected s
 page, cursor history, request IDs, and compact-mode choice. It does not persist evidence, drafts,
 credentials, URLs, or preferences.
 
-## Evidence discovery addendum — [#22](https://github.com/AmrMohamad/WorkTrace/issues/22) implementation contract, not implemented
+## Evidence discovery addendum — [#22](https://github.com/AmrMohamad/WorkTrace/issues/22) implementation contract
 
 `ReadOnlyWorkspace.search_evidence()` will return frozen page, result, link, and TUI-search-cursor
 DTOs. Each completed page retains successfully submitted parameters, returned results,

--- a/src/worktrace/read_models/agent_pages.py
+++ b/src/worktrace/read_models/agent_pages.py
@@ -297,6 +297,7 @@ def scan_evidence(
     date_from: str | None,
     date_to: str | None,
     after: tuple[str, str] | None = None,
+    page_builder: PacketBuilder | None = None,
 ) -> Iterator[ScannedRow]:
     """Yield at most 200 evidence-search rows in freshness/id keyset order."""
 
@@ -327,15 +328,15 @@ def scan_evidence(
                 limit=1,
             )
         )
-    page_builder: PacketBuilder | None = None
+    projection_builder = page_builder
 
     def project(row: sqlite3.Row) -> dict[str, object] | None:
-        nonlocal page_builder
-        if page_builder is None:
-            page_builder = _page_builder(builder, app_id, diagnostics)
+        nonlocal projection_builder
+        if projection_builder is None:
+            projection_builder = _page_builder(builder, app_id, diagnostics)
         diagnostics.hydrated_body_bytes += len(str(row["page_text"]).encode("utf-8"))
         record = _evidence_record_from_row(row, context_only=False)
-        period = page_builder._activity_period([record])
+        period = projection_builder._activity_period([record])
         if not period.matches(date_from, date_to, builder.config.employment_timezone):
             return None
         return {

--- a/src/worktrace/read_models/evidence_context.py
+++ b/src/worktrace/read_models/evidence_context.py
@@ -26,6 +26,7 @@ from worktrace.db.authority import (
 from worktrace.db.repository import source_instance_id
 from worktrace.errors import NotFound, ScopeViolation
 from worktrace.packets.builder import PacketBuilder
+from worktrace.packets.models import ContributionView
 from worktrace.read_models.candidates import _active_generation
 
 MAX_CONTEXT_SCAN_BUDGET = 200
@@ -583,7 +584,12 @@ def _decision_mentions_object(action: str, payload: Mapping[str, object], object
     return False
 
 
-def _membership_locator_ids(builder: PacketBuilder, app_id: str, object_id: str) -> set[str]:
+def membership_locator_ids(builder: PacketBuilder, app_id: str, object_id: str) -> set[str]:
+    """Find generated and decision-backed membership locators for one object.
+
+    This intentionally does not resolve a contribution.  Callers which need
+    several objects can deduplicate aliases before paying for any projection.
+    """
     result = {
         str(row["candidate_id"])
         for row in builder.connection.execute(
@@ -607,7 +613,7 @@ def _membership_locator_ids(builder: PacketBuilder, app_id: str, object_id: str)
     return result
 
 
-def _lineage_identity(
+def lineage_identity(
     builder: PacketBuilder, app_id: str, identifier: str
 ) -> tuple[str, str | None, str, bool]:
     context_builder = builder.page_projection_builder(app_id)
@@ -638,6 +644,134 @@ def _lineage_identity(
     return contribution_id, contribution_id, lineage.canonical_candidate_id, True
 
 
+@dataclass(frozen=True, slots=True)
+class CanonicalMembershipLocator:
+    """One canonical group reachable from an object's membership locator."""
+
+    key: str
+    identifier: str
+    contribution_id: str | None
+    candidate_id: str
+    confirmed: bool
+
+
+def canonical_membership_locators(
+    builder: PacketBuilder, app_id: str, object_id: str
+) -> tuple[CanonicalMembershipLocator, ...]:
+    """Return deterministic, alias-deduplicated canonical membership groups."""
+
+    context_builder = builder.page_projection_builder(app_id)
+    by_key: dict[str, CanonicalMembershipLocator] = {}
+    for identifier in sorted(membership_locator_ids(context_builder, app_id, object_id)):
+        try:
+            key, contribution_id, candidate_id, confirmed = lineage_identity(
+                context_builder, app_id, identifier
+            )
+        except ScopeViolation:
+            continue
+        locator = CanonicalMembershipLocator(
+            key=key,
+            identifier=identifier,
+            contribution_id=contribution_id,
+            candidate_id=candidate_id,
+            confirmed=confirmed,
+        )
+        existing = by_key.get(key)
+        if existing is None or (locator.confirmed and not existing.confirmed):
+            by_key[key] = locator
+    return tuple(by_key[key] for key in sorted(by_key))
+
+
+def resolve_canonical_membership(
+    builder: PacketBuilder,
+    app_id: str,
+    object_id: str,
+    locator: CanonicalMembershipLocator,
+    *,
+    legacy_generated: bool,
+) -> dict[str, object] | None:
+    """Resolve one group to an effective membership, if it remains applicable.
+
+    One invocation is one canonical projection attempt.  It deliberately
+    returns ``None`` for a disappeared, ignored, unsupported, or nonmatching
+    locator so callers can account for that work without inventing a link.
+    """
+
+    contribution = resolve_canonical_group(
+        builder, app_id, locator, legacy_generated=legacy_generated
+    )
+    if contribution is None:
+        return None
+    return project_canonical_membership(builder, app_id, object_id, locator, contribution)
+
+
+def resolve_canonical_group(
+    builder: PacketBuilder,
+    app_id: str,
+    locator: CanonicalMembershipLocator,
+    *,
+    legacy_generated: bool,
+) -> ContributionView | None:
+    """Resolve one canonical group once, independent of the object being displayed."""
+
+    if legacy_generated and not locator.confirmed:
+        return None
+    context_builder = builder.page_projection_builder(app_id)
+    try:
+        return context_builder.resolve_contribution(locator.identifier)
+    except (NotFound, ScopeViolation):
+        return None
+
+
+def project_canonical_membership(
+    builder: PacketBuilder,
+    app_id: str,
+    object_id: str,
+    locator: CanonicalMembershipLocator,
+    contribution: ContributionView,
+) -> dict[str, object] | None:
+    """Apply one already-resolved group to one evidence object without resolving again."""
+
+    context_builder = builder.page_projection_builder(app_id)
+    object_description = describe_object(context_builder, app_id, object_id)
+    object_has_current = object_description["current_observation_id"] is not None
+    role = (
+        "material"
+        if object_id in contribution.member_ids
+        else "context"
+        if object_id in contribution.context_ids
+        else None
+    )
+    if role is None:
+        return None
+    citations = sorted(contribution.decision_evidence_ids) if locator.confirmed else []
+    if not citations and object_has_current:
+        citations = [str(object_description["current_observation_id"])]
+    raw_limitations = object_description["limitations"]
+    limitations = list(raw_limitations) if isinstance(raw_limitations, list) else []
+    generation = _active_generation(builder.connection, app_id)
+    legacy_generated = generation is not None and generation.generator_version != GENERATOR_VERSION
+    if legacy_generated and locator.confirmed:
+        limitations.append(
+            "Generated locator coverage is legacy; this row persists because "
+            "a human-confirmed decision lineage remains effective."
+        )
+    return {
+        "object_id": object_id,
+        "candidate_id": locator.candidate_id,
+        "contribution_id": locator.contribution_id,
+        "role": role,
+        "basis": "confirmed" if locator.confirmed else "suggestion",
+        "status": "confirmed" if locator.confirmed else "suggestion",
+        "evidence_state": (
+            "authoritative_current" if object_has_current else "current_evidence_unavailable"
+        ),
+        "citations": citations[:20],
+        "citations_truncated": len(citations) > 20,
+        "limitations": limitations,
+    }
+
+
 def scan_memberships(
     builder: PacketBuilder,
     app_id: str,
@@ -652,25 +786,11 @@ def scan_memberships(
     generation_token = generation.token if generation is not None else None
     legacy_generated = generation is not None and generation.generator_version != GENERATOR_VERSION
     context_builder = builder.page_projection_builder(app_id)
-    locator_ids = _membership_locator_ids(context_builder, app_id, object_id)
-    by_key: dict[str, tuple[str, str | None, str, bool]] = {}
-    for identifier in sorted(locator_ids):
-        try:
-            key, contribution_id, candidate_id, confirmed = _lineage_identity(
-                context_builder, app_id, identifier
-            )
-        except ScopeViolation:
-            continue
-        existing = by_key.get(key)
-        if existing is None or (confirmed and not existing[3]):
-            by_key[key] = (identifier, contribution_id, candidate_id, confirmed)
-
-    object_description = describe_object(context_builder, app_id, object_id)
-    object_has_current = object_description["current_observation_id"] is not None
-    entries = [(key, *value) for key, value in sorted(by_key.items()) if key > (after or "")][
+    locators = canonical_membership_locators(context_builder, app_id, object_id)
+    entries = [locator for locator in locators if locator.key > (after or "")][
         :MAX_CONTEXT_SCAN_BUDGET
     ]
-    has_more = len([key for key in by_key if key > (after or "")]) > len(entries)
+    has_more = len([locator for locator in locators if locator.key > (after or "")]) > len(entries)
 
     class _MembershipRows(Iterator[ScannedRow]):
         def __init__(self) -> None:
@@ -679,55 +799,17 @@ def scan_memberships(
         def __next__(self) -> ScannedRow:
             if self.index >= len(entries):
                 raise StopIteration
-            key, identifier, contribution_id, candidate_id, confirmed = entries[self.index]
+            locator = entries[self.index]
             self.index += 1
-            item: dict[str, object] | None = None
-            # Old generated rows are not newly validated by an upgrade.  A
-            # human-confirmed lineage remains inspectable despite that gap.
-            if not (legacy_generated and not confirmed):
-                try:
-                    contribution = context_builder.resolve_contribution(identifier)
-                except (NotFound, ScopeViolation):
-                    contribution = None
-                if contribution is not None:
-                    role = (
-                        "material"
-                        if object_id in contribution.member_ids
-                        else "context"
-                        if object_id in contribution.context_ids
-                        else None
-                    )
-                    if role is not None:
-                        citations = sorted(contribution.decision_evidence_ids) if confirmed else []
-                        if not citations and object_has_current:
-                            citations = [str(object_description["current_observation_id"])]
-                        raw_limitations = object_description["limitations"]
-                        limitations = (
-                            list(raw_limitations) if isinstance(raw_limitations, list) else []
-                        )
-                        if legacy_generated and confirmed:
-                            limitations.append(
-                                "Generated locator coverage is legacy; this row persists because "
-                                "a human-confirmed decision lineage remains effective."
-                            )
-                        item = {
-                            "object_id": object_id,
-                            "candidate_id": candidate_id,
-                            "contribution_id": contribution_id,
-                            "role": role,
-                            "basis": "confirmed" if confirmed else "suggestion",
-                            "status": "confirmed" if confirmed else "suggestion",
-                            "evidence_state": (
-                                "authoritative_current"
-                                if object_has_current
-                                else "current_evidence_unavailable"
-                            ),
-                            "citations": citations[:20],
-                            "citations_truncated": len(citations) > 20,
-                            "limitations": limitations,
-                        }
+            item = resolve_canonical_membership(
+                context_builder,
+                app_id,
+                object_id,
+                locator,
+                legacy_generated=legacy_generated,
+            )
             return (
-                {"phase": "after", "key": key},
+                {"phase": "after", "key": locator.key},
                 item,
                 self.index < len(entries) or has_more,
             )

--- a/src/worktrace/read_models/evidence_search.py
+++ b/src/worktrace/read_models/evidence_search.py
@@ -1,0 +1,455 @@
+"""Bounded, TUI-only evidence discovery over one immutable read snapshot."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import date
+from types import MappingProxyType
+from typing import Literal, cast
+
+from worktrace.candidates.builder import GENERATOR_VERSION
+from worktrace.errors import DatabaseError, NotFound, ScopeViolation
+from worktrace.packets.builder import PacketBuilder
+from worktrace.packets.models import ContributionView
+from worktrace.read_models.agent_pages import scan_evidence
+from worktrace.read_models.candidates import _active_generation
+from worktrace.read_models.evidence_context import (
+    CanonicalMembershipLocator,
+    canonical_membership_locators,
+    describe_object,
+    project_canonical_membership,
+    resolve_canonical_group,
+)
+
+TUI_EVIDENCE_SEARCH_READ_MODEL_VERSION = 1
+EVIDENCE_SEARCH_PAGE_SIZE = 20
+EVIDENCE_SEARCH_SCAN_BUDGET = 200
+EVIDENCE_SEARCH_PROJECTION_BUDGET = 50
+EVIDENCE_SEARCH_LINK_CAP = 5
+_SOURCES = frozenset({"git", "jira", "gitlab", "manual"})
+
+
+class EvidenceSearchValidationError(ValueError):
+    """A submitted TUI search filter is outside the frozen reader contract."""
+
+
+class EvidenceSearchInvalidated(DatabaseError):
+    """A continuation cannot safely describe the current application view."""
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSearchFilters:
+    query: str
+    source: str | None
+    module_text: str | None
+    date_from: str | None
+    date_to: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSearchCursor:
+    app_id: str
+    filters: EvidenceSearchFilters
+    revision: int
+    read_model_version: int
+    after_sort_time: str
+    after_observation_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class CandidateLink:
+    candidate_id: str
+    contribution_id: str | None
+    status: str
+    role: str
+    confirmation_basis: str
+    evidence_state: str
+    limitations: tuple[str, ...]
+
+    @property
+    def identifier(self) -> str:
+        """The only contribution-review identifier a link is permitted to open."""
+
+        return self.contribution_id or self.candidate_id
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSearchItem:
+    evidence_id: str
+    object_id: str
+    source: str
+    kind: str
+    title: str | None
+    period_from: str | None
+    period_to: str | None
+    period_status: str
+    period_limitations: tuple[str, ...]
+    links: tuple[CandidateLink, ...]
+    link_completeness: bool
+    link_limit_reason: Literal["projection_budget", "display_cap"] | None
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSearchDiagnostics:
+    scanned_rows: int
+    eligible_results: int
+    returned_results: int
+    projection_attempts: int
+    projection_budget: int
+    display_link_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceSearchPage:
+    app_id: str
+    filters: EvidenceSearchFilters
+    items: tuple[EvidenceSearchItem, ...]
+    next_cursor: EvidenceSearchCursor | None
+    revision: int
+    read_model_version: int
+    readiness: Mapping[str, object]
+    limitations: tuple[str, ...]
+    diagnostics: EvidenceSearchDiagnostics
+
+
+def _optional_text(value: str | None, name: str, maximum: int | None = None) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise EvidenceSearchValidationError(f"{name} must be text")
+    normalized = value.strip()
+    if not normalized:
+        return None
+    if "\0" in normalized:
+        raise EvidenceSearchValidationError(f"{name} must not contain NUL")
+    if maximum is not None and len(normalized) > maximum:
+        raise EvidenceSearchValidationError(f"{name} must be at most {maximum} characters")
+    return normalized
+
+
+def normalize_evidence_search_filters(
+    query: str,
+    *,
+    source: str | None = None,
+    module_text: str | None = None,
+    date_from: str | None = None,
+    date_to: str | None = None,
+) -> EvidenceSearchFilters:
+    """Normalize the one filter contract shared by screen and direct callers."""
+
+    normalized_query = _optional_text(query, "query", 500)
+    if normalized_query is None:
+        raise EvidenceSearchValidationError("query must contain 1 to 500 characters")
+    normalized_source = _optional_text(source, "source")
+    if normalized_source is not None:
+        normalized_source = normalized_source.casefold()
+        if normalized_source not in _SOURCES:
+            allowed = ", ".join(sorted(_SOURCES))
+            raise EvidenceSearchValidationError(f"source must be one of: {allowed}")
+    normalized_module = _optional_text(module_text, "module text", 200)
+    normalized_from = _optional_text(date_from, "date_from")
+    normalized_to = _optional_text(date_to, "date_to")
+    for name, value in (("date_from", normalized_from), ("date_to", normalized_to)):
+        if value is None:
+            continue
+        try:
+            date.fromisoformat(value)
+        except ValueError as exc:
+            raise EvidenceSearchValidationError(f"{name} must be an ISO calendar date") from exc
+    if (
+        normalized_from is not None
+        and normalized_to is not None
+        and normalized_from > normalized_to
+    ):
+        raise EvidenceSearchValidationError("date_from must not be after date_to")
+    return EvidenceSearchFilters(
+        query=normalized_query,
+        source=normalized_source,
+        module_text=normalized_module,
+        date_from=normalized_from,
+        date_to=normalized_to,
+    )
+
+
+def _freeze(value: object) -> object:
+    if isinstance(value, dict):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _read_revision(connection: sqlite3.Connection, app_id: str) -> int:
+    row = connection.execute("SELECT read_revision FROM apps WHERE id=?", (app_id,)).fetchone()
+    if row is None:
+        # config.app() already checked scope; a missing app table row is ledger corruption.
+        raise DatabaseError("configured application is missing from the read model")
+    return int(row[0])
+
+
+def _period_limitations(
+    period_status: str, date_from: str | None, date_to: str | None
+) -> tuple[str, ...]:
+    if not (date_from or date_to) or period_status != "unknown":
+        return ()
+    return ("Undated evidence is excluded while an activity-date filter is supplied.",)
+
+
+def _link_from_projection(value: dict[str, object]) -> CandidateLink:
+    raw_limitations = value.get("limitations")
+    return CandidateLink(
+        candidate_id=str(value["candidate_id"]),
+        contribution_id=(
+            str(value["contribution_id"]) if value.get("contribution_id") is not None else None
+        ),
+        status=str(value["status"]),
+        role=str(value["role"]),
+        confirmation_basis=str(value["basis"]),
+        evidence_state=str(value["evidence_state"]),
+        limitations=(
+            tuple(str(item) for item in raw_limitations if isinstance(item, str))
+            if isinstance(raw_limitations, list)
+            else ()
+        ),
+    )
+
+
+def _is_admitted_search_object(
+    builder: PacketBuilder, app_id: str, value: Mapping[str, object]
+) -> bool:
+    """Apply the canonical configured-source guard before page admission.
+
+    Scanner order/positions remain authoritative: an out-of-config or vanished
+    row is excluded, not an exception which can strand the continuation.  The
+    public application and continuation checks occur before this per-row guard.
+    """
+
+    try:
+        describe_object(builder, app_id, str(value["object_id"]))
+    except (NotFound, ScopeViolation):
+        return False
+    return True
+
+
+def _resolve_canonical_membership(
+    builder: PacketBuilder,
+    app_id: str,
+    object_id: str,
+    locator: CanonicalMembershipLocator,
+    *,
+    legacy_generated: bool,
+) -> ContributionView | None:
+    """Resolve exactly one group; callers count every invocation as an attempt."""
+
+    del object_id
+    return resolve_canonical_group(
+        builder,
+        app_id,
+        locator,
+        legacy_generated=legacy_generated,
+    )
+
+
+def _link_for_object(
+    builder: PacketBuilder,
+    app_id: str,
+    object_id: str,
+    locator: CanonicalMembershipLocator,
+    contribution: ContributionView,
+) -> CandidateLink | None:
+    projected = project_canonical_membership(builder, app_id, object_id, locator, contribution)
+    return _link_from_projection(projected) if projected is not None else None
+
+
+def _enrich(
+    builder: PacketBuilder,
+    app_id: str,
+    raw_items: list[dict[str, object]],
+) -> tuple[list[tuple[CandidateLink, ...]], list[bool], list[str | None], int]:
+    """Allocate a single fair projection budget across all displayed results."""
+
+    generation = _active_generation(builder.connection, app_id)
+    legacy_generated = generation is not None and generation.generator_version != GENERATOR_VERSION
+    locators = [
+        list(canonical_membership_locators(builder, app_id, str(item["object_id"])))
+        for item in raw_items
+    ]
+    positions = [0] * len(raw_items)
+    links: list[list[CandidateLink]] = [[] for _ in raw_items]
+    limits: list[str | None] = [None] * len(raw_items)
+    cache: dict[str, ContributionView | None] = {}
+    attempts = 0
+    progressed = True
+    while progressed:
+        progressed = False
+        for index, item in enumerate(raw_items):
+            if limits[index] == "display_cap":
+                continue
+            while positions[index] < len(locators[index]):
+                locator = locators[index][positions[index]]
+                positions[index] += 1
+                progressed = True
+                if locator.key in cache:
+                    contribution = cache[locator.key]
+                elif attempts >= EVIDENCE_SEARCH_PROJECTION_BUDGET:
+                    # This distinct group remains unprojected, but later
+                    # locators can still reuse a group cached by another row.
+                    # Consume this locator so an exhausted page cannot spin.
+                    limits[index] = "projection_budget"
+                    break
+                else:
+                    attempts += 1
+                    contribution = _resolve_canonical_membership(
+                        builder,
+                        app_id,
+                        str(item["object_id"]),
+                        locator,
+                        legacy_generated=legacy_generated,
+                    )
+                    cache[locator.key] = contribution
+                # Test seams and the old single-object resolver return an
+                # already-shaped link.  Production caches the group instead,
+                # then projects its role independently for each evidence row.
+                link = (
+                    contribution
+                    if isinstance(contribution, CandidateLink)
+                    else _link_for_object(
+                        builder, app_id, str(item["object_id"]), locator, contribution
+                    )
+                    if contribution is not None
+                    else None
+                )
+                if link is not None:
+                    links[index].append(link)
+                    if len(links[index]) == EVIDENCE_SEARCH_LINK_CAP:
+                        if positions[index] < len(locators[index]):
+                            limits[index] = "display_cap"
+                        break
+                # Round robin gives each result one uncached/cached group per pass.
+                break
+    complete = [
+        positions[index] == len(locators[index]) and limits[index] is None
+        for index in range(len(raw_items))
+    ]
+    return [tuple(value) for value in links], complete, limits, attempts
+
+
+def evidence_search_page(
+    connection: sqlite3.Connection,
+    builder: PacketBuilder,
+    app_id: str,
+    filters: EvidenceSearchFilters,
+    *,
+    cursor: EvidenceSearchCursor | None,
+    expected_revision: int | None = None,
+) -> EvidenceSearchPage:
+    """Build one page without opening a connection or transaction of its own."""
+
+    builder.config.app(app_id)
+    revision = _read_revision(connection, app_id)
+    if expected_revision is not None and expected_revision != revision:
+        raise EvidenceSearchInvalidated("Evidence changed; restart the search from its first page.")
+    if cursor is not None and (
+        cursor.app_id != app_id
+        or cursor.filters != filters
+        or cursor.revision != revision
+        or cursor.read_model_version != TUI_EVIDENCE_SEARCH_READ_MODEL_VERSION
+    ):
+        raise EvidenceSearchInvalidated("Evidence changed; restart the search from its first page.")
+    page_builder = builder.page_projection_builder(app_id)
+    rows = scan_evidence(
+        page_builder,
+        filters.query,
+        app_id,
+        source_types=(filters.source,) if filters.source else (),
+        actor_id=None,
+        module=filters.module_text,
+        date_from=filters.date_from,
+        date_to=filters.date_to,
+        after=(cursor.after_sort_time, cursor.after_observation_id) if cursor else None,
+        page_builder=page_builder,
+    )
+    raw_items: list[dict[str, object]] = []
+    scanned_rows = 0
+    eligible = 0
+    last_position: dict[str, str] | None = None
+    has_more = False
+    for position, projected, more in rows:
+        scanned_rows += 1
+        last_position = position
+        has_more = more
+        if projected is None:
+            if scanned_rows == EVIDENCE_SEARCH_SCAN_BUDGET:
+                break
+            continue
+        if not _is_admitted_search_object(page_builder, app_id, projected):
+            if scanned_rows == EVIDENCE_SEARCH_SCAN_BUDGET:
+                break
+            continue
+        eligible += 1
+        raw_items.append(projected)
+        if len(raw_items) == EVIDENCE_SEARCH_PAGE_SIZE:
+            break
+        if scanned_rows == EVIDENCE_SEARCH_SCAN_BUDGET:
+            break
+    links, complete, limits, attempts = _enrich(page_builder, app_id, raw_items)
+    items = tuple(
+        EvidenceSearchItem(
+            evidence_id=str(value["evidence_id"]),
+            object_id=str(value["object_id"]),
+            source=str(value["source"]),
+            kind=str(value["kind"]),
+            title=(str(value["title"])[:500] if value.get("title") is not None else None),
+            period_from=str(value["date_from"]) if value.get("date_from") is not None else None,
+            period_to=str(value["date_to"]) if value.get("date_to") is not None else None,
+            period_status=str(value["period_status"]),
+            period_limitations=_period_limitations(
+                str(value["period_status"]), filters.date_from, filters.date_to
+            ),
+            links=links[index],
+            link_completeness=complete[index],
+            link_limit_reason=cast(
+                Literal["projection_budget", "display_cap"] | None,
+                limits[index] if limits[index] in {"projection_budget", "display_cap"} else None,
+            ),
+        )
+        for index, value in enumerate(raw_items)
+    )
+    next_cursor = (
+        EvidenceSearchCursor(
+            app_id=app_id,
+            filters=filters,
+            revision=revision,
+            read_model_version=TUI_EVIDENCE_SEARCH_READ_MODEL_VERSION,
+            after_sort_time=last_position["sort_time"],
+            after_observation_id=last_position["observation_id"],
+        )
+        if has_more and last_position is not None
+        else None
+    )
+    readiness = _freeze(page_builder.source_status(app_id))
+    assert isinstance(readiness, Mapping)
+    return EvidenceSearchPage(
+        app_id=app_id,
+        filters=filters,
+        items=items,
+        next_cursor=next_cursor,
+        revision=revision,
+        read_model_version=TUI_EVIDENCE_SEARCH_READ_MODEL_VERSION,
+        readiness=readiness,
+        limitations=(
+            "Undated evidence is excluded while an activity-date filter is supplied."
+            if filters.date_from or filters.date_to
+            else "Undated evidence is included when no activity-date filter is supplied.",
+        ),
+        diagnostics=EvidenceSearchDiagnostics(
+            scanned_rows=scanned_rows,
+            eligible_results=eligible,
+            returned_results=len(items),
+            projection_attempts=attempts,
+            projection_budget=EVIDENCE_SEARCH_PROJECTION_BUDGET,
+            display_link_count=sum(len(item.links) for item in items),
+        ),
+    )

--- a/src/worktrace/read_workspace.py
+++ b/src/worktrace/read_workspace.py
@@ -6,15 +6,23 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 
+from worktrace.candidates.decisions import CREATION_ACTIONS
 from worktrace.candidates.projector import project_candidate
 from worktrace.config import WorkTraceConfig
 from worktrace.constants import MAX_EXCERPT_CHARS
 from worktrace.db.connection import connect_read_only
 from worktrace.db.readiness import DatabaseReadinessStatus, database_readiness
-from worktrace.errors import DatabaseError, ScopeViolation
+from worktrace.errors import DatabaseError, NotFound, ScopeViolation
 from worktrace.packets.builder import PacketBuilder
 from worktrace.packets.gaps import build_gap_report
 from worktrace.read_models.candidates import CandidateCursor, CandidatePage, candidate_page
+from worktrace.read_models.evidence_search import (
+    EvidenceSearchCursor,
+    EvidenceSearchFilters,
+    EvidenceSearchPage,
+    evidence_search_page,
+    normalize_evidence_search_filters,
+)
 
 TUI_BUSY_TIMEOUT_MS = 500
 
@@ -166,13 +174,49 @@ class ReadOnlyWorkspace:
                 cursor=cursor,
             )
 
+    def search_evidence(
+        self,
+        app_id: str,
+        filters: EvidenceSearchFilters,
+        *,
+        cursor: EvidenceSearchCursor | None = None,
+        expected_revision: int | None = None,
+    ) -> EvidenceSearchPage:
+        """Search current evidence with a TUI-only, revision-bound continuation."""
+
+        self._config.app(app_id)
+        normalized = normalize_evidence_search_filters(
+            filters.query,
+            source=filters.source,
+            module_text=filters.module_text,
+            date_from=filters.date_from,
+            date_to=filters.date_to,
+        )
+        with self._read_snapshot() as connection:
+            return evidence_search_page(
+                connection,
+                PacketBuilder(connection, self._config),
+                app_id,
+                normalized,
+                cursor=cursor,
+                expected_revision=expected_revision,
+            )
+
     def contribution_review(self, app_id: str, candidate_id: str) -> ContributionReview:
         self._config.app(app_id)
         with self._read_snapshot() as connection:
-            projected = project_candidate(connection, candidate_id)
-            if projected.app_id != app_id:
+            builder = PacketBuilder(connection, self._config)
+            canonical = builder.resolve_contribution(candidate_id)
+            if canonical.app_id != app_id:
                 raise ScopeViolation("candidate belongs to another application")
-            packet = PacketBuilder(connection, self._config).build_packet(candidate_id)
+            resolved_candidate_id = canonical.candidate_id or candidate_id
+            try:
+                projected = project_candidate(connection, resolved_candidate_id)
+            except NotFound:
+                projected = None
+            if projected is not None and projected.app_id != app_id:
+                raise ScopeViolation("candidate belongs to another application")
+            packet = builder.build_packet(candidate_id)
             contribution = packet.get("contribution")
             if not isinstance(contribution, dict) or contribution.get("app_id") != app_id:
                 raise ScopeViolation("candidate belongs to another application")
@@ -209,11 +253,31 @@ class ReadOnlyWorkspace:
                     )
                     for row in rows
                 )
+            lineage = builder._decision_projection
+            if lineage is None:
+                lineage = builder.page_projection_builder(app_id)._decision_projection
+            canonical_lineage = (
+                lineage.resolve_lineage(candidate_id, app_id=app_id)
+                if lineage is not None
+                else None
+            )
+            confirmed = bool(
+                canonical_lineage
+                and any(
+                    decision.action in CREATION_ACTIONS for decision in canonical_lineage.decisions
+                )
+            )
         return ContributionReview(
             app_id=app_id,
-            candidate_id=candidate_id,
+            candidate_id=resolved_candidate_id,
             resolved_contribution_id=contribution_id,
-            status=projected.status,
+            status=(
+                projected.status
+                if projected is not None
+                else "confirmed"
+                if confirmed
+                else "suggestion"
+            ),
             packet=packet,
             gaps=build_gap_report(packet),
             unsupported_members=unsupported,

--- a/src/worktrace/tui/app.py
+++ b/src/worktrace/tui/app.py
@@ -19,6 +19,7 @@ from worktrace.tui.screens.applications import ApplicationScreen
 from worktrace.tui.screens.base import WorkTraceModal, WorkTraceScreen
 from worktrace.tui.screens.candidates import CandidateScreen
 from worktrace.tui.screens.contribution import ContributionScreen
+from worktrace.tui.screens.evidence_search import EvidenceSearchScreen
 
 # Below this width the candidate browser uses the four-column compact table; the
 # six-column full layout is reserved for the documented full terminal size.
@@ -44,6 +45,10 @@ j/k     Move selection
 Arrows  Scroll focused details
 Enter   Open
 n/p     Next/previous candidate page
+/       Search the selected application's current evidence
+Search  Enter submits query/source/module/from/to filters
+Search  Tab traverses form, results, and canonical links
+Search  n/p pages outside editable fields; incomplete links name their limit
 1-5     Contribution tabs
 
 The UI cannot import, modify, rebuild, export, or contact providers.
@@ -230,6 +235,12 @@ class WorkTraceApp(App[None], inherit_bindings=False):
                 "Return to the selected application's candidate page",
                 self.action_return_to_candidates,
             )
+        if isinstance(screen, EvidenceSearchScreen) and self.current_app_id is not None:
+            yield SystemCommand(
+                "Return to candidates",
+                "Return to the selected application's candidate page",
+                self.action_return_to_candidates,
+            )
 
     def action_copy_text(self) -> None:
         """No selected-text clipboard path exists in WorkTrace."""
@@ -389,6 +400,14 @@ class WorkTraceApp(App[None], inherit_bindings=False):
             self.push_screen(screen)
         else:
             self._show_screen(screen)
+
+    def open_evidence_search(self, app_id: str) -> None:
+        application = self._application(app_id)
+        if application is None:
+            self._show_screen(InitialErrorScreen(FailureKind.OUT_OF_SCOPE))
+            return
+        self.current_app_id = app_id
+        self.push_screen(EvidenceSearchScreen(application))
 
 
 def run_worktrace_ui(

--- a/src/worktrace/tui/messages.py
+++ b/src/worktrace/tui/messages.py
@@ -6,6 +6,7 @@ from textual.message import Message
 
 from worktrace.errors import DatabaseError, NotFound, ScopeViolation
 from worktrace.read_models.candidates import CandidateGenerationChanged, CandidatePage
+from worktrace.read_models.evidence_search import EvidenceSearchInvalidated, EvidenceSearchPage
 from worktrace.read_workspace import (
     ApplicationSummary,
     ContributionReview,
@@ -18,6 +19,7 @@ from worktrace.read_workspace import (
 class FailureKind(StrEnum):
     BUSY = "busy"
     GENERATION_CHANGED = "generation_changed"
+    EVIDENCE_CHANGED = "evidence_changed"
     NOT_FOUND = "not_found"
     OUT_OF_SCOPE = "out_of_scope"
     UPGRADE_REQUIRED = "upgrade_required"
@@ -31,6 +33,8 @@ def failure_kind(error: Exception) -> FailureKind:
         return FailureKind.BUSY
     if isinstance(error, CandidateGenerationChanged):
         return FailureKind.GENERATION_CHANGED
+    if isinstance(error, EvidenceSearchInvalidated):
+        return FailureKind.EVIDENCE_CHANGED
     if isinstance(error, NotFound):
         return FailureKind.NOT_FOUND
     if isinstance(error, ScopeViolation):
@@ -60,6 +64,13 @@ class SourceStatusLoaded(Message):
 
 class CandidatePageLoaded(Message):
     def __init__(self, request_id: int, page: CandidatePage) -> None:
+        super().__init__()
+        self.request_id = request_id
+        self.page = page
+
+
+class EvidenceSearchPageLoaded(Message):
+    def __init__(self, request_id: int, page: EvidenceSearchPage) -> None:
         super().__init__()
         self.request_id = request_id
         self.page = page

--- a/src/worktrace/tui/screens/candidates.py
+++ b/src/worktrace/tui/screens/candidates.py
@@ -111,6 +111,7 @@ class CandidateScreen(WorkTraceScreen):
         Binding("n", "next_page", "Next page"),
         Binding("p", "previous_page", "Previous page"),
         Binding("r", "refresh", "Refresh"),
+        Binding("/", "open_evidence_search", "Search evidence"),
         Binding("a", "app.switch_application", "Switch app"),
         Binding("y", "app.copy_selected_id", "Copy ID"),
         Binding("q,escape", "app.quit", "Quit"),
@@ -166,6 +167,14 @@ class CandidateScreen(WorkTraceScreen):
         self.query_one("#candidate-message", Static).update("Refreshing read-only data…")
         self._load_source_status()
         self._begin_page_load(None, "restart")
+
+    def action_open_evidence_search(self) -> None:
+        if self._page_load_in_flight():
+            self.app.notify(
+                "Wait for candidate paging to settle before searching evidence.", markup=False
+            )
+            return
+        cast("WorkTraceApp", self.app).open_evidence_search(self.application.app_id)
 
     def action_cursor_down(self) -> None:
         focused = self.focused

--- a/src/worktrace/tui/screens/evidence_search.py
+++ b/src/worktrace/tui/screens/evidence_search.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
+
+from rich.text import Text
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding, BindingType
+from textual.containers import VerticalScroll
+from textual.widgets import Button, DataTable, Footer, Input, Static
+
+from worktrace.read_models.evidence_search import (
+    CandidateLink,
+    EvidenceSearchCursor,
+    EvidenceSearchFilters,
+    EvidenceSearchItem,
+    EvidenceSearchPage,
+    EvidenceSearchValidationError,
+    normalize_evidence_search_filters,
+)
+from worktrace.tui.messages import (
+    EvidenceExcerptLoaded,
+    EvidenceSearchPageLoaded,
+    FailureKind,
+    ReadFailed,
+    failure_kind,
+)
+from worktrace.tui.modals.evidence import EvidenceModal
+from worktrace.tui.screens.base import WorkTraceScreen
+from worktrace.tui.terminal_text import literal_dynamic_text
+
+if TYPE_CHECKING:
+    from worktrace.read_workspace import ApplicationSummary
+    from worktrace.tui.app import WorkTraceApp
+
+
+_PageDirection = Literal["submit", "next", "previous", "restart"]
+_EVIDENCE_PREFIXES = frozenset(
+    {"obs", "participation", "part", "availability", "decision", "ref", "reference"}
+)
+_CONTRIBUTION_PREFIXES = frozenset({"candidate", "contribution"})
+
+_FAILURE_TEXT = {
+    FailureKind.BUSY: "WorkTrace data is busy.",
+    FailureKind.EVIDENCE_CHANGED: "Evidence changed while searching. Restarting this search once.",
+    FailureKind.NOT_FOUND: "The requested evidence is no longer available. Retry the search.",
+    FailureKind.OUT_OF_SCOPE: "The requested evidence is outside this application.",
+    FailureKind.UPGRADE_REQUIRED: "Exit and run `worktrace init`, then retry.",
+    FailureKind.UNSUPPORTED_NEWER: "Upgrade WorkTrace before opening this database.",
+    FailureKind.DATABASE: "WorkTrace could not read the database. Run `worktrace doctor`.",
+    FailureKind.UNEXPECTED: "WorkTrace could not complete this read.",
+}
+
+
+@dataclass(slots=True)
+class _HistoryEntry:
+    cursor: EvidenceSearchCursor | None
+    revision: int
+    result_row: int = 0
+    link_row: int = 0
+
+
+def _append_dynamic(output: Text, value: object) -> None:
+    output.append_text(literal_dynamic_text(value))
+
+
+def _append_filter(output: Text, label: str, value: str | None) -> None:
+    output.append(f"{label}: ")
+    _append_dynamic(output, value or "any")
+    output.append("  ")
+
+
+def _readiness_summary(readiness: object) -> str:
+    """Return a bounded, literal-safe summary without treating source state as truth."""
+    if not isinstance(readiness, Mapping):
+        return "not recorded"
+    sources = sorted(str(source) for source in readiness)
+    return ", ".join(sources) if sources else "no source status recorded"
+
+
+class EvidenceSearchScreen(WorkTraceScreen):
+    """Bounded, explicitly submitted evidence discovery above candidate review."""
+
+    ALLOW_SELECT = False
+    BINDINGS: ClassVar[list[BindingType]] = [
+        Binding("n", "next_page", "Next page"),
+        Binding("p", "previous_page", "Previous page"),
+        Binding("r", "retry", "Retry"),
+        Binding("a", "app.switch_application", "Switch app"),
+        Binding("y", "app.copy_selected_id", "Copy ID"),
+        Binding("q,escape", "back", "Back"),
+    ]
+
+    def __init__(self, application: ApplicationSummary) -> None:
+        super().__init__()
+        self.application = application
+        self._draft_query = ""
+        self._draft_source = ""
+        self._draft_module = ""
+        self._draft_from = ""
+        self._draft_to = ""
+        self._submitted_filters: EvidenceSearchFilters | None = None
+        self._page: EvidenceSearchPage | None = None
+        self._items: tuple[EvidenceSearchItem, ...] = ()
+        self._selected_links: tuple[CandidateLink, ...] = ()
+        self._committed_history: list[_HistoryEntry] = []
+        self._pending_direction: _PageDirection | None = None
+        self._pending_cursor: EvidenceSearchCursor | None = None
+        self._pending_filters: EvidenceSearchFilters | None = None
+        self._pending_expected_revision: int | None = None
+        self._page_request_id = 0
+        self._excerpt_request_id = 0
+        self._restart_attempted = False
+
+    def compose(self) -> ComposeResult:
+        title = Text("Evidence search / ")
+        _append_dynamic(title, self.application.name)
+        yield Static(title, id="evidence-search-title", classes="page-title", markup=False)
+        yield Static(
+            "Enter literal search terms, then choose Search. No search runs automatically.",
+            id="evidence-search-message",
+            markup=False,
+        )
+        with VerticalScroll(id="evidence-search-form", can_focus=True):
+            yield Input(placeholder="Query (required)", id="evidence-search-query")
+            yield Input(
+                placeholder="Source: git, jira, gitlab, or manual",
+                id="evidence-search-source",
+            )
+            yield Input(placeholder="Module text (optional)", id="evidence-search-module")
+            yield Input(placeholder="From: YYYY-MM-DD (optional)", id="evidence-search-from")
+            yield Input(placeholder="To: YYYY-MM-DD (optional)", id="evidence-search-to")
+            yield Button("Search", id="evidence-search-submit", variant="primary")
+        yield Static(id="evidence-search-status", classes="notice", markup=False)
+        yield DataTable(id="evidence-search-results", cursor_type="row", zebra_stripes=True)
+        yield Static(
+            "No selected evidence result.",
+            id="evidence-search-result-detail",
+            classes="notice",
+            markup=False,
+        )
+        yield DataTable(id="evidence-search-links", cursor_type="row", zebra_stripes=True)
+        yield Static(id="evidence-search-link-detail", classes="notice", markup=False)
+        yield Footer()
+
+    def on_mount(self) -> None:
+        results = self.query_one("#evidence-search-results", DataTable)
+        results.add_columns("Source", "Kind", "Evidence", "Period", "Links")
+        links = self.query_one("#evidence-search-links", DataTable)
+        links.add_columns("Contribution", "State", "Role", "Basis", "Evidence")
+        self.query_one("#evidence-search-query", Input).focus()
+        self._render_status()
+
+    def on_unmount(self) -> None:
+        # Workers own their connections; invalidating IDs makes late messages inert.
+        self._page_request_id += 1
+        self._excerpt_request_id += 1
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        value = event.value
+        if event.input.id == "evidence-search-query":
+            self._draft_query = value
+        elif event.input.id == "evidence-search-source":
+            self._draft_source = value
+        elif event.input.id == "evidence-search-module":
+            self._draft_module = value
+        elif event.input.id == "evidence-search-from":
+            self._draft_from = value
+        elif event.input.id == "evidence-search-to":
+            self._draft_to = value
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        self.action_submit()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "evidence-search-submit":
+            self.action_submit()
+
+    def action_submit(self) -> None:
+        try:
+            filters = normalize_evidence_search_filters(
+                self._draft_query,
+                source=self._draft_source,
+                module_text=self._draft_module,
+                date_from=self._draft_from,
+                date_to=self._draft_to,
+            )
+        except EvidenceSearchValidationError as error:
+            self.query_one("#evidence-search-message", Static).update(literal_dynamic_text(error))
+            return
+        self._restart_attempted = False
+        self._submitted_filters = filters
+        self._begin_page_load(None, "submit", filters, expected_revision=None)
+
+    def action_next_page(self) -> None:
+        if self._editable_focus() or self._page_load_in_flight():
+            return
+        if self._page is None:
+            self.app.notify("Submit a search before moving to another page.", markup=False)
+            return
+        if self._page.next_cursor is None:
+            self.app.notify("No later evidence page is available.", markup=False)
+            return
+        self._save_current_selection()
+        self._begin_page_load(
+            self._page.next_cursor,
+            "next",
+            self._page.filters,
+            expected_revision=self._page.revision,
+        )
+
+    def action_previous_page(self) -> None:
+        if self._editable_focus() or self._page_load_in_flight():
+            return
+        if len(self._committed_history) <= 1 or self._page is None:
+            self.app.notify("Already on the first evidence page.", markup=False)
+            return
+        self._save_current_selection()
+        self._begin_page_load(
+            self._committed_history[-2].cursor,
+            "previous",
+            self._page.filters,
+            expected_revision=self._committed_history[-2].revision,
+        )
+
+    def action_retry(self) -> None:
+        if self._page_load_in_flight() or self._submitted_filters is None:
+            return
+        self._restart_attempted = False
+        self._begin_page_load(None, "restart", self._submitted_filters, expected_revision=None)
+
+    def action_back(self) -> None:
+        self._page_request_id += 1
+        self._excerpt_request_id += 1
+        self.app.pop_screen()
+
+    def selected_stable_id(self) -> tuple[str, frozenset[str]] | None:
+        focused = self.focused
+        if (
+            isinstance(focused, DataTable)
+            and focused.id == "evidence-search-results"
+            and 0 <= focused.cursor_row < len(self._items)
+        ):
+            return self._items[focused.cursor_row].evidence_id, _EVIDENCE_PREFIXES
+        if (
+            isinstance(focused, DataTable)
+            and focused.id == "evidence-search-links"
+            and 0 <= focused.cursor_row < len(self._selected_links)
+        ):
+            return self._selected_links[focused.cursor_row].identifier, _CONTRIBUTION_PREFIXES
+        return None
+
+    def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:
+        if event.data_table.id == "evidence-search-results":
+            self._open_evidence_row(event.cursor_row)
+        elif event.data_table.id == "evidence-search-links":
+            self._open_link_row(event.cursor_row)
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        if event.data_table.id == "evidence-search-results":
+            self._select_result(event.cursor_row)
+        elif event.data_table.id == "evidence-search-links":
+            self._render_link_detail(event.cursor_row)
+
+    def _editable_focus(self) -> bool:
+        return isinstance(self.focused, Input)
+
+    def _page_load_in_flight(self) -> bool:
+        return self._pending_direction is not None
+
+    def _begin_page_load(
+        self,
+        cursor: EvidenceSearchCursor | None,
+        direction: _PageDirection,
+        filters: EvidenceSearchFilters,
+        *,
+        expected_revision: int | None,
+    ) -> None:
+        self._page_request_id += 1
+        request_id = self._page_request_id
+        self._pending_direction = direction
+        self._pending_cursor = cursor
+        self._pending_filters = filters
+        self._pending_expected_revision = expected_revision
+        self.query_one("#evidence-search-message", Static).update("Searching current evidence…")
+        self.search_evidence_page(request_id, filters, cursor, expected_revision)
+
+    @work(thread=True, exclusive=True, group="evidence-search-page", exit_on_error=False)
+    def search_evidence_page(
+        self,
+        request_id: int,
+        filters: EvidenceSearchFilters,
+        cursor: EvidenceSearchCursor | None,
+        expected_revision: int | None,
+    ) -> None:
+        try:
+            page = cast("WorkTraceApp", self.app).workspace.search_evidence(
+                self.application.app_id,
+                filters,
+                cursor=cursor,
+                expected_revision=expected_revision,
+            )
+        except Exception as error:
+            self.post_message(ReadFailed("evidence_search", request_id, failure_kind(error)))
+        else:
+            self.post_message(EvidenceSearchPageLoaded(request_id, page))
+
+    @work(thread=True, exclusive=True, group="evidence-search-excerpt", exit_on_error=False)
+    def load_excerpt(self, request_id: int, evidence_id: str) -> None:
+        try:
+            excerpt = cast("WorkTraceApp", self.app).workspace.evidence_excerpt(
+                self.application.app_id,
+                evidence_id,
+                max_chars=4_000,
+            )
+        except Exception as error:
+            self.post_message(
+                ReadFailed("evidence_search_excerpt", request_id, failure_kind(error))
+            )
+        else:
+            self.post_message(EvidenceExcerptLoaded(request_id, excerpt))
+
+    def on_evidence_search_page_loaded(self, message: EvidenceSearchPageLoaded) -> None:
+        if not self._accept_page_response(message.request_id):
+            return
+        direction = self._pending_direction
+        cursor = self._pending_cursor
+        filters = self._pending_filters
+        expected_revision = self._pending_expected_revision
+        self._pending_direction = None
+        self._pending_cursor = None
+        self._pending_filters = None
+        self._pending_expected_revision = None
+        if direction is None or filters is None:
+            return
+        if expected_revision is not None and message.page.revision != expected_revision:
+            self._restart_after_invalidation()
+            return
+        if direction == "submit":
+            self._committed_history = [_HistoryEntry(cursor, message.page.revision)]
+        elif direction == "next":
+            self._committed_history.append(_HistoryEntry(cursor, message.page.revision))
+        elif direction == "previous" and len(self._committed_history) > 1:
+            self._committed_history.pop()
+        elif direction == "restart":
+            self._committed_history = [_HistoryEntry(cursor, message.page.revision)]
+        self._page = message.page
+        self._items = message.page.items
+        self._render_page()
+        self._restore_current_selection()
+        self._render_status()
+        self.query_one("#evidence-search-message", Static).update(
+            "Read-only evidence search loaded."
+        )
+
+    def on_evidence_excerpt_loaded(self, message: EvidenceExcerptLoaded) -> None:
+        if message.request_id != self._excerpt_request_id:
+            return
+        self.query_one("#evidence-search-message", Static).update(
+            "Read-only evidence search loaded."
+        )
+        self.app.push_screen(EvidenceModal(message.excerpt))
+
+    def on_read_failed(self, message: ReadFailed) -> None:
+        if message.operation == "evidence_search_excerpt":
+            if message.request_id == self._excerpt_request_id:
+                self.query_one("#evidence-search-message", Static).update(
+                    _FAILURE_TEXT[message.kind]
+                )
+            return
+        if message.operation != "evidence_search" or not self._accept_page_response(
+            message.request_id
+        ):
+            return
+        direction = self._pending_direction
+        self._pending_direction = None
+        self._pending_cursor = None
+        self._pending_filters = None
+        self._pending_expected_revision = None
+        if message.kind is FailureKind.EVIDENCE_CHANGED:
+            self._restart_after_invalidation()
+            return
+        failure = _FAILURE_TEXT[message.kind]
+        if self._page is None:
+            if direction == "restart":
+                failure += " The automatic restart failed. No stale rows remain. Press r to retry."
+            else:
+                failure += " No evidence page was loaded. Press r to retry."
+        else:
+            failure += " The successful search page remains available."
+        self.query_one("#evidence-search-message", Static).update(failure)
+
+    def _restart_after_invalidation(self) -> None:
+        if self._submitted_filters is not None and not self._restart_attempted:
+            self._restart_attempted = True
+            self._clear_loaded_page()
+            self.query_one("#evidence-search-message", Static).update(
+                _FAILURE_TEXT[FailureKind.EVIDENCE_CHANGED]
+            )
+            self._begin_page_load(
+                None,
+                "restart",
+                self._submitted_filters,
+                expected_revision=None,
+            )
+            return
+        self._clear_loaded_page()
+        self.query_one("#evidence-search-message", Static).update(
+            "Evidence changed again. No stale rows remain. Press r to retry."
+        )
+
+    def _accept_page_response(self, request_id: int) -> bool:
+        return (
+            request_id == self._page_request_id
+            and self.is_mounted
+            and cast("WorkTraceApp", self.app).current_app_id == self.application.app_id
+        )
+
+    def _clear_loaded_page(self) -> None:
+        self._page = None
+        self._items = ()
+        self._selected_links = ()
+        self._committed_history = []
+        self.query_one("#evidence-search-results", DataTable).clear()
+        self.query_one("#evidence-search-links", DataTable).clear()
+        self.query_one("#evidence-search-link-detail", Static).update(
+            "No selected canonical contribution link."
+        )
+        self._render_status()
+
+    def _render_page(self) -> None:
+        results = self.query_one("#evidence-search-results", DataTable)
+        results.clear()
+        for index, item in enumerate(self._items):
+            period = item.period_from or "Undated"
+            if item.period_to and item.period_to != item.period_from:
+                period = f"{period} → {item.period_to}"
+            coverage = (
+                "complete" if item.link_completeness else item.link_limit_reason or "incomplete"
+            )
+            results.add_row(
+                literal_dynamic_text(item.source),
+                literal_dynamic_text(item.kind),
+                literal_dynamic_text(item.title or item.evidence_id),
+                literal_dynamic_text(period),
+                literal_dynamic_text(f"{len(item.links)} {coverage}"),
+                key=f"evidence-search-row-{index}",
+            )
+        if not self._items:
+            if self._page is not None and self._page.next_cursor is not None:
+                state = "No eligible evidence on this bounded scan. Press n to continue."
+            else:
+                state = "No current evidence matched the submitted filters."
+            self.query_one("#evidence-search-message", Static).update(state)
+        self._select_result(0)
+
+    def _select_result(self, row_index: int) -> None:
+        if not 0 <= row_index < len(self._items):
+            self._selected_links = ()
+            self.query_one("#evidence-search-links", DataTable).clear()
+            self.query_one("#evidence-search-result-detail", Static).update(
+                "No selected evidence result."
+            )
+            self.query_one("#evidence-search-link-detail", Static).update(
+                "No selected canonical contribution link."
+            )
+            return
+        item = self._items[row_index]
+        self._selected_links = item.links
+        result_detail = Text("Observation ID: ")
+        _append_dynamic(result_detail, item.evidence_id)
+        result_detail.append("\nSource object ID: ")
+        _append_dynamic(result_detail, item.object_id)
+        self.query_one("#evidence-search-result-detail", Static).update(result_detail)
+        links = self.query_one("#evidence-search-links", DataTable)
+        links.clear()
+        for index, link in enumerate(item.links):
+            links.add_row(
+                literal_dynamic_text(link.identifier),
+                literal_dynamic_text(link.status),
+                literal_dynamic_text(link.role),
+                literal_dynamic_text(link.confirmation_basis),
+                literal_dynamic_text(link.evidence_state),
+                key=f"evidence-search-link-{index}",
+            )
+        if item.link_completeness:
+            detail = "Canonical link evaluation complete."
+        else:
+            reason = (
+                "projection budget"
+                if item.link_limit_reason == "projection_budget"
+                else "display cap"
+            )
+            detail = f"Canonical links are incomplete: {reason} reached; exact total is unknown."
+        self.query_one("#evidence-search-link-detail", Static).update(detail)
+        self._render_link_detail(0)
+
+    def _render_link_detail(self, row_index: int) -> None:
+        if not 0 <= row_index < len(self._selected_links):
+            return
+        link = self._selected_links[row_index]
+        output = Text()
+        results = self.query_one("#evidence-search-results", DataTable)
+        item = (
+            self._items[results.cursor_row] if 0 <= results.cursor_row < len(self._items) else None
+        )
+        if item is not None:
+            output.append("Link evaluation: ")
+            if item.link_completeness:
+                output.append("complete")
+            else:
+                _append_dynamic(
+                    output,
+                    (
+                        f"incomplete ({item.link_limit_reason or 'unknown reason'}; "
+                        "exact total unknown)"
+                    ),
+                )
+            output.append("\n")
+        output.append("Canonical contribution: ")
+        _append_dynamic(output, link.identifier)
+        output.append("  |  limitations: ")
+        _append_dynamic(output, "; ".join(link.limitations) or "none recorded")
+        self.query_one("#evidence-search-link-detail", Static).update(output)
+
+    def _open_evidence_row(self, row_index: int) -> None:
+        if not 0 <= row_index < len(self._items):
+            return
+        self._excerpt_request_id += 1
+        request_id = self._excerpt_request_id
+        self.query_one("#evidence-search-message", Static).update(
+            "Loading bounded evidence excerpt…"
+        )
+        self.load_excerpt(request_id, self._items[row_index].evidence_id)
+
+    def _open_link_row(self, row_index: int) -> None:
+        if not 0 <= row_index < len(self._selected_links):
+            return
+        cast("WorkTraceApp", self.app).open_contribution(
+            self.application.app_id,
+            self._selected_links[row_index].identifier,
+            return_to_existing=True,
+        )
+
+    def _save_current_selection(self) -> None:
+        if not self._committed_history:
+            return
+        results = self.query_one("#evidence-search-results", DataTable)
+        links = self.query_one("#evidence-search-links", DataTable)
+        self._committed_history[-1].result_row = max(0, results.cursor_row)
+        self._committed_history[-1].link_row = max(0, links.cursor_row)
+
+    def _restore_current_selection(self) -> None:
+        if not self._committed_history or not self._items:
+            return
+        entry = self._committed_history[-1]
+        result_row = min(entry.result_row, len(self._items) - 1)
+        results = self.query_one("#evidence-search-results", DataTable)
+        results.move_cursor(row=result_row)
+        self._select_result(result_row)
+        if self._selected_links:
+            links = self.query_one("#evidence-search-links", DataTable)
+            links.move_cursor(row=min(entry.link_row, len(self._selected_links) - 1))
+            self._render_link_detail(links.cursor_row)
+
+    def _render_status(self) -> None:
+        output = Text()
+        filters = self._submitted_filters
+        if filters is None:
+            output.append("Submitted filters: none")
+        else:
+            output.append("Submitted filters: ")
+            _append_filter(output, "query", filters.query)
+            _append_filter(output, "source", filters.source)
+            _append_filter(output, "module", filters.module_text)
+            _append_filter(output, "from", filters.date_from)
+            _append_filter(output, "to", filters.date_to)
+        page = self._page
+        if page is not None:
+            if filters is not None and page.filters != filters:
+                output.append("\nDisplayed page filters: ")
+                _append_filter(output, "query", page.filters.query)
+                _append_filter(output, "source", page.filters.source)
+                _append_filter(output, "module", page.filters.module_text)
+                _append_filter(output, "from", page.filters.date_from)
+                _append_filter(output, "to", page.filters.date_to)
+            output.append("\nPage: ")
+            _append_dynamic(output, len(self._committed_history))
+            output.append("  |  readiness: ")
+            _append_dynamic(output, _readiness_summary(page.readiness))
+            output.append("  |  scanned rows: ")
+            _append_dynamic(output, page.diagnostics.scanned_rows)
+            output.append("  |  projection attempts: ")
+            _append_dynamic(output, page.diagnostics.projection_attempts)
+            output.append("/")
+            _append_dynamic(output, page.diagnostics.projection_budget)
+            if page.limitations:
+                output.append("\nLimitations: ")
+                _append_dynamic(output, "; ".join(page.limitations))
+        self.query_one("#evidence-search-status", Static).update(output)

--- a/src/worktrace/tui/worktrace.tcss
+++ b/src/worktrace/tui/worktrace.tcss
@@ -64,6 +64,40 @@ TabbedContent {
     height: auto;
 }
 
+#evidence-search-form {
+    height: 6;
+    max-height: 6;
+    padding: 0 1;
+}
+
+#evidence-search-form:focus {
+    border: solid $accent;
+}
+
+#evidence-search-form Input {
+    height: 1;
+}
+
+#evidence-search-submit {
+    width: 16;
+    height: 1;
+}
+
+#evidence-search-status, #evidence-search-link-detail {
+    height: auto;
+    max-height: 3;
+}
+
+#evidence-search-result-detail {
+    height: 2;
+    max-height: 2;
+}
+
+#evidence-search-results, #evidence-search-links {
+    height: 1fr;
+    min-height: 3;
+}
+
 #evidence-dialog, #help-dialog, #terminal-dialog {
     width: 90%;
     height: 90%;

--- a/tests/test_evidence_search.py
+++ b/tests/test_evidence_search.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import worktrace.read_models.evidence_search as evidence_search_module
+from tests.public_workflow_support import PublicWorkflowFixture
+from tests.test_packets_golden import _packet_state
+from worktrace.candidates.decisions import append_decision
+from worktrace.config import load_config
+from worktrace.db.connection import connect, connect_read_only
+from worktrace.packets.builder import PacketBuilder
+from worktrace.read_models.evidence_search import (
+    CandidateLink,
+    CanonicalMembershipLocator,
+    EvidenceSearchCursor,
+    EvidenceSearchInvalidated,
+    EvidenceSearchValidationError,
+    evidence_search_page,
+    normalize_evidence_search_filters,
+)
+from worktrace.read_workspace import ReadOnlyWorkspace
+
+
+def _locator(key: str) -> CanonicalMembershipLocator:
+    return CanonicalMembershipLocator(
+        key=key,
+        identifier=f"candidate:{key}",
+        contribution_id=None,
+        candidate_id=f"candidate:{key}",
+        confirmed=False,
+    )
+
+
+def _link(locator: CanonicalMembershipLocator) -> CandidateLink:
+    return CandidateLink(
+        candidate_id=locator.candidate_id,
+        contribution_id=None,
+        status="suggestion",
+        role="material",
+        confirmation_basis="suggestion",
+        evidence_state="authoritative_current",
+        limitations=(),
+    )
+
+
+def _enrich_with(
+    monkeypatch: pytest.MonkeyPatch,
+    locator_map: dict[str, tuple[CanonicalMembershipLocator, ...]],
+    resolver: Any,
+) -> tuple[list[tuple[CandidateLink, ...]], list[bool], list[str | None], int]:
+    monkeypatch.setattr(evidence_search_module, "_active_generation", lambda *_: None)
+    monkeypatch.setattr(
+        evidence_search_module,
+        "canonical_membership_locators",
+        lambda _builder, _app_id, object_id: locator_map[object_id],
+    )
+    monkeypatch.setattr(evidence_search_module, "_resolve_canonical_membership", resolver)
+    return evidence_search_module._enrich(
+        SimpleNamespace(connection=None),
+        "sample",
+        [{"object_id": object_id} for object_id in locator_map],
+    )
+
+
+def test_normalize_evidence_search_filters_trims_optionals_and_is_frozen() -> None:
+    filters = normalize_evidence_search_filters(
+        "  literal * and ?  ",
+        source=" git ",
+        module_text="  src/checkout/*?  ",
+        date_from=" 2026-01-01 ",
+        date_to="2026-01-31 ",
+    )
+
+    assert filters.query == "literal * and ?"
+    assert filters.source == "git"
+    assert filters.module_text == "src/checkout/*?"
+    assert filters.date_from == "2026-01-01"
+    assert filters.date_to == "2026-01-31"
+    with pytest.raises(FrozenInstanceError):
+        filters.query = "changed"  # type: ignore[misc]
+
+    blank_optionals = normalize_evidence_search_filters(
+        "literal", source=" ", module_text="\t", date_from="", date_to="  "
+    )
+    assert blank_optionals.source is None
+    assert blank_optionals.module_text is None
+    assert blank_optionals.date_from is None
+    assert blank_optionals.date_to is None
+
+
+@pytest.mark.parametrize(
+    ("query", "kwargs"),
+    [
+        ("", {}),
+        ("\x00", {}),
+        ("x" * 501, {}),
+        ("valid", {"source": "github"}),
+        ("valid", {"module_text": "\x00"}),
+        ("valid", {"module_text": "x" * 201}),
+        ("valid", {"date_from": "2026-02-30"}),
+        ("valid", {"date_to": "not-a-date"}),
+        ("valid", {"date_from": "2026-02-01", "date_to": "2026-01-31"}),
+    ],
+)
+def test_normalize_evidence_search_filters_rejects_invalid_inputs(
+    query: str, kwargs: dict[str, str]
+) -> None:
+    with pytest.raises(EvidenceSearchValidationError):
+        normalize_evidence_search_filters(query, **kwargs)
+
+
+def test_imported_synthetic_evidence_is_searchable_before_grouping(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Discovery is proved from actual public imports, not fixture membership rows."""
+    fixture = PublicWorkflowFixture.create(tmp_path, monkeypatch)
+    assert fixture.invoke("init").exit_code == 0
+    imported = fixture.invoke("import", "all", "sample")
+    assert imported.exit_code == 0, imported.output
+
+    config = load_config(fixture.config_path)
+    connection = connect_read_only(config.database_path)
+    try:
+        assert connection.execute("SELECT COUNT(*) FROM human_decisions").fetchone()[0] == 0
+    finally:
+        connection.close()
+
+    workspace = ReadOnlyWorkspace(config)
+    page = workspace.search_evidence(
+        "sample",
+        normalize_evidence_search_filters("DEMO-1 context"),
+    )
+
+    assert page.items
+    assert any(item.source == "git" for item in page.items)
+    assert page.diagnostics.returned_results == len(page.items)
+
+    literal_wildcard = workspace.search_evidence(
+        "sample",
+        normalize_evidence_search_filters("DEMO-*"),
+    )
+    assert literal_wildcard.items == ()
+
+    rebuilt = fixture.invoke("rebuild", "all", "sample")
+    assert rebuilt.exit_code == 0, rebuilt.output
+    linked = workspace.search_evidence(
+        "sample",
+        normalize_evidence_search_filters("DEMO-1 context"),
+    )
+    evidence = next(item for item in linked.items if item.source == "git")
+    link = next(item for item in evidence.links if item.role == "material")
+    assert link.status == "suggestion"
+    assert link.confirmation_basis == "suggestion"
+    assert link.contribution_id is None
+    assert link.candidate_id.startswith("candidate:")
+
+    review = workspace.contribution_review("sample", link.identifier)
+    assert review.status == "candidate"
+    summary = review.packet["evidence_summary"]
+    assert isinstance(summary, dict)
+    assert any(
+        isinstance(member, dict) and member.get("object_id") == evidence.object_id
+        for member in summary["members"]
+    )
+
+
+def test_unconfigured_current_row_is_excluded_without_skipping_configured_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = PublicWorkflowFixture.create(tmp_path, monkeypatch)
+    assert fixture.invoke("init").exit_code == 0
+    assert fixture.invoke("import", "all", "sample").exit_code == 0
+    config = load_config(fixture.config_path)
+    writer = connect(config.database_path)
+    try:
+        run_id = str(
+            writer.execute(
+                "SELECT id FROM sync_runs WHERE app_id='sample' AND source='git' "
+                "ORDER BY id LIMIT 1"
+            ).fetchone()[0]
+        )
+        writer.execute(
+            """
+            INSERT INTO source_objects(
+                id, app_id, source, source_instance, kind, external_id,
+                first_seen_run_id, last_seen_run_id
+            ) VALUES (
+                'obj:outside-scope', 'sample', 'git', 'unconfigured-repository', 'git_commit',
+                'outside', ?, ?
+            )
+            """,
+            (run_id, run_id),
+        )
+        writer.execute(
+            """
+            INSERT INTO observations(
+                id, source_object_id, sync_run_id, source_updated_at, fetched_at,
+                payload_hash, title, body_text, data_json, completeness,
+                adapter_version, normalization_version, redaction_version
+            ) VALUES (
+                'obs:outside-scope', 'obj:outside-scope', ?, '2026-04-01T12:00:00+00:00',
+                '2026-04-01T12:00:00+00:00', 'outside-hash',
+                'DEMO-1 context outside configured repository', 'outside', '{}', 'complete',
+                'fixture', '1', '1'
+            )
+            """,
+            (run_id,),
+        )
+        writer.commit()
+    finally:
+        writer.close()
+
+    page = ReadOnlyWorkspace(config).search_evidence(
+        "sample", normalize_evidence_search_filters("DEMO-1 context")
+    )
+    assert any(item.source == "git" for item in page.items)
+    assert all(item.evidence_id != "obs:outside-scope" for item in page.items)
+
+
+def test_revision_change_invalidates_a_previously_valid_tui_cursor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fixture = PublicWorkflowFixture.create(tmp_path, monkeypatch)
+    assert fixture.invoke("init").exit_code == 0
+    assert fixture.invoke("import", "all", "sample").exit_code == 0
+    config = load_config(fixture.config_path)
+    workspace = ReadOnlyWorkspace(config)
+    filters = normalize_evidence_search_filters("DEMO-1 context")
+    first = workspace.search_evidence("sample", filters)
+    cursor = EvidenceSearchCursor(
+        app_id="sample",
+        filters=filters,
+        revision=first.revision,
+        read_model_version=first.read_model_version,
+        after_sort_time="2026-01-01T00:00:00Z",
+        after_observation_id="obs:cursor-boundary",
+    )
+    writer = connect(config.database_path)
+    try:
+        writer.execute("UPDATE apps SET read_revision=read_revision+1 WHERE id='sample'")
+        writer.commit()
+    finally:
+        writer.close()
+
+    with pytest.raises(EvidenceSearchInvalidated, match="restart"):
+        workspace.search_evidence("sample", filters, cursor=cursor)
+    with pytest.raises(EvidenceSearchInvalidated, match="restart"):
+        workspace.search_evidence("sample", filters, expected_revision=first.revision)
+
+
+def test_canonical_review_opens_confirmed_history_after_generated_candidate_disappears(
+    tmp_path: Path,
+) -> None:
+    connection, _, config, candidate_id = _packet_state(tmp_path)
+    append_decision(
+        connection,
+        "confirm_candidate",
+        candidate_id,
+        {
+            "app_id": "sample_store",
+            "contribution_id": "contribution:rowless-history",
+            "title": "Surviving confirmed history",
+            "members": ["obj:commit"],
+        },
+    )
+    connection.execute("DELETE FROM candidate_members WHERE candidate_id=?", (candidate_id,))
+    connection.execute("DELETE FROM candidate_groups WHERE id=?", (candidate_id,))
+    connection.commit()
+    connection.close()
+
+    review = ReadOnlyWorkspace(config).contribution_review(
+        "sample_store", "contribution:rowless-history"
+    )
+    assert review.status == "confirmed"
+    assert review.resolved_contribution_id == "contribution:rowless-history"
+    contribution = review.packet["contribution"]
+    assert isinstance(contribution, dict)
+    assert contribution["id"] == "contribution:rowless-history"
+
+
+def test_page_wide_projection_budget_counts_failures_and_round_robins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unit-layer budget fixture: locators are synthetic, not discovery evidence."""
+    first = tuple(_locator(f"first-{index:02d}") for index in range(100))
+    second = (_locator("second"),)
+    calls: list[tuple[str, str]] = []
+
+    def resolve(
+        _builder: object,
+        _app_id: str,
+        object_id: str,
+        locator: CanonicalMembershipLocator,
+        *,
+        legacy_generated: bool,
+    ) -> CandidateLink | None:
+        assert legacy_generated is False
+        calls.append((object_id, locator.key))
+        return None
+
+    links, complete, limits, attempts = _enrich_with(
+        monkeypatch,
+        {"obj:first": first, "obj:second": second},
+        resolve,
+    )
+
+    assert attempts == 50
+    assert calls[:4] == [
+        ("obj:first", "first-00"),
+        ("obj:second", "second"),
+        ("obj:first", "first-01"),
+        ("obj:first", "first-02"),
+    ]
+    assert all(not values for values in links)
+    assert complete == [False, True]
+    assert limits == ["projection_budget", None]
+
+
+def test_cached_canonical_group_is_reused_after_projection_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    locator_map = {
+        "obj:cached": (_locator("shared"),),
+        "obj:target": (
+            *(_locator(f"unique-{index:02d}") for index in range(49)),
+            _locator("uncached-after-budget"),
+            _locator("shared"),
+        ),
+    }
+    calls: list[str] = []
+
+    def resolve(
+        _builder: object,
+        _app_id: str,
+        _object_id: str,
+        locator: CanonicalMembershipLocator,
+        *,
+        legacy_generated: bool,
+    ) -> CandidateLink | None:
+        assert legacy_generated is False
+        calls.append(locator.key)
+        return None if locator.key.startswith("unique-") else _link(locator)
+
+    links, complete, limits, attempts = _enrich_with(monkeypatch, locator_map, resolve)
+
+    assert attempts == 50
+    assert calls == ["shared", *[f"unique-{index:02d}" for index in range(49)]]
+    assert links[1] == (_link(_locator("shared")),)
+    assert complete[1] is False
+    assert limits[1] == "projection_budget"
+
+
+def test_link_display_cap_and_incomplete_empty_coverage_are_truthful(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    display_locators = tuple(_locator(f"display-{index}") for index in range(6))
+
+    def resolve_link(
+        _builder: object,
+        _app_id: str,
+        _object_id: str,
+        locator: CanonicalMembershipLocator,
+        *,
+        legacy_generated: bool,
+    ) -> CandidateLink:
+        assert legacy_generated is False
+        return _link(locator)
+
+    links, complete, limits, attempts = _enrich_with(
+        monkeypatch, {"obj:display": display_locators}, resolve_link
+    )
+    assert attempts == 5
+    assert len(links[0]) == 5
+    assert complete == [False]
+    assert limits == ["display_cap"]
+
+    failed = tuple(_locator(f"failed-{index:02d}") for index in range(51))
+    links, complete, limits, attempts = _enrich_with(
+        monkeypatch,
+        {"obj:failed": failed},
+        lambda *_args, **_kwargs: None,
+    )
+    assert attempts == 50
+    assert links == [()]
+    assert complete == [False]
+    assert limits == ["projection_budget"]
+
+
+def test_scanner_bounds_continue_across_empty_pages_without_skipping_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unit-layer scanner fixture: positions model the existing bounded scanner stream."""
+    from tests.test_packets_golden import _packet_state
+
+    connection, _, config, _ = _packet_state(tmp_path)
+    filters = normalize_evidence_search_filters("literal")
+    rows = [
+        (
+            {"sort_time": f"2026-01-01T00:00:{index:03d}Z", "observation_id": f"obs:{index:03d}"},
+            (
+                None
+                if index < 200
+                else {
+                    "evidence_id": f"obs:{index:03d}",
+                    "object_id": f"obj:{index:03d}",
+                    "source": "git",
+                    "kind": "git_commit",
+                    "title": f"literal {index:03d}",
+                    "date_from": "2026-01-01",
+                    "date_to": "2026-01-01",
+                    "period_status": "known",
+                }
+            ),
+        )
+        for index in range(221)
+    ]
+
+    def scan(
+        _builder: object,
+        _query: str,
+        _app_id: str,
+        *,
+        after: tuple[str, str] | None,
+        **_kwargs: object,
+    ) -> Any:
+        start = 0
+        if after is not None:
+            start = next(
+                index + 1
+                for index, (position, _) in enumerate(rows)
+                if position == {"sort_time": after[0], "observation_id": after[1]}
+            )
+        stop = min(start + 200, len(rows))
+        has_more = stop < len(rows)
+        return iter(
+            (position, projected, index < stop - 1 or has_more)
+            for index, (position, projected) in enumerate(rows[start:stop], start=start)
+        )
+
+    monkeypatch.setattr(evidence_search_module, "scan_evidence", scan)
+    monkeypatch.setattr(
+        evidence_search_module,
+        "_is_admitted_search_object",
+        lambda _builder, _app_id, _object_id: True,
+    )
+    monkeypatch.setattr(
+        evidence_search_module,
+        "_enrich",
+        lambda _builder, _app_id, raw: ([()] * len(raw), [True] * len(raw), [None] * len(raw), 0),
+    )
+    try:
+        first = evidence_search_page(
+            connection, PacketBuilder(connection, config), "sample_store", filters, cursor=None
+        )
+        assert first.items == ()
+        assert first.diagnostics.scanned_rows == 200
+        assert first.next_cursor is not None
+        assert first.next_cursor.after_observation_id == "obs:199"
+
+        second = evidence_search_page(
+            connection,
+            PacketBuilder(connection, config),
+            "sample_store",
+            filters,
+            cursor=first.next_cursor,
+        )
+        assert second.next_cursor is not None
+        third = evidence_search_page(
+            connection,
+            PacketBuilder(connection, config),
+            "sample_store",
+            filters,
+            cursor=second.next_cursor,
+        )
+    finally:
+        connection.close()
+
+    assert second.diagnostics.scanned_rows == 20
+    assert [item.evidence_id for item in second.items] == [
+        f"obs:{index:03d}" for index in range(200, 220)
+    ]
+    assert [item.evidence_id for item in third.items] == ["obs:220"]
+    assert third.next_cursor is None

--- a/tests/test_evidence_search_lifecycle.py
+++ b/tests/test_evidence_search_lifecycle.py
@@ -1,0 +1,222 @@
+"""Reader lifecycle proof for the bounded TUI evidence-search contract."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import worktrace.read_models.evidence_search as evidence_search_module
+from tests.public_workflow_support import PublicWorkflowFixture
+from tests.test_read_workspace import _workspace
+from worktrace.candidates.decisions import append_decision
+from worktrace.config import load_config
+from worktrace.db.connection import connect
+from worktrace.errors import NotFound
+from worktrace.read_models.evidence_search import (
+    EvidenceSearchInvalidated,
+    normalize_evidence_search_filters,
+)
+from worktrace.read_workspace import ReadOnlyWorkspace
+
+
+def _result_id(result: Any, key: str) -> str:
+    payload = json.loads(result.output)
+    value = payload[key]
+    assert isinstance(value, str) and value
+    return value
+
+
+def test_search_snapshot_stays_coherent_during_writer_and_next_read_invalidates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A writer cannot mix its new decision with this page's old snapshot."""
+
+    workspace, candidate_id = _workspace(tmp_path)
+    journal = sqlite3.connect(workspace.database_path, autocommit=True)
+    try:
+        assert str(journal.execute("PRAGMA journal_mode = WAL").fetchone()[0]) == "wal"
+    finally:
+        journal.close()
+    filters = normalize_evidence_search_filters("checkout")
+    baseline = workspace.search_evidence("sample_store", filters)
+    ready, committed = threading.Event(), threading.Event()
+    original_scan = evidence_search_module.scan_evidence
+    paused = False
+
+    def scan_then_pause(*args: Any, **kwargs: Any) -> Any:
+        nonlocal paused
+        rows = original_scan(*args, **kwargs)
+
+        def gated() -> Any:
+            nonlocal paused
+            for row in rows:
+                if not paused:
+                    paused = True
+                    ready.set()
+                    assert committed.wait(timeout=5)
+                yield row
+
+        return gated()
+
+    monkeypatch.setattr(evidence_search_module, "scan_evidence", scan_then_pause)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(workspace.search_evidence, "sample_store", filters)
+        assert ready.wait(timeout=5)
+        writer = connect(workspace.database_path)
+        try:
+            append_decision(
+                writer,
+                "confirm_candidate",
+                candidate_id,
+                {
+                    "app_id": "sample_store",
+                    "contribution_id": "contribution:concurrent-search",
+                    "title": "Concurrent search decision",
+                    "members": ["obj:commit", "obj:mr", "obj:jira"],
+                },
+            )
+        finally:
+            writer.close()
+            committed.set()
+        interleaved = future.result(timeout=5)
+
+    assert interleaved.revision == baseline.revision
+    assert interleaved.items == baseline.items
+    with pytest.raises(EvidenceSearchInvalidated):
+        workspace.search_evidence("sample_store", filters, expected_revision=interleaved.revision)
+
+
+def test_expected_revision_rejects_cursorless_history_before_scanning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace, candidate_id = _workspace(tmp_path)
+    filters = normalize_evidence_search_filters("checkout")
+    first = workspace.search_evidence("sample_store", filters)
+    writer = connect(workspace.database_path)
+    try:
+        append_decision(writer, "ignore_candidate", candidate_id, {"reason": "new revision"})
+    finally:
+        writer.close()
+
+    def must_not_scan(*_args: object, **_kwargs: object) -> Any:
+        raise AssertionError("expected-revision mismatch must happen before scanner work")
+
+    monkeypatch.setattr(evidence_search_module, "scan_evidence", must_not_scan)
+    with pytest.raises(EvidenceSearchInvalidated):
+        workspace.search_evidence("sample_store", filters, expected_revision=first.revision)
+
+
+def test_public_cli_corrections_keep_search_links_and_canonical_review_in_sync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Imported evidence is discovered before CLI corrections reshape its lineage."""
+
+    fixture = PublicWorkflowFixture.create(tmp_path, monkeypatch, bulk_keys=2)
+    assert fixture.invoke("init").exit_code == 0
+    assert fixture.invoke("import", "all", "sample").exit_code == 0
+    assert fixture.invoke("rebuild", "all", "sample").exit_code == 0
+    workspace = ReadOnlyWorkspace(load_config(fixture.config_path))
+    candidates = workspace.candidate_page("sample", page_size=50).items
+    primary = next(item for item in candidates if item.title and "DEMO-1 context" in item.title)
+    secondary = next(item for item in candidates if item.title and "DEMO-2" in item.title)
+    first_filters = normalize_evidence_search_filters("DEMO-1 context")
+    second_filters = normalize_evidence_search_filters("DEMO-2")
+    before = workspace.search_evidence("sample", first_filters)
+    first_item = next(item for item in before.items if item.links)
+    primary_link = next(
+        link for link in first_item.links if link.candidate_id == primary.candidate_id
+    )
+    assert primary_link.contribution_id is None and primary_link.role == "material"
+    context_link = next(link for link in first_item.links if link.role == "context")
+    context_review = workspace.contribution_review("sample", context_link.identifier)
+    context_summary = context_review.packet["evidence_summary"]
+    assert isinstance(context_summary, dict)
+    assert any(
+        isinstance(member, dict)
+        and member.get("object_id") == first_item.object_id
+        and member.get("context_only") is True
+        for member in context_summary["members"]
+    )
+
+    confirmed = fixture.invoke("confirm", primary.candidate_id)
+    assert confirmed.exit_code == 0, confirmed.output
+    contribution_id = _result_id(confirmed, "contribution_id")
+    confirmed_link = next(
+        link
+        for item in workspace.search_evidence("sample", first_filters).items
+        for link in item.links
+        if link.candidate_id == primary.candidate_id
+    )
+    assert confirmed_link.contribution_id == contribution_id
+    assert workspace.contribution_review("sample", confirmed_link.identifier).status == "confirmed"
+
+    second_item = next(
+        item for item in workspace.search_evidence("sample", second_filters).items if item.links
+    )
+    second_object_id = second_item.object_id
+    added = fixture.invoke("add-member", primary.candidate_id, second_object_id)
+    assert added.exit_code == 0, added.output
+    assert any(
+        link.candidate_id == primary.candidate_id and link.role == "material"
+        for item in workspace.search_evidence("sample", second_filters).items
+        for link in item.links
+    )
+
+    removed = fixture.invoke("remove-member", primary.candidate_id, first_item.object_id)
+    assert removed.exit_code == 0, removed.output
+    assert not any(
+        link.candidate_id == primary.candidate_id
+        for item in workspace.search_evidence("sample", first_filters).items
+        for link in item.links
+    )
+    assert fixture.invoke("undo", _result_id(removed, "decision_id")).exit_code == 0
+    assert any(
+        link.candidate_id == primary.candidate_id
+        for item in workspace.search_evidence("sample", first_filters).items
+        for link in item.links
+    )
+
+    merged = fixture.invoke("merge", primary.candidate_id, secondary.candidate_id)
+    assert merged.exit_code == 0, merged.output
+    merged_id = _result_id(merged, "contribution_id")
+    assert workspace.contribution_review("sample", merged_id).status == "confirmed"
+    split = fixture.invoke("split", primary.candidate_id, first_item.object_id)
+    assert split.exit_code == 0, split.output
+    split_id = _result_id(split, "contribution_id")
+    split_review = workspace.contribution_review("sample", split_id)
+    assert split_review.status == "confirmed"
+    members = split_review.packet["evidence_summary"]
+    assert isinstance(members, dict)
+    assert {member["object_id"] for member in members["members"]} == {first_item.object_id}
+
+    ignored = fixture.invoke("ignore", primary.candidate_id)
+    assert ignored.exit_code == 0, ignored.output
+    with pytest.raises(NotFound):
+        workspace.contribution_review("sample", primary.candidate_id)
+    assert fixture.invoke("undo", _result_id(ignored, "decision_id")).exit_code == 0
+    assert workspace.contribution_review("sample", split_id).status == "confirmed"
+
+    # Controlled edge state: generated suggestions may be rebuilt away, while
+    # an active confirmed lineage remains inspectable from its canonical link.
+    writer = connect(workspace.database_path)
+    try:
+        writer.execute("DELETE FROM candidate_groups WHERE id=?", (primary.candidate_id,))
+        writer.commit()
+    finally:
+        writer.close()
+    rowless_link = next(
+        link
+        for item in workspace.search_evidence("sample", first_filters).items
+        for link in item.links
+        if link.contribution_id == split_id
+    )
+    assert workspace.contribution_review("sample", rowless_link.identifier).status == "confirmed"

--- a/tests/test_installed_wheel_protocol.py
+++ b/tests/test_installed_wheel_protocol.py
@@ -188,6 +188,45 @@ gitlab_project_ids = []
     assert str(observed["stylesheet_text"])
 
 
+def test_installed_wheel_runs_headless_imported_evidence_search_outside_checkout(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    checkout = Path(__file__).resolve().parents[1]
+    python, _prefix, working_directory = _wheel_environment(tmp_path, checkout)
+    fixture = PublicWorkflowFixture.create(tmp_path / "search-fixture", monkeypatch)
+    import_fixture(fixture)
+    result = subprocess.run(
+        [
+            str(python),
+            "-c",
+            (
+                "import json; from pathlib import Path; from worktrace.config import load_config; "
+                "from worktrace.read_models.evidence_search import "
+                "normalize_evidence_search_filters; "
+                "from worktrace.read_workspace import ReadOnlyWorkspace; "
+                f"workspace=ReadOnlyWorkspace(load_config(Path({str(fixture.config_path)!r}))); "
+                "page=workspace.search_evidence('sample', "
+                "normalize_evidence_search_filters('DEMO-1 context')); "
+                "link=next(link for item in page.items for link in item.links); "
+                "review=workspace.contribution_review('sample', link.identifier); "
+                "print(json.dumps({'items': len(page.items), 'link': link.identifier, "
+                "'status': review.status}))"
+            ),
+        ],
+        check=False,
+        cwd=working_directory,
+        env=_installed_environment(),
+        capture_output=True,
+        text=True,
+        timeout=_INSTALLED_COMMAND_TIMEOUT_SECONDS,
+    )
+    assert result.returncode == 0, result.stderr
+    observed = json.loads(result.stdout)
+    assert int(observed["items"]) > 0
+    assert str(observed["link"]).startswith("candidate:")
+    assert observed["status"] == "candidate"
+
+
 @pytest.mark.asyncio
 async def test_installed_wheel_stdio_protocol_uses_site_packages_outside_checkout(
     tmp_path: Path, monkeypatch: Any

--- a/tests/test_tui_search.py
+++ b/tests/test_tui_search.py
@@ -1,0 +1,491 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import threading
+from pathlib import Path
+
+import pytest
+from textual.widgets import DataTable, Input, Static
+
+from tests.public_workflow_support import PublicWorkflowFixture
+from tests.test_packets_golden import _packet_state
+from worktrace.config import load_config
+from worktrace.read_models.evidence_search import EvidenceSearchInvalidated
+from worktrace.read_workspace import DatabaseBusy, ReadOnlyWorkspace
+from worktrace.tui.app import WorkTraceApp
+from worktrace.tui.messages import EvidenceSearchPageLoaded
+from worktrace.tui.modals.evidence import EvidenceModal
+from worktrace.tui.screens.applications import ApplicationScreen
+from worktrace.tui.screens.candidates import CandidateScreen
+from worktrace.tui.screens.contribution import ContributionScreen
+from worktrace.tui.screens.evidence_search import EvidenceSearchScreen
+
+
+class RecordingWorkTraceApp(WorkTraceApp):
+    def __init__(self, workspace: ReadOnlyWorkspace, **kwargs: object) -> None:
+        super().__init__(workspace, **kwargs)  # type: ignore[arg-type]
+        self.copied: list[str] = []
+
+    def copy_to_clipboard(self, text: str) -> None:
+        self.copied.append(text)
+
+
+async def _pause_until(
+    pilot: object,
+    predicate: object,
+    *,
+    attempts: int = 80,
+) -> None:
+    for _ in range(attempts):
+        if predicate():  # type: ignore[operator]
+            await pilot.pause()  # type: ignore[attr-defined]
+            return
+        await pilot.pause()  # type: ignore[attr-defined]
+    raise AssertionError("Textual state did not settle")
+
+
+def _app(tmp_path: Path) -> RecordingWorkTraceApp:
+    connection, _, config, candidate_id = _packet_state(tmp_path)
+    assert candidate_id == "candidate:phase4"
+    connection.close()
+    return RecordingWorkTraceApp(ReadOnlyWorkspace(config), initial_app_id="sample_store")
+
+
+def _imported_app(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> RecordingWorkTraceApp:
+    fixture = PublicWorkflowFixture.create(tmp_path, monkeypatch)
+    assert fixture.invoke("init").exit_code == 0
+    imported = fixture.invoke("import", "all", "sample")
+    assert imported.exit_code == 0, imported.output
+    rebuilt = fixture.invoke("rebuild", "all", "sample")
+    assert rebuilt.exit_code == 0, rebuilt.output
+    return RecordingWorkTraceApp(
+        ReadOnlyWorkspace(load_config(fixture.config_path)), initial_app_id="sample"
+    )
+
+
+def _paged_imported_app(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[RecordingWorkTraceApp, PublicWorkflowFixture]:
+    fixture = PublicWorkflowFixture.create(tmp_path, monkeypatch)
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "GIT_AUTHOR_NAME": "Fixture Engineer",
+            "GIT_AUTHOR_EMAIL": "old-alias@example.test",
+            "GIT_COMMITTER_NAME": "Fixture Engineer",
+            "GIT_COMMITTER_EMAIL": "integrator@example.test",
+            "GIT_AUTHOR_DATE": "2026-04-02T12:00:00Z",
+            "GIT_COMMITTER_DATE": "2026-04-02T12:00:00Z",
+        }
+    )
+    for index in range(22):
+        path = fixture.repository_path / f"page-{index:02d}.txt"
+        path.write_text(f"page {index}\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", path.name],
+            check=True,
+            cwd=fixture.repository_path,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", f"PAGE SEARCH {index:02d}"],
+            check=True,
+            cwd=fixture.repository_path,
+            env=environment,
+            capture_output=True,
+            text=True,
+        )
+    assert fixture.invoke("init").exit_code == 0
+    imported = fixture.invoke("import", "all", "sample")
+    assert imported.exit_code == 0, imported.output
+    rebuilt = fixture.invoke("rebuild", "all", "sample")
+    assert rebuilt.exit_code == 0, rebuilt.output
+    return (
+        RecordingWorkTraceApp(
+            ReadOnlyWorkspace(load_config(fixture.config_path)), initial_app_id="sample"
+        ),
+        fixture,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("size", "minimum_results", "minimum_links"),
+    [((80, 24), 5, 6), ((120, 40), 13, 14)],
+)
+async def test_evidence_search_keyboard_journey_preserves_search_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    size: tuple[int, int],
+    minimum_results: int,
+    minimum_links: int,
+) -> None:
+    app = _imported_app(tmp_path, monkeypatch)
+
+    async with app.run_test(size=size) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidates = app.screen
+        assert isinstance(candidates, CandidateScreen)
+        await _pause_until(
+            pilot,
+            lambda: (
+                candidates.query_one("#candidate-table", DataTable).row_count > 0
+                and candidates._page is not None
+            ),
+        )
+        await pilot.press("/")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceSearchScreen))
+        search = app.screen
+        assert isinstance(search, EvidenceSearchScreen)
+        query = search.query_one("#evidence-search-query", Input)
+        results = search.query_one("#evidence-search-results", DataTable)
+        links = search.query_one("#evidence-search-links", DataTable)
+        assert query.has_focus
+        assert results.size.height >= minimum_results
+        assert links.size.height >= minimum_links
+
+        await pilot.press(*"demo-1", "space", *"context", "enter")
+        await _pause_until(pilot, lambda: results.row_count > 0 and search._page is not None)
+        successful_page = search._page
+        assert successful_page is not None
+        assert search._submitted_filters is not None
+        assert search._submitted_filters.query == "demo-1 context"
+        assert "Submitted filters: query: demo-1 context" in str(
+            search.query_one("#evidence-search-status", Static).render()
+        )
+
+        # Editable fields keep printable navigation keys as text.  Once focus leaves the
+        # form, Tab reaches the result and canonical-link tables in deterministic order.
+        await pilot.press("n", "p")
+        assert query.value.endswith("np")
+        await pilot.press("tab", "tab", "tab", "tab", "tab", "tab")
+        assert results.has_focus
+        linked_result_row = next(index for index, item in enumerate(search._items) if item.links)
+        for _ in range(linked_result_row):
+            await pilot.press("j")
+        await _pause_until(pilot, lambda: links.row_count > 0)
+        selected = search._items[results.cursor_row]
+        detail = search.query_one("#evidence-search-result-detail", Static).render()
+        assert detail.plain == (
+            f"Observation ID: {selected.evidence_id}\nSource object ID: {selected.object_id}"
+        )
+        assert detail.spans == []
+        await pilot.press("y")
+        assert app.copied == [selected.evidence_id]
+
+        await pilot.press("enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceModal))
+        await pilot.press("escape")
+        assert app.screen is search
+        assert (
+            search.query_one("#evidence-search-results", DataTable).cursor_row == linked_result_row
+        )
+
+        await pilot.press("tab")
+        await _pause_until(pilot, lambda: links.has_focus and links.row_count > 0)
+        link_id = search._selected_links[links.cursor_row].identifier
+        await pilot.press("y")
+        assert app.copied[-1] == link_id
+        await pilot.press("enter")
+        await _pause_until(pilot, lambda: isinstance(app.screen, ContributionScreen))
+        assert len(app.screen_stack) == 4
+        await pilot.press("escape")
+        assert app.screen is search
+        assert len(app.screen_stack) == 3
+        await pilot.press("escape")
+        assert app.screen is candidates
+        assert len(app.screen_stack) == 2
+
+        # Invalid replacement input starts no worker and cannot discard the successful page.
+        await pilot.press("/")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceSearchScreen))
+        retry_search = app.screen
+        assert isinstance(retry_search, EvidenceSearchScreen)
+        retry_query = retry_search.query_one("#evidence-search-query", Input)
+        await pilot.press(*"demo-1", "space", *"context", "enter")
+        await _pause_until(pilot, lambda: retry_search._page is not None)
+        retained = retry_search._page
+        retry_query.focus()
+        retry_query.value = ""
+        await pilot.press("enter")
+        assert retry_search._page is retained
+        assert "query must contain" in str(
+            retry_search.query_one("#evidence-search-message", Static).render()
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_invalidation_failed_restart_clears_every_copyable_state(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidates = app.screen
+        assert isinstance(candidates, CandidateScreen)
+        await _pause_until(
+            pilot,
+            lambda: candidates.query_one("#candidate-table", DataTable).row_count == 1,
+        )
+        await pilot.press("/")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceSearchScreen))
+        search = app.screen
+        assert isinstance(search, EvidenceSearchScreen)
+        await pilot.press(*"checkout", "enter")
+        results = search.query_one("#evidence-search-results", DataTable)
+        links = search.query_one("#evidence-search-links", DataTable)
+        await _pause_until(pilot, lambda: results.row_count > 0 and search._page is not None)
+
+        calls = 0
+
+        def invalidated_then_busy(*_args: object, **_kwargs: object) -> object:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise EvidenceSearchInvalidated("synthetic revision change")
+            raise DatabaseBusy("synthetic busy database detail")
+
+        original = app.workspace.search_evidence
+        app.workspace.search_evidence = invalidated_then_busy  # type: ignore[method-assign]
+        try:
+            results.focus()
+            await pilot.pause()
+            await pilot.press("r")
+            await _pause_until(pilot, lambda: calls == 2 and search._pending_direction is None)
+        finally:
+            app.workspace.search_evidence = original  # type: ignore[method-assign]
+
+        message = str(search.query_one("#evidence-search-message", Static).render()).casefold()
+        assert search._page is None
+        assert search._items == ()
+        assert search._selected_links == ()
+        assert search._committed_history == []
+        assert results.row_count == 0
+        assert links.row_count == 0
+        assert search.selected_stable_id() is None
+        await pilot.press("y")
+        assert app.copied == []
+        assert "retry" in message
+        assert "successful search page remains" not in message
+
+
+@pytest.mark.asyncio
+async def test_late_search_page_cannot_replace_the_mounted_request(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidates = app.screen
+        assert isinstance(candidates, CandidateScreen)
+        await _pause_until(
+            pilot,
+            lambda: candidates.query_one("#candidate-table", DataTable).row_count == 1,
+        )
+        await pilot.press("/")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceSearchScreen))
+        search = app.screen
+        assert isinstance(search, EvidenceSearchScreen)
+        await pilot.press(*"checkout", "enter")
+        results = search.query_one("#evidence-search-results", DataTable)
+        await _pause_until(pilot, lambda: search._page is not None and results.row_count > 0)
+        committed = search._page
+        assert committed is not None
+        committed_ids = tuple(item.evidence_id for item in search._items)
+
+        search.on_evidence_search_page_loaded(
+            EvidenceSearchPageLoaded(search._page_request_id - 1, committed)
+        )
+        assert search._page is committed
+        assert tuple(item.evidence_id for item in search._items) == committed_ids
+
+
+@pytest.mark.asyncio
+async def test_evidence_search_screen_disables_selection_and_ambient_copy(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidates = app.screen
+        assert isinstance(candidates, CandidateScreen)
+        await _pause_until(pilot, lambda: candidates._page is not None)
+        await pilot.press("/")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceSearchScreen))
+        search = app.screen
+        assert isinstance(search, EvidenceSearchScreen)
+        copy_actions = [
+            binding.action
+            for bindings in search._bindings.key_to_bindings.values()
+            for binding in bindings
+            if binding.key in {"ctrl+c", "super+c"}
+        ]
+        assert search.ALLOW_SELECT is False
+        assert copy_actions == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("switch_application", [False, True])
+async def test_late_held_search_cannot_replace_superseding_query_or_application_screen(
+    tmp_path: Path,
+    switch_application: bool,
+) -> None:
+    app = _app(tmp_path)
+    started = threading.Event()
+    release = threading.Event()
+    original = app.workspace.search_evidence
+    calls = 0
+
+    def held_first(*args: object, **kwargs: object) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            assert release.wait(timeout=5)
+        return original(*args, **kwargs)
+
+    app.workspace.search_evidence = held_first  # type: ignore[method-assign]
+    try:
+        async with app.run_test(size=(80, 24)) as pilot:
+            await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+            candidates = app.screen
+            assert isinstance(candidates, CandidateScreen)
+            await _pause_until(pilot, lambda: candidates._page is not None)
+            await pilot.press("/")
+            await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceSearchScreen))
+            search = app.screen
+            assert isinstance(search, EvidenceSearchScreen)
+            await pilot.press(*"synthetic", "enter")
+            assert started.wait(timeout=5)
+
+            if switch_application:
+                app.action_switch_application()
+                await _pause_until(pilot, lambda: isinstance(app.screen, ApplicationScreen))
+                application_screen = app.screen
+                assert isinstance(application_screen, ApplicationScreen)
+                stack_depth = len(app.screen_stack)
+                release.set()
+                await pilot.pause()
+                assert app.screen is application_screen
+                assert len(app.screen_stack) == stack_depth
+            else:
+                query = search.query_one("#evidence-search-query", Input)
+                query.value = "checkout"
+                await pilot.press("enter")
+                results = search.query_one("#evidence-search-results", DataTable)
+                await _pause_until(
+                    pilot, lambda: search._page is not None and results.row_count > 0
+                )
+                committed = search._page
+                assert committed is not None
+                release.set()
+                await pilot.pause()
+                assert app.screen is search
+                assert search._page is committed
+                assert search._submitted_filters is not None
+                assert search._submitted_filters.query == "checkout"
+                assert search._pending_direction is None
+    finally:
+        release.set()
+        app.workspace.search_evidence = original  # type: ignore[method-assign]
+
+
+@pytest.mark.asyncio
+async def test_previous_page_detects_cli_revision_change_before_republishing_page_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app, fixture = _paged_imported_app(tmp_path, monkeypatch)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidates = app.screen
+        assert isinstance(candidates, CandidateScreen)
+        await _pause_until(pilot, lambda: candidates._page is not None)
+        await pilot.press("/")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceSearchScreen))
+        search = app.screen
+        assert isinstance(search, EvidenceSearchScreen)
+        await pilot.press(*"page", "space", *"search", "enter")
+        results = search.query_one("#evidence-search-results", DataTable)
+        await _pause_until(
+            pilot,
+            lambda: search._page is not None and results.row_count == 20,
+        )
+        first_revision = search._page.revision
+        results.focus()
+        await pilot.press("n")
+        await _pause_until(
+            pilot,
+            lambda: (
+                search._page is not None
+                and len(search._committed_history) == 2
+                and results.row_count == 2
+            ),
+        )
+        assert search._page.revision == first_revision
+
+        changed = fixture.invoke("rebuild", "all", "sample")
+        assert changed.exit_code == 0, changed.output
+        await pilot.press("p")
+        await _pause_until(
+            pilot,
+            lambda: (
+                search._pending_direction is None
+                and search._page is not None
+                and len(search._committed_history) == 1
+                and search._page.revision != first_revision
+            ),
+        )
+        assert results.row_count == 20
+        assert app.copied == []
+
+
+@pytest.mark.asyncio
+async def test_failed_valid_replacement_search_retains_successful_page_and_filters(
+    tmp_path: Path,
+) -> None:
+    app = _app(tmp_path)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await _pause_until(pilot, lambda: isinstance(app.screen, CandidateScreen))
+        candidates = app.screen
+        assert isinstance(candidates, CandidateScreen)
+        await _pause_until(pilot, lambda: candidates._page is not None)
+        await pilot.press("/")
+        await _pause_until(pilot, lambda: isinstance(app.screen, EvidenceSearchScreen))
+        search = app.screen
+        assert isinstance(search, EvidenceSearchScreen)
+        await pilot.press(*"checkout", "enter")
+        results = search.query_one("#evidence-search-results", DataTable)
+        await _pause_until(pilot, lambda: search._page is not None and results.row_count > 0)
+        retained_page = search._page
+        retained_ids = tuple(item.evidence_id for item in search._items)
+        retained_filters = search._submitted_filters
+
+        def fail_replacement(*_args: object, **_kwargs: object) -> object:
+            raise DatabaseBusy("synthetic replacement failure")
+
+        original = app.workspace.search_evidence
+        app.workspace.search_evidence = fail_replacement  # type: ignore[method-assign]
+        try:
+            query = search.query_one("#evidence-search-query", Input)
+            query.value = "replacement"
+            await pilot.press("enter")
+            await _pause_until(pilot, lambda: search._pending_direction is None)
+        finally:
+            app.workspace.search_evidence = original  # type: ignore[method-assign]
+
+        assert search._page is retained_page
+        assert tuple(item.evidence_id for item in search._items) == retained_ids
+        assert search._submitted_filters is not retained_filters
+        assert search._submitted_filters is not None
+        assert search._submitted_filters.query == "replacement"
+        assert retained_page.filters == retained_filters
+        assert retained_page.filters.query == "checkout"
+        assert len(search._committed_history) == 1
+        assert results.row_count == len(retained_ids)
+        assert (
+            "successful search page remains"
+            in str(search.query_one("#evidence-search-message", Static).render()).casefold()
+        )


### PR DESCRIPTION
## Summary

Adds the offline, read-only evidence-discovery journey above the settled candidate browser. It normalizes bounded filters, scans current evidence in one query-only snapshot, exposes a separate revision-bound TUI cursor, and enriches result rows through a fair page-wide canonical projection budget. Users can inspect a bounded excerpt, open a surviving canonical contribution, and return to their original candidate page without losing selection.

The implementation preserves the seven-tool MCP surface and its `wtc1:` cursors. No dependency, migration, index, cache, provider access, private-ledger operation, or write capability was added.

## Acceptance map

| Contract area | Proof |
|---|---|
| Filter validation, literal matching, bounds, continuation, budget, aliases, caps | `tests/test_evidence_search.py` |
| Snapshot coherence, cursorless revision invalidation, CLI corrections, canonical/rowless/context review | `tests/test_evidence_search_lifecycle.py` |
| Keyboard lifecycle, literal rendering, copy restrictions, screen restoration, terminal sizes | `tests/test_tui_search.py` |
| Installed package journey | `tests/test_installed_wheel_protocol.py` |
| Existing reader, MCP, authority, paging behavior | full suite |

## Validation

Independent final-head proof completed at `ed35299f6bb413985c7048151103fb2a3f903a72`:

- `uv run coverage run -m pytest`: 517 passed in 149.30s
- Coverage: 87% (minimum: 81%)
- Formatting: 174 files passed
- Ruff: passed
- Strict mypy: 83 source files passed
- Build / sdist / wheel: passed
- Installed-wheel smoke: 3 passed
- Diff check: passed

## Delivery

- [Quality CI run 34041902889](https://github.com/AmrMohamad/WorkTrace/actions/runs/34041902889) succeeded at the final head.
- [Code review](https://github.com/AmrMohamad/WorkTrace/pull/40#pullrequestreview-5125778371) and [security review](https://github.com/AmrMohamad/WorkTrace/pull/40#pullrequestreview-5125779079) approved that head.
- [Architecture and UI/design review](https://github.com/AmrMohamad/WorkTrace/pull/40#pullrequestreview-5125782632) approved that head.

## Limitations

Discovery is limited to authoritative current evidence in the selected configured application. It uses literal matching and bounded traversal, reports incomplete canonical coverage without estimating unseen totals, and does not establish ownership, provider completeness, private-ledger performance, business impact, or any write capability.

## Contract references

Implements #22 under the accepted PR #39 addendum and AgDR-0005 / AgDR-0006. AgDR-0007 remains the supersession for historical MCP six-tool and `offset:` wording; the installed seven-tool MCP contract is unchanged.

All final-head CI and independent reviews above are observed. Explicit `/approve-merge 40` authorization was granted; PR #40 merged as `0a49e1cafe5632d063c4249f1fa46b2cddb93ce7`; exact-main [Quality run 34042237266](https://github.com/AmrMohamad/WorkTrace/actions/runs/34042237266) passed; and independent post-merge QA approved and closed [#22](https://github.com/AmrMohamad/WorkTrace/issues/22). #21 representative private-ledger measurement and parent #17 remain open.

## Glossary

| Term | Definition |
|---|---|
| Evidence discovery | Literal search over current authoritative observations in one configured application. |
| Canonical projection | Resolution of a decision-aware contribution group for a returned evidence row. |
| TUI cursor | In-memory revision-bound search continuation, separate from MCP cursors. |
| Rowless confirmed history | An active confirmed lineage that remains inspectable after its generated candidate row disappears. |

Refs #22