### PR TITLE
fix(#43): reuse prepared evidence page context

### DIFF
--- a/src/worktrace/read_models/evidence_context.py
+++ b/src/worktrace/read_models/evidence_context.py
@@ -584,6 +584,21 @@ def _decision_mentions_object(action: str, payload: Mapping[str, object], object
     return False
 
 
+def _page_context_builder(builder: PacketBuilder, app_id: str) -> PacketBuilder:
+    """Reuse an already scoped metadata-only page context without changing its contract."""
+
+    builder.config.app(app_id)
+    authority_context = builder._authority_context
+    if (
+        builder._decision_projection is not None
+        and authority_context is not None
+        and authority_context.metadata_only
+        and authority_context.app_id == app_id
+    ):
+        return builder
+    return builder.page_projection_builder(app_id)
+
+
 def membership_locator_ids(builder: PacketBuilder, app_id: str, object_id: str) -> set[str]:
     """Find generated and decision-backed membership locators for one object.
 
@@ -602,7 +617,7 @@ def membership_locator_ids(builder: PacketBuilder, app_id: str, object_id: str) 
             (app_id, object_id),
         )
     }
-    context_builder = builder.page_projection_builder(app_id)
+    context_builder = _page_context_builder(builder, app_id)
     context = context_builder._decision_projection
     assert context is not None
     for decision in context.active_decisions:
@@ -616,7 +631,7 @@ def membership_locator_ids(builder: PacketBuilder, app_id: str, object_id: str) 
 def lineage_identity(
     builder: PacketBuilder, app_id: str, identifier: str
 ) -> tuple[str, str | None, str, bool]:
-    context_builder = builder.page_projection_builder(app_id)
+    context_builder = _page_context_builder(builder, app_id)
     context = context_builder._decision_projection
     assert context is not None
     lineage = context.resolve_lineage(identifier, app_id=app_id)
@@ -660,7 +675,7 @@ def canonical_membership_locators(
 ) -> tuple[CanonicalMembershipLocator, ...]:
     """Return deterministic, alias-deduplicated canonical membership groups."""
 
-    context_builder = builder.page_projection_builder(app_id)
+    context_builder = _page_context_builder(builder, app_id)
     by_key: dict[str, CanonicalMembershipLocator] = {}
     for identifier in sorted(membership_locator_ids(context_builder, app_id, object_id)):
         try:
@@ -716,7 +731,7 @@ def resolve_canonical_group(
 
     if legacy_generated and not locator.confirmed:
         return None
-    context_builder = builder.page_projection_builder(app_id)
+    context_builder = _page_context_builder(builder, app_id)
     try:
         return context_builder.resolve_contribution(locator.identifier)
     except (NotFound, ScopeViolation):
@@ -732,7 +747,7 @@ def project_canonical_membership(
 ) -> dict[str, object] | None:
     """Apply one already-resolved group to one evidence object without resolving again."""
 
-    context_builder = builder.page_projection_builder(app_id)
+    context_builder = _page_context_builder(builder, app_id)
     object_description = describe_object(context_builder, app_id, object_id)
     object_has_current = object_description["current_observation_id"] is not None
     role = (

--- a/tests/test_evidence_search.py
+++ b/tests/test_evidence_search.py
@@ -10,10 +10,12 @@ import pytest
 import worktrace.read_models.evidence_search as evidence_search_module
 from tests.public_workflow_support import PublicWorkflowFixture
 from tests.test_packets_golden import _packet_state
+from tests.tui_support import add_visible_candidate_page
 from worktrace.candidates.decisions import append_decision
 from worktrace.config import load_config
 from worktrace.db.connection import connect, connect_read_only
 from worktrace.packets.builder import PacketBuilder
+from worktrace.read_models import evidence_context as evidence_context_module
 from worktrace.read_models.evidence_search import (
     CandidateLink,
     CanonicalMembershipLocator,
@@ -91,6 +93,57 @@ def test_normalize_evidence_search_filters_trims_optionals_and_is_frozen() -> No
     assert blank_optionals.module_text is None
     assert blank_optionals.date_from is None
     assert blank_optionals.date_to is None
+
+
+def test_evidence_search_reuses_prepared_page_context_without_changing_page_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection, _, config, _ = _packet_state(tmp_path)
+    add_visible_candidate_page(connection, count=30)
+    connection.close()
+    workspace = ReadOnlyWorkspace(config)
+    filters = normalize_evidence_search_filters("Synthetic")
+    baseline = workspace.search_evidence("sample_store", filters)
+
+    original = PacketBuilder.page_projection_builder
+    calls = 0
+
+    def counted(self: PacketBuilder, app_id: str) -> PacketBuilder:
+        nonlocal calls
+        calls += 1
+        return original(self, app_id)
+
+    monkeypatch.setattr(PacketBuilder, "page_projection_builder", counted)
+    actual = workspace.search_evidence("sample_store", filters)
+
+    assert calls == 1
+    assert actual.items == baseline.items
+    assert [item.links for item in actual.items] == [item.links for item in baseline.items]
+    assert [item.link_completeness for item in actual.items] == [
+        item.link_completeness for item in baseline.items
+    ]
+    assert [item.period_limitations for item in actual.items] == [
+        item.period_limitations for item in baseline.items
+    ]
+    assert [[link.limitations for link in item.links] for item in actual.items] == [
+        [link.limitations for link in item.links] for item in baseline.items
+    ]
+    assert actual.diagnostics == baseline.diagnostics
+    assert actual.diagnostics.returned_results <= 20
+    assert actual.diagnostics.scanned_rows <= 200
+    assert actual.diagnostics.projection_attempts <= 50
+    assert all(len(item.links) <= 5 for item in actual.items)
+
+
+def test_page_context_builder_falls_back_when_context_is_not_prepared(tmp_path: Path) -> None:
+    connection, _, config, _ = _packet_state(tmp_path)
+    try:
+        builder = PacketBuilder(connection, config)
+        prepared = evidence_context_module._page_context_builder(builder, "sample_store")
+    finally:
+        connection.close()
+
+    assert prepared is not builder
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Reuse the already validated metadata-only page context throughout canonical evidence-link enrichment, avoiding repeated context normalization for one bounded search page.
- Preserve the existing fallback whenever a builder lacks a matching prepared decision/authority context.
- Add a regression that proves page items, links, completeness, limitations, and 20/200/50/5 bounds are unchanged while only one page-context normalization occurs.

This change removes demonstrated redundant normalization only. It does not claim a latency improvement; retiming remains separate evidence.

## Validation

- `uv run pytest tests/test_evidence_search.py -k "page_context_builder or reuses_prepared_page_context"` — 2 passed
- `COVERAGE_FILE=/private/tmp/worktrace-gh43-coverage uv run coverage run -m pytest && COVERAGE_FILE=/private/tmp/worktrace-gh43-coverage uv run coverage report` — 519 passed, 87% total coverage
- `uv run ruff check .`
- `uv run mypy src`
- Built and installed wheel in a clean temporary environment; `worktrace --help` exited successfully outside the checkout.

## Glossary

| Term | Meaning |
| --- | --- |
| Page context | Immutable decision and metadata-only authority projection for one read snapshot. |
| Canonical enrichment | Bounded resolution of evidence-to-contribution links. |
| 20/200/50/5 | Existing result, scan, projection, and per-item link bounds. |

## QA

- [x] Focused regression covers prepared-context reuse and unprepared fallback.
- [x] Full tests, coverage, lint, typing, and wheel installation pass.
- [ ] Independent exact-head review and CI.
- [ ] Human QA and merge approval.